### PR TITLE
[UniPoly] AddCommGroup by trimming after additions

### DIFF
--- a/ZKLib/Data/Math/Operations.lean
+++ b/ZKLib/Data/Math/Operations.lean
@@ -378,6 +378,13 @@ where
       -- recursively invoke the theorem we are proving!
       apply aux
 
+theorem findIdxRev?_emtpy_none {cond} {as : Array α} (h : as = #[]) :
+  findIdxRev? cond as = none
+:= by
+  rw [h]
+  apply findIdxRev?_eq_none
+  simp
+
 /-- if the condition is true on some element, then findIdxRev? finds something -/
 theorem findIdxRev?_eq_some {cond} {as : Array α} (h: ∃ a ∈ as, cond a) :
   ∃ k : Fin as.size, findIdxRev? cond as = some k

--- a/ZKLib/Data/Math/Operations.lean
+++ b/ZKLib/Data/Math/Operations.lean
@@ -197,8 +197,57 @@ theorem matchSize_eq_iff_forall_eq (l₁ l₂ : List α) (unit : α) :
   by sorry
     -- TODO: finish this lemma based on `rightpad_getD_eq_getD`
 
+theorem matchSize_length_eq (l₁ l₂ : List α) (unit : α) :
+    (matchSize l₁ l₂ unit).1.length = (matchSize l₁ l₂ unit).2.length := by
+  simp [matchSize]; omega
 
+theorem matchSize_length (l₁ l₂ : List α) (unit : α) :
+    (matchSize l₁ l₂ unit).1.length = max l₁.length l₂.length := by
+  simp [matchSize]; omega
 
+theorem matchSize_length₂ (l₁ l₂ : List α) (unit : α) :
+    (matchSize l₁ l₂ unit).2.length = max l₁.length l₂.length := by
+  rw [← matchSize_length_eq, matchSize_length]
+
+theorem getElem?_matchSize_1 (l₁ l₂ : List α) (unit : α) (i : Nat) :
+    (matchSize l₁ l₂ unit).1[i]?.getD unit = l₁[i]?.getD unit := by
+  rcases (Nat.lt_or_ge i l₁.length) with h_lt₁ | h_ge₁
+  · simp [h_lt₁, matchSize_length] -- eliminate `getD`
+    dsimp [matchSize]
+    simp [h_lt₁, getElem_append]
+  simp [List.getElem?_eq_none h_ge₁] -- eliminate second `getD` for `unit`
+  rcases (Nat.lt_or_ge i l₂.length) with h_lt₂ | h_ge₂
+  · simp [h_lt₂, matchSize_length] -- eliminate first `getD`
+    dsimp [matchSize]
+    simp [h_ge₁, getElem_append]
+  · have h_ge' : i ≥ (l₁.matchSize l₂ unit).1.length := by simp [h_ge₁, h_ge₂, matchSize_length]
+    simp [List.getElem?_eq_none h_ge']
+
+theorem getElem?_matchSize_2 (l₁ l₂ : List α) (unit : α) (i : Nat) :
+    (matchSize l₁ l₂ unit).2[i]?.getD unit = l₂[i]?.getD unit := by
+  rcases (Nat.lt_or_ge i l₂.length) with h_lt₂ | h_ge₂
+  · simp [h_lt₂, matchSize_length₂] -- eliminate `getD`
+    dsimp [matchSize]
+    simp [h_lt₂, getElem_append]
+  simp [getElem?_eq_none h_ge₂] -- eliminate second `getD` for `unit`
+  rcases (Nat.lt_or_ge i l₁.length) with h_lt₁ | h_ge₁
+  · simp [h_lt₁, matchSize_length₂] -- eliminate first `getD`
+    dsimp [matchSize]
+    simp [h_ge₂, getElem_append]
+  · have h_ge' : i ≥ (l₁.matchSize l₂ unit).2.length := by simp [h_ge₁, h_ge₂, matchSize_length₂]
+    simp [getElem?_eq_none h_ge']
+
+theorem getElem_matchSize_1 {a b : List α} {unit : α} {i : Nat} :
+  (h: i < (matchSize a b unit).1.length) → (matchSize a b unit).1[i] = a[i]?.getD unit := by
+  intro h
+  rw [← getElem?_matchSize_1 a b]
+  simp [h]
+
+theorem getElem_matchSize_2 {a b : List α} {unit : α} {i : Nat} :
+  (h: i < (matchSize a b unit).2.length) → (matchSize a b unit).2[i] = b[i]?.getD unit := by
+  intro h
+  rw [← getElem?_matchSize_2 a b]
+  simp [h]
 
 /-- `List.dropWhile` but starting from the last element. Performed by `dropWhile` on the reversed
   list, followed by a reversal. -/
@@ -247,6 +296,10 @@ def rightpad (n : Nat) (unit : α) (a : Array α) : Array α :=
 def matchSize (a : Array α) (b : Array α) (unit : α) : Array α × Array α :=
   let tuple := List.matchSize a.toList b.toList unit
   (⟨tuple.1⟩, ⟨tuple.2⟩)
+
+theorem getElem?_eq_toList {a : Array α} {i : ℕ} : a.toList[i]? = a[i]? := by
+  rw (occs := .pos [2]) [← List.toArray_toList a]
+  rw [List.getElem?_toArray]
 
 -- @[simp] theorem matchSize_comm (a : Array α) (b : Array α) (unit : α) :
 --     matchSize a b unit = (matchSize b a unit).swap := by

--- a/ZKLib/Data/Math/Operations.lean
+++ b/ZKLib/Data/Math/Operations.lean
@@ -301,6 +301,12 @@ theorem getElem?_eq_toList {a : Array α} {i : ℕ} : a.toList[i]? = a[i]? := by
   rw (occs := .pos [2]) [← List.toArray_toList a]
   rw [List.getElem?_toArray]
 
+-- simplify `a[i]?` to `some a[i]` or `none` given hypotheses about `i` vs `a.size`
+@[simp] theorem getElem?_eq_none {a: Array α} {i: Nat} : (a.size ≤ i) → a[i]? = none :=
+  Array.getElem?_eq_none_iff.mpr
+
+attribute [simp] Array.getElem?_eq_getElem
+
 -- @[simp] theorem matchSize_comm (a : Array α) (b : Array α) (unit : α) :
 --     matchSize a b unit = (matchSize b a unit).swap := by
 --   simp [matchSize, List.matchSize]

--- a/ZKLib/Data/Math/Operations.lean
+++ b/ZKLib/Data/Math/Operations.lean
@@ -292,7 +292,7 @@ def findIdxRev?_def {cond} {as: Array α} {k : Fin as.size} :
   induction i using findIdxRev?.find.induct cond as with
   | case1 => simp
   | case2 => simp [*]; rintro rfl; assumption
-  | case3 _ _ not_true ih => unfold findIdxRev?.find; simp [*]; assumption
+  | case3 => unfold findIdxRev?.find; simp [*]; assumption
 
 /-- if findIdxRev? finds an index, then for every greater index the condition doesn't hold -/
 def findIdxRev?_maximal {cond} {as: Array α} {k : Fin as.size} :
@@ -320,7 +320,7 @@ def findIdxRev?_maximal {cond} {as: Array α} {k : Fin as.size} :
     · simp only [not_true]
 
 /-- if the condition is false on all elements, then findIdxRev? finds nothing -/
-theorem findIdxRev?_eq_none {cond} {as : Array α} (h : ∀ a ∈ as, ¬ cond a) :
+theorem findIdxRev?_eq_none {cond} {as : Array α} (h : ∀ i, (hi : i < as.size) → ¬ cond as[i]) :
   findIdxRev? cond as = none
 := by
   apply aux
@@ -332,7 +332,7 @@ where
     next _ j _ =>
       split -- then/else cases inside .find
       next cond_true =>
-        have cond_false : ¬ cond as[j] := h as[j] (getElem_mem _)
+        have cond_false : ¬ cond as[j] := h j _
         have : False := cond_false cond_true
         contradiction
       -- recursively invoke the theorem we are proving!
@@ -346,12 +346,11 @@ theorem findIdxRev?_emtpy_none {cond} {as : Array α} (h : as = #[]) :
   simp
 
 /-- if the condition is true on some element, then findIdxRev? finds something -/
-theorem findIdxRev?_eq_some {cond} {as : Array α} (h: ∃ a ∈ as, cond a) :
+theorem findIdxRev?_eq_some {cond} {as : Array α} (h: ∃ i, ∃ hi : i < as.size, cond as[i]) :
   ∃ k : Fin as.size, findIdxRev? cond as = some k
 := by
-  obtain ⟨ a, ha, hcond ⟩ := h
-  obtain ⟨ k, hk, rfl ⟩ := Array.mem_iff_getElem.mp ha
-  apply aux ⟨ as.size, Nat.lt_succ_self _ ⟩ ⟨ .mk k hk, hk, hcond ⟩
+  obtain ⟨ i, hi, hcond ⟩ := h
+  apply aux ⟨ as.size, Nat.lt_succ_self _ ⟩ ⟨ .mk i hi, hi, hcond ⟩
 where
   aux (i : Fin (as.size + 1)) (h': ∃ i' : Fin as.size, i' < i.val ∧ cond as[i']) :
     ∃ k, findIdxRev?.find cond as i = some k := by

--- a/ZKLib/Data/Math/Operations.lean
+++ b/ZKLib/Data/Math/Operations.lean
@@ -337,21 +337,21 @@ def findIdxRev?_def {cond} {as: Array α} {k : Fin as.size} :
 /-- if findIdxRev? finds an index, then for every greater index the condition doesn't hold -/
 def findIdxRev?_maximal {cond} {as: Array α} {k : Fin as.size} :
   findIdxRev? cond as = some k → ∀ j : Fin as.size, j > k → ¬ cond as[j] := by
-  suffices aux : ∀ i, findIdxRev?.find cond as i = some k → ∀ j :
-    Fin as.size, j > k → j.val < i → ¬ cond as[j] by
+  suffices aux : ∀ i, findIdxRev?.find cond as i = some k →
+    ∀ j : Fin as.size, j > k → j.val < i → ¬ cond as[j] by
     intro h j j_gt_k
     exact aux ⟨ as.size, Nat.lt_succ_self _ ⟩ h j j_gt_k j.is_lt
   intro i
+  unfold findIdxRev?.find
   induction i using findIdxRev?.find.induct cond as with
-  | case1 => unfold findIdxRev?.find; simp
+  | case1 => simp
   | case2 i =>
-    unfold findIdxRev?.find
     simp [*]
     rintro rfl j (_: j > i) (_: j < i + 1) -- contradiction
     linarith
   | case3 i _ not_true ih =>
-    unfold findIdxRev?.find
     simp [*]
+    unfold findIdxRev?.find
     intro h j j_gt_k j_lt_isucc
     specialize ih h j j_gt_k
     rcases (Nat.lt_or_eq_of_le (Nat.le_of_lt_succ j_lt_isucc): j < i ∨ j = i) with (j_lt_i | rfl)

--- a/ZKLib/Data/Math/Operations.lean
+++ b/ZKLib/Data/Math/Operations.lean
@@ -334,6 +334,31 @@ def findIdxRev?_def {cond} {as: Array α} {k : Fin as.size} :
   | case2 => simp [*]; rintro rfl; assumption
   | case3 _ _ not_true ih => unfold findIdxRev?.find; simp [*]; assumption
 
+/-- if findIdxRev? finds an index, then for every greater index the condition doesn't hold -/
+def findIdxRev?_maximal {cond} {as: Array α} {k : Fin as.size} :
+  findIdxRev? cond as = some k → ∀ j : Fin as.size, j > k → ¬ cond as[j] := by
+  suffices aux : ∀ i, findIdxRev?.find cond as i = some k → ∀ j :
+    Fin as.size, j > k → j.val < i → ¬ cond as[j] by
+    intro h j j_gt_k
+    exact aux ⟨ as.size, Nat.lt_succ_self _ ⟩ h j j_gt_k j.is_lt
+  intro i
+  induction i using findIdxRev?.find.induct cond as with
+  | case1 => unfold findIdxRev?.find; simp
+  | case2 i =>
+    unfold findIdxRev?.find
+    simp [*]
+    rintro rfl j (_: j > i) (_: j < i + 1) -- contradiction
+    linarith
+  | case3 i _ not_true ih =>
+    unfold findIdxRev?.find
+    simp [*]
+    intro h j j_gt_k j_lt_isucc
+    specialize ih h j j_gt_k
+    rcases (Nat.lt_or_eq_of_le (Nat.le_of_lt_succ j_lt_isucc): j < i ∨ j = i) with (j_lt_i | rfl)
+    · specialize ih j_lt_i
+      rwa [Bool.not_eq_true] at ih
+    · simp only [not_true]
+
 /-- if the condition is false on all elements, then findIdxRev? finds nothing -/
 theorem findIdxRev?_eq_none {cond} {as : Array α} (h : ∀ a ∈ as, ¬ cond a) :
   findIdxRev? cond as = none

--- a/ZKLib/Data/Math/Operations.lean
+++ b/ZKLib/Data/Math/Operations.lean
@@ -325,11 +325,11 @@ where
         find i (Nat.le_of_lt h_lt)
 
 /-- if the condition is false on all elements, then findIdxRev? finds nothing -/
-theorem findIdxRev?_eq_none (cond : α → Bool) (as : Array α) (h : ∀ a ∈ as, cond a = false) :
+theorem findIdxRev?_eq_none {cond} {as : Array α} (h : ∀ a ∈ as, cond a = false) :
   findIdxRev? cond as = none
   := by apply aux
 where
-  aux (i : Nat) (hi : i ≤ as.size) : findIdxRev?.find cond as i hi = none := by
+  aux i hi : findIdxRev?.find cond as i hi = none := by
     unfold findIdxRev?.find
     split
     next => tauto

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -250,42 +250,30 @@ theorem add_coeff? (p q : UniPoly R) (i: ℕ) :
   (p + q).coeffs.getD i 0 = p.coeffs.getD i 0 + q.coeffs.getD i 0
 := by
   rcases (Nat.lt_or_ge i (p + q).coeffs.size) with h_lt | h_ge
-  · rw [← add_coeff h_lt, Array.getD_eq_get?, Array.getElem?_eq_getElem h_lt]
-    simp
+  · rw [← add_coeff h_lt]; simp [h_lt]
   have h_lt' : i ≥ max p.size q.size := by rwa [← add_size]
   have h_p : i ≥ p.size := by omega
   have h_q : i ≥ q.size := by omega
-  simp [Array.getElem?_eq_none_iff.mpr, h_ge, h_p, h_q]
+  simp [h_ge, h_p, h_q]
 
 -- algebra theorems about add
 
 theorem add_comm : p + q = q + p := by
-  simp only [instHAdd, Add.add, add, List.zipWith_toArray, mk.injEq, Array.mk.injEq]
-  exact List.zipWith_comm_of_comm _ (fun x y ↦ by change x + y = y + x; rw [_root_.add_comm]) _ _
+  ext
+  · simp only [add_size]; omega
+  · simp only [add_coeff]
+    apply _root_.add_comm
 
 @[simp] theorem zero_add : 0 + p = p := by
-  simp [instHAdd, instAdd, add, List.matchSize]
-  refine UniPoly.ext (Array.ext' ?_)
-  simp only
-  rw [List.zipWith_congr
-        (g := fun _ x ↦ x)
-        (h := by simp [List.forall₂_iff_get]
-                 intros i h
-                 change 0 + p.coeffs[i] = p.coeffs[i]
-                 simp)]
-  exact List.zipWith_const (by simp) (by simp)
+  ext <;> simp [add_size, add_coeff, *]
 
 theorem add_assoc : p + q + r = p + (q + r) := by
   ext i
-  -- size is equal
-  show (p + q + r).size = (p + (q + r)).size
-  simp only [add_size]
-  omega
-  -- coefficients are equal
-  show (p + q + r).coeffs[i] = (p + (q + r)).coeffs[i]
-  simp only [add_coeff, add_coeff?]
-  apply _root_.add_assoc
-
+  · show (p + q + r).size = (p + (q + r)).size
+    simp only [add_size]; omega
+  · show (p + q + r).coeffs[i] = (p + (q + r)).coeffs[i]
+    simp only [add_coeff, add_coeff?]
+    apply _root_.add_assoc
 
 -- TODO: define `SemiRing` structure on `UniPoly`
 -- instance : AddCommMonoid (UniPoly R) := {

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -77,16 +77,13 @@ theorem last_non_zero_none [LawfulBEq R] {p : UniPoly R} :
 := by
   intro h
   apply Array.findIdxRev?_eq_none
-  intro a ha
-  suffices a = 0 by rwa [bne_iff_ne, ne_eq, not_not]
-  -- translate index access to array membership
-  -- TODO if this is nicer to use then we should use index access in `Array.findIdxRev?` theorems
-  obtain ⟨ i, hi, rfl: p.coeffs[i] = a ⟩ := Array.mem_iff_getElem.mp ha
-  exact h i hi
+  intros
+  rw [bne_iff_ne, ne_eq, not_not]
+  apply_assumption
 
 theorem last_non_zero_some [LawfulBEq R] {p : UniPoly R} {i} (hi: i < p.size) (h: p.coeffs[i] ≠ 0) :
   ∃ k, p.last_non_zero = some k
-:= Array.findIdxRev?_eq_some ⟨p.coeffs[i], Array.getElem_mem _, bne_iff_ne.mpr h⟩
+:= Array.findIdxRev?_eq_some ⟨i, hi, bne_iff_ne.mpr h⟩
 
 theorem last_non_zero_spec [LawfulBEq R] {p : UniPoly R} {k} :
   p.last_non_zero = some k

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -379,19 +379,7 @@ def UniPolyC (R : Type*) [BEq R] [Ring R] := { p : UniPoly R // p.trim = p }
 
 @[ext] theorem UniPolyC.ext {p q : UniPolyC R} (h : p.val = q.val) : p = q := Subtype.eq h
 
-instance : Zero (UniPoly R) := ⟨UniPoly.mk #[]⟩
-
-@[simp] theorem zero_def : (0 : UniPoly Q) = ⟨#[]⟩ := rfl
-
-theorem zero_canonical {R : Type*} [BEq R] [Ring R] : (0 : UniPoly R).trim = 0 := by
-  have : (0 : UniPoly R).last_non_zero = none := by
-    simp [last_non_zero];
-    apply Array.findIdxRev?_emtpy_none
-    rfl
-  rw [trim, this]
-  rfl
-
-instance : Inhabited (UniPolyC R) := ⟨⟨#[]⟩, zero_canonical⟩
+instance : Inhabited (UniPolyC R) := ⟨⟨#[]⟩, Trim.canonical_empty⟩
 
 section Operations
 
@@ -453,6 +441,7 @@ def pow (p : UniPoly R) (n : Nat) : UniPoly R := (mul p)^[n] (C 1)
 
 -- TODO: define repeated squaring version of `pow`
 
+instance : Zero (UniPoly R) := ⟨UniPoly.mk #[]⟩
 instance : One (UniPoly R) := ⟨UniPoly.C 1⟩
 instance : Add (UniPoly R) := ⟨UniPoly.add⟩
 instance : SMul R (UniPoly R) := ⟨UniPoly.smul⟩
@@ -575,7 +564,9 @@ lemma trim_add_trim [LawfulBEq R] (p q : UniPoly R) : p.trim + q = p + q := by
   intro i
   rw [add_coeff?, add_coeff?, Trim.coeff_eq_getD]
 
--- algebra theorems about add
+-- algebra theorems about addition
+
+@[simp] theorem zero_def : (0 : UniPoly Q) = ⟨#[]⟩ := rfl
 
 theorem add_comm : p + q = q + p := by
   apply congrArg trim
@@ -585,6 +576,8 @@ theorem add_comm : p + q = q + p := by
     apply _root_.add_comm
 
 def canonical (p : UniPoly R) := p.trim = p
+
+theorem zero_canonical : (0 : UniPoly R).trim = 0 := Trim.canonical_empty
 
 theorem zero_add (hp : p.canonical) : 0 + p = p := by
   rw (occs := .pos [2]) [← hp]
@@ -680,25 +673,18 @@ theorem neg_add_cancel : -p + p = 0 := by
   apply UniPolyC.ext
   apply UniPoly.neg_add_cancel
 
-instance [LawfulBEq R] : AddCommMonoid (UniPolyC R) where
+instance [LawfulBEq R] : AddCommGroup (UniPolyC R) where
   add_assoc := add_assoc
   zero_add := zero_add
   add_zero := add_zero
   add_comm := add_comm
-  nsmul := nsmul
+  neg_add_cancel := neg_add_cancel
+  nsmul := nsmul -- TODO do we actually need this custom implementation?
   nsmul_zero := nsmul_zero
   nsmul_succ := nsmul_succ
+  zsmul := zsmulRec -- TODO do we want a custom efficient implementation?
 
-instance [LawfulBEq R] : AddGroup (UniPolyC R) where
-  neg := Neg.neg
-  sub := Sub.sub
-  zsmul := zsmulRec
-  neg_add_cancel := neg_add_cancel
-
-instance [LawfulBEq R] : AddCommGroup (UniPolyC R) where
-  add_comm := add_comm
-
--- TODO: define `SemiRing` structure on `UniPoly` and `UniPolyC`
+-- TODO: define `SemiRing` structure on `UniPolyC`
 
 end OperationsC
 

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -50,18 +50,18 @@ def C (r : R) : UniPoly R := ⟨#[r]⟩
 def X : UniPoly R := ⟨#[0, 1]⟩
 
 /-- Return the index of the last non-zero coefficient of a `UniPoly` -/
-def last_non_zero [BEq R] (p: UniPoly R) : Option (Fin p.size) :=
+def last_nonzero [BEq R] (p: UniPoly R) : Option (Fin p.size) :=
   p.coeffs.findIdxRev? (· != 0)
 
 /-- Remove leading zeroes from a `UniPoly`. Requires `BEq` to check if the coefficients are zero. -/
 def trim [BEq R] (p : UniPoly R) : UniPoly R :=
-  match p.last_non_zero with
+  match p.last_nonzero with
   | none => ⟨#[]⟩
   | some i => ⟨p.coeffs.extract 0 (i.val + 1)⟩
 
 /-- Return the degree of a `UniPoly`. -/
 def degree [BEq R] (p : UniPoly R) : Nat :=
-  match p.last_non_zero with
+  match p.last_nonzero with
   | none => 0
   | some i => i.val + 1
 
@@ -71,9 +71,9 @@ def leadingCoeff [BEq R] (p : UniPoly R) : R := p.trim.coeffs.getLastD 0
 
 namespace Trim
 
--- characterize .last_non_zero
-theorem last_non_zero_none [LawfulBEq R] {p : UniPoly R} :
-  (∀ i, (hi : i < p.size) → p.coeffs[i] = 0) → p.last_non_zero = none
+-- characterize .last_nonzero
+theorem last_nonzero_none [LawfulBEq R] {p : UniPoly R} :
+  (∀ i, (hi : i < p.size) → p.coeffs[i] = 0) → p.last_nonzero = none
 := by
   intro h
   apply Array.findIdxRev?_eq_none
@@ -81,15 +81,15 @@ theorem last_non_zero_none [LawfulBEq R] {p : UniPoly R} :
   rw [bne_iff_ne, ne_eq, not_not]
   apply_assumption
 
-theorem last_non_zero_some [LawfulBEq R] {p : UniPoly R} {i} (hi: i < p.size) (h: p.coeffs[i] ≠ 0) :
-  ∃ k, p.last_non_zero = some k
+theorem last_nonzero_some [LawfulBEq R] {p : UniPoly R} {i} (hi: i < p.size) (h: p.coeffs[i] ≠ 0) :
+  ∃ k, p.last_nonzero = some k
 := Array.findIdxRev?_eq_some ⟨i, hi, bne_iff_ne.mpr h⟩
 
-theorem last_non_zero_spec [LawfulBEq R] {p : UniPoly R} {k} :
-  p.last_non_zero = some k
+theorem last_nonzero_spec [LawfulBEq R] {p : UniPoly R} {k} :
+  p.last_nonzero = some k
   → p.coeffs[k] ≠ 0 ∧ (∀ j, (hj : j < p.size) → j > k → p.coeffs[j] = 0)
 := by
-  intro (h : p.last_non_zero = some k)
+  intro (h : p.last_nonzero = some k)
   constructor
   · by_contra
     have h : p.coeffs[k] != 0 := Array.findIdxRev?_def h
@@ -98,15 +98,15 @@ theorem last_non_zero_spec [LawfulBEq R] {p : UniPoly R} {k} :
     have h : ¬(p.coeffs[j] != 0) := Array.findIdxRev?_maximal h ⟨ j, hj ⟩ j_gt_k
     rwa [bne_iff_ne, ne_eq, not_not] at h
 
--- the property of `last_non_zero_spec` uniquely identifies an element,
+-- the property of `last_nonzero_spec` uniquely identifies an element,
 -- and that allows us to prove the reverse as well
-def last_non_zero_prop {p : UniPoly R} (k: Fin p.size) : Prop :=
+def last_nonzero_prop {p : UniPoly R} (k: Fin p.size) : Prop :=
   p.coeffs[k] ≠ 0 ∧ (∀ j, (hj : j < p.size) → j > k → p.coeffs[j] = 0)
 
-lemma last_non_zero_unique {p : UniPoly Q} {k k' : Fin p.size} :
-  last_non_zero_prop k → last_non_zero_prop k' → k = k'
+lemma last_nonzero_unique {p : UniPoly Q} {k k' : Fin p.size} :
+  last_nonzero_prop k → last_nonzero_prop k' → k = k'
 := by
-  suffices weaker : ∀ k k', last_non_zero_prop k → last_non_zero_prop k' → k ≤ k' by
+  suffices weaker : ∀ k k', last_nonzero_prop k → last_nonzero_prop k' → k ≤ k' by
     intro h h'
     exact Fin.le_antisymm (weaker k k' h h') (weaker k' k h' h)
   intro k k' ⟨ h_nonzero, h ⟩ ⟨ h_nonzero', h' ⟩
@@ -114,34 +114,34 @@ lemma last_non_zero_unique {p : UniPoly Q} {k k' : Fin p.size} :
   have : p.coeffs[k] = 0 := h' k k.is_lt (Nat.lt_of_not_ge k_not_le)
   contradiction
 
-theorem last_non_zero_some_iff [LawfulBEq R]  {p : UniPoly R} {k} :
-  p.last_non_zero = some k ↔ (p.coeffs[k] ≠ 0 ∧ (∀ j, (hj : j < p.size) → j > k → p.coeffs[j] = 0))
+theorem last_nonzero_some_iff [LawfulBEq R]  {p : UniPoly R} {k} :
+  p.last_nonzero = some k ↔ (p.coeffs[k] ≠ 0 ∧ (∀ j, (hj : j < p.size) → j > k → p.coeffs[j] = 0))
 := by
   constructor
-  · apply last_non_zero_spec
+  · apply last_nonzero_spec
   intro h_prop
-  have ⟨ k', h_some'⟩ := last_non_zero_some k.is_lt h_prop.left
-  have k_is_k' := last_non_zero_unique (last_non_zero_spec h_some') h_prop
+  have ⟨ k', h_some'⟩ := last_nonzero_some k.is_lt h_prop.left
+  have k_is_k' := last_nonzero_unique (last_nonzero_spec h_some') h_prop
   rwa [← k_is_k']
 
-/-- eliminator for `p.last_non_zero`, e.g. use with the induction tactic as follows:
+/-- eliminator for `p.last_nonzero`, e.g. use with the induction tactic as follows:
   ```
   induction p using last_none_zero_elim with
   | case1 p h_none h_all_zero => ...
   | case2 p k h_some h_nonzero h_max => ...
   ```
 -/
-theorem last_non_zero_induct [LawfulBEq R] {motive : UniPoly R → Prop}
-  (case1 : ∀ p, p.last_non_zero = none → (∀ i, (hi : i < p.size) → p.coeffs[i] = 0) → motive p)
-  (case2 : ∀ p : UniPoly R, ∀ k : Fin p.size, p.last_non_zero = some k → p.coeffs[k] ≠ 0 →
+theorem last_nonzero_induct [LawfulBEq R] {motive : UniPoly R → Prop}
+  (case1 : ∀ p, p.last_nonzero = none → (∀ i, (hi : i < p.size) → p.coeffs[i] = 0) → motive p)
+  (case2 : ∀ p : UniPoly R, ∀ k : Fin p.size, p.last_nonzero = some k → p.coeffs[k] ≠ 0 →
     (∀ j : ℕ, (hj : j < p.size) → j > k → p.coeffs[j] = 0) → motive p)
   (p : UniPoly R) : motive p
 := by
   by_cases h : ∀ i, (hi : i < p.size) → p.coeffs[i] = 0
-  · exact case1 p (last_non_zero_none h) h
+  · exact case1 p (last_nonzero_none h) h
   · push_neg at h; rcases h with ⟨ i, hi, h ⟩
-    obtain ⟨ k, h_some ⟩ := last_non_zero_some hi h
-    have ⟨ h_nonzero, h_max ⟩ := last_non_zero_spec h_some
+    obtain ⟨ k, h_some ⟩ := last_nonzero_some hi h
+    have ⟨ h_nonzero, h_max ⟩ := last_nonzero_spec h_some
     exact case2 p k h_some h_nonzero h_max
 
 /-- eliminator for `p.trim`; use with the induction tactic as follows:
@@ -156,7 +156,7 @@ theorem induct [LawfulBEq R] {motive : UniPoly R → Prop}
   (case2 : ∀ p : UniPoly R, ∀ k : Fin p.size, p.trim = ⟨p.coeffs.extract 0 (k + 1)⟩
     → p.coeffs[k] ≠ 0 → (∀ j : ℕ, (hj : j < p.size) → j > k → p.coeffs[j] = 0) → motive p)
   (p : UniPoly R) : motive p
-:= by induction p using last_non_zero_induct with
+:= by induction p using last_nonzero_induct with
   | case1 p h_none h_all_zero =>
     have h_empty : p.trim = ⟨#[]⟩ := by unfold trim; rw [h_none]
     exact case1 p h_empty h_all_zero
@@ -181,13 +181,13 @@ theorem elim [LawfulBEq R] (p : UniPoly R) :
 
 theorem size_eq_degree (p : UniPoly R) : p.trim.size = p.degree := by
   unfold trim degree
-  match h : p.last_non_zero with
+  match h : p.last_nonzero with
   | none => simp
   | some i => simp [Fin.is_lt, Nat.succ_le_of_lt]
 
 theorem size_le_size (p : UniPoly R) : p.trim.size ≤ p.size := by
   unfold trim
-  match h : p.last_non_zero with
+  match h : p.last_nonzero with
   | none => simp
   | some i => simp [Array.size_extract]
 
@@ -236,11 +236,11 @@ lemma getD_eq_zero {p : UniPoly Q} :
 lemma eq_degree_of_equiv [LawfulBEq R] {p q : UniPoly R} : equiv p q → p.degree = q.degree := by
   unfold equiv degree
   intro h_equiv
-  induction p using last_non_zero_induct with
+  induction p using last_nonzero_induct with
   | case1 p h_none_p h_all_zero =>
     have h_zero_p : ∀ i, p.coeffs.getD i 0 = 0 := getD_eq_zero.mp h_all_zero
     have h_zero_q : ∀ i, q.coeffs.getD i 0 = 0 := by intro i; rw [← h_equiv, h_zero_p]
-    have h_none_q : q.last_non_zero = none := last_non_zero_none (getD_eq_zero.mpr h_zero_q)
+    have h_none_q : q.last_nonzero = none := last_nonzero_none (getD_eq_zero.mpr h_zero_q)
     rw [h_none_p, h_none_q]
   | case2 p k h_some_p h_nonzero_p h_max_p =>
     have h_equiv_k := h_equiv k
@@ -259,8 +259,8 @@ lemma eq_degree_of_equiv [LawfulBEq R] {p q : UniPoly R} : equiv p q → p.degre
       rcases Nat.lt_or_ge j p.size with hj | hj
       · simp [hj, h_max_p j hj j_gt_k]
       · simp [hj]
-    have h_some_q : q.last_non_zero = some ⟨ k, k_lt_q ⟩ :=
-      last_non_zero_some_iff.mpr ⟨ h_nonzero_q, h_max_q ⟩
+    have h_some_q : q.last_nonzero = some ⟨ k, k_lt_q ⟩ :=
+      last_nonzero_some_iff.mpr ⟨ h_nonzero_q, h_max_q ⟩
     rw [h_some_p, h_some_q]
 
 theorem eq_of_equiv [LawfulBEq R] {p q : UniPoly R} : equiv p q → p.trim = q.trim := by
@@ -281,8 +281,8 @@ theorem trim_twice [LawfulBEq R] (p : UniPoly R) : p.trim.trim = p.trim := by
   apply trim_equiv
 
 theorem canonical_empty : (UniPoly.mk #[]).trim = UniPoly.mk (R:=R) #[] := by
-  have : (UniPoly.mk (R:=R) #[]).last_non_zero = none := by
-    simp [last_non_zero];
+  have : (UniPoly.mk (R:=R) #[]).last_nonzero = none := by
+    simp [last_nonzero];
     apply Array.findIdxRev?_emtpy_none
     rfl
   rw [trim, this]
@@ -294,10 +294,10 @@ theorem canonical_of_size_zero {p : UniPoly R} : p.coeffs.size = 0 → p.trim = 
   exact Array.eq_empty_of_size_eq_zero h
 
 theorem canonical_nonempty_iff [LawfulBEq R] {p : UniPoly R} (hp: p.size > 0) :
-  p.trim = p ↔ p.last_non_zero = some ⟨ p.size - 1, Nat.pred_lt_self hp ⟩
+  p.trim = p ↔ p.last_nonzero = some ⟨ p.size - 1, Nat.pred_lt_self hp ⟩
 := by
   unfold trim
-  induction p using last_non_zero_induct with
+  induction p using last_nonzero_induct with
   | case1 p h_none h_all_zero =>
     simp [h_none]
     by_contra h_empty
@@ -317,10 +317,10 @@ theorem canonical_nonempty_iff [LawfulBEq R] {p : UniPoly R} (hp: p.size > 0) :
       rw [this]
       exact Array.extract_all p.coeffs
 
-theorem last_non_zero_last_iff [LawfulBEq R] {p : UniPoly R} (hp: p.size > 0) :
-  p.last_non_zero = some ⟨ p.size - 1, Nat.pred_lt_self hp ⟩ ↔ p.coeffs.getLast hp ≠ 0
+theorem last_nonzero_last_iff [LawfulBEq R] {p : UniPoly R} (hp: p.size > 0) :
+  p.last_nonzero = some ⟨ p.size - 1, Nat.pred_lt_self hp ⟩ ↔ p.coeffs.getLast hp ≠ 0
 := by
-  induction p using last_non_zero_induct with
+  induction p using last_nonzero_induct with
   | case1 => simp [Array.getLast, *]
   | case2 p k h_some h_nonzero h_max =>
     simp only [h_some, Option.some_inj, Array.getLast]
@@ -343,11 +343,11 @@ theorem canonical_iff [LawfulBEq R] {p : UniPoly R} :
 := by
   constructor
   · intro h hp
-    rwa [← last_non_zero_last_iff hp, ← canonical_nonempty_iff hp]
+    rwa [← last_nonzero_last_iff hp, ← canonical_nonempty_iff hp]
   · rintro h
     rcases Nat.eq_zero_or_pos p.size with h_zero | hp
     · exact canonical_of_size_zero h_zero
-    · rw [canonical_nonempty_iff hp, last_non_zero_last_iff hp]
+    · rw [canonical_nonempty_iff hp, last_nonzero_last_iff hp]
       exact h hp
 
 theorem non_zero_map [LawfulBEq R] (f : R → R) (hf : ∀ r, f r = 0 → r = 0) (p : UniPoly R) :
@@ -599,8 +599,8 @@ theorem add_assoc [LawfulBEq R] : p + q + r = p + (q + r) := by
     apply _root_.add_assoc
 
 theorem nsmul_zero [LawfulBEq R] (p : UniPoly R) : nsmul 0 p = 0 := by
-  suffices (nsmul_raw 0 p).last_non_zero = none by simp [nsmul, trim, *]
-  apply Trim.last_non_zero_none
+  suffices (nsmul_raw 0 p).last_nonzero = none by simp [nsmul, trim, *]
+  apply Trim.last_nonzero_none
   intros; unfold nsmul_raw
   simp only [Nat.cast_zero, zero_mul, Array.getElem_map]
 

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -520,34 +520,39 @@ variable (p q r : UniPoly R)
 
 -- some helper lemmas to characterize p + q
 
-theorem matchSize_size_eq {p q : UniPoly Q} :
+lemma matchSize_size_eq {p q : UniPoly Q} :
   let (p', q') := Array.matchSize p.coeffs q.coeffs 0
   p'.size = q'.size := by
-  apply List.matchSize_length_eq
+  show (List.rightpad _ _ _).length = (List.rightpad _ _ _).length
+  rw [List.rightpad_length, List.rightpad_length]
+  omega
 
-theorem matchSize_size {p q : UniPoly Q} :
+lemma matchSize_size {p q : UniPoly Q} :
   let (p', _) := Array.matchSize p.coeffs q.coeffs 0
   p'.size = max p.size q.size := by
-  apply List.matchSize_length
+  show (List.rightpad _ _ _).length = max (List.length _) (List.length _)
+  rw [List.rightpad_length]
+  omega
 
-theorem zipWith_size {R} {f : R → R → R} {a b : Array R} :
+lemma zipWith_size {R} {f : R → R → R} {a b : Array R} :
   a.size = b.size → (Array.zipWith a b f).size = a.size := by
   simp; omega
 
--- TODO generalize to matchSize + zipWith f for any f
+-- TODO could generalize this to matchSize + zipWith f for any f
 theorem add_size {p q : UniPoly Q} : (add_raw p q).size = max p.size q.size := by
   show (Array.zipWith _ _ _ ).size = max p.size q.size
   rw [zipWith_size matchSize_size_eq, matchSize_size]
 
--- TODO generalize to matchSize + zipWith f for any f
+-- TODO could generalize this generalize to matchSize + zipWith f for any f
 theorem add_coeff {p q : UniPoly Q} {i: ℕ} (hi: i < (add_raw p q).size) :
   (add_raw p q).coeffs[i] = p.coeffs.getD i 0 + q.coeffs.getD i 0
 := by
   simp [add_raw]
-  rw [List.getElem_matchSize_1, List.getElem_matchSize_2]
-  repeat rw [Array.getElem?_eq_toList]
+  unfold List.matchSize
+  repeat rw [List.rightpad_getElem_eq_getD]
+  simp only [List.getD_eq_getElem?_getD, Array.getElem?_eq_toList]
 
--- TODO generalize to matchSize + zipWith f for any f
+-- TODO could generalize this generalize to matchSize + zipWith f for any f
 theorem add_coeff? (p q : UniPoly Q) (i: ℕ) :
   (add_raw p q).coeffs.getD i 0 = p.coeffs.getD i 0 + q.coeffs.getD i 0
 := by

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -240,17 +240,16 @@ lemma eq_degree_of_equiv [LawfulBEq R] {p q : UniPoly R} : equiv p q → p.degre
   unfold equiv degree
   intro h_equiv
   induction p using last_non_zero_induct with
-  | case1 p h_none h_all_zero =>
-    rw [h_none]
+  | case1 p h_none_p h_all_zero =>
     have h_zero_p : ∀ i, p.coeffs.getD i 0 = 0 := getD_eq_zero.mp h_all_zero
     have h_zero_q : ∀ i, q.coeffs.getD i 0 = 0 := by intro i; rw [← h_equiv, h_zero_p]
     have h_none_q : q.last_non_zero = none := last_non_zero_none (getD_eq_zero.mpr h_zero_q)
-    rw [h_none_q]
+    rw [h_none_p, h_none_q]
   | case2 p k h_some_p h_nonzero_p h_max_p =>
     have h_equiv_k := h_equiv k
     have k_lt_q : k < q.size := by
-      rcases Nat.lt_or_ge k q.size with h_lt | h_ge
-      · exact h_lt
+      by_contra h_not_lt
+      have h_ge := Nat.le_of_not_lt h_not_lt
       simp [h_ge] at h_equiv_k
       contradiction
     simp [k_lt_q] at h_equiv_k

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -533,12 +533,12 @@ lemma zipWith_size {R} {f : R → R → R} {a b : Array R} :
   a.size = b.size → (Array.zipWith a b f).size = a.size := by
   simp; omega
 
--- TODO could generalize this to matchSize + zipWith f for any f
+-- TODO we could generalize the next few lemmas to matchSize + zipWith f for any f
+
 theorem add_size {p q : UniPoly Q} : (add_raw p q).size = max p.size q.size := by
   show (Array.zipWith _ _ _ ).size = max p.size q.size
   rw [zipWith_size matchSize_size_eq, matchSize_size]
 
--- TODO could generalize this generalize to matchSize + zipWith f for any f
 theorem add_coeff {p q : UniPoly Q} {i: ℕ} (hi: i < (add_raw p q).size) :
   (add_raw p q).coeffs[i] = p.coeffs.getD i 0 + q.coeffs.getD i 0
 := by
@@ -547,7 +547,6 @@ theorem add_coeff {p q : UniPoly Q} {i: ℕ} (hi: i < (add_raw p q).size) :
   repeat rw [List.rightpad_getElem_eq_getD]
   simp only [List.getD_eq_getElem?_getD, Array.getElem?_eq_toList]
 
--- TODO could generalize this generalize to matchSize + zipWith f for any f
 theorem add_coeff? (p q : UniPoly Q) (i: ℕ) :
   (add_raw p q).coeffs.getD i 0 = p.coeffs.getD i 0 + q.coeffs.getD i 0
 := by
@@ -558,7 +557,6 @@ theorem add_coeff? (p q : UniPoly Q) (i: ℕ) :
   have h_q : i ≥ q.size := by omega
   simp [h_ge, h_p, h_q]
 
--- TODO generalize to matchSize + zipWith f for any f
 lemma trim_add_trim [LawfulBEq R] (p q : UniPoly R) : p.trim + q = p + q := by
   apply Trim.eq_of_equiv
   intro i

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -50,24 +50,24 @@ def C (r : R) : UniPoly R := ⟨#[r]⟩
 def X : UniPoly R := ⟨#[0, 1]⟩
 
 /-- Return the index of the last non-zero coefficient of a `UniPoly` -/
-def last_nonzero [BEq R] (p: UniPoly R) : Option (Fin p.size) :=
+def last_nonzero (p: UniPoly R) : Option (Fin p.size) :=
   p.coeffs.findIdxRev? (· != 0)
 
 /-- Remove leading zeroes from a `UniPoly`. Requires `BEq` to check if the coefficients are zero. -/
-def trim [BEq R] (p : UniPoly R) : UniPoly R :=
+def trim (p : UniPoly R) : UniPoly R :=
   match p.last_nonzero with
   | none => ⟨#[]⟩
   | some i => ⟨p.coeffs.extract 0 (i.val + 1)⟩
 
 /-- Return the degree of a `UniPoly`. -/
-def degree [BEq R] (p : UniPoly R) : Nat :=
+def degree (p : UniPoly R) : Nat :=
   match p.last_nonzero with
   | none => 0
   | some i => i.val + 1
 
 /-- Return the leading coefficient of a `UniPoly` as the last coefficient of the trimmed array,
 or `0` if the trimmed array is empty. -/
-def leadingCoeff [BEq R] (p : UniPoly R) : R := p.trim.coeffs.getLastD 0
+def leadingCoeff (p : UniPoly R) : R := p.trim.coeffs.getLastD 0
 
 namespace Trim
 
@@ -468,8 +468,6 @@ def natDegreeBound (p : UniPoly R) : Nat :=
 
 /-- Check if a `UniPoly` is monic, i.e. its leading coefficient is 1. -/
 def monic (p : UniPoly R) : Bool := p.leadingCoeff == 1
-
--- TODO: remove dependence on `BEq` for division and modulus
 
 /-- Division and modulus of `p : UniPoly R` by a monic `q : UniPoly R`. -/
 def divModByMonicAux [Field R] (p : UniPoly R) (q : UniPoly R) :

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -118,8 +118,19 @@ theorem coeff_eq_getD_lt [LawfulBEq R] {p : UniPoly R} {i} (hi: i < p.size) :
   · have h' : ∃ a ∈ p.coeffs, a != 0 := by push_neg at h; assumption
     obtain ⟨ k, hk ⟩ := Array.findIdxRev?_eq_some h'
     simp [hk]
-    have h_zero_after_k := Array.findIdxRev?_maximal hk
-    -- split between i <= k and i > k
+    -- split between i > k and i <= k
+    have h_size : k + 1 = (p.coeffs.extract 0 (k + 1)).size := by
+      simp [Array.size_extract]
+      exact Nat.succ_le_of_lt k.is_lt
+    rcases (Nat.lt_or_ge k i) with hik | hik
+    · have hik' : i ≥ (p.coeffs.extract 0 (k + 1)).size := by linarith
+      rw [Array.getElem?_eq_none hik', Option.getD_none]
+      have h_zero := Array.findIdxRev?_maximal hk ⟨ i, hi ⟩ hik
+      simp at h_zero
+      rw [‹p.coeffs[i] = 0›]
+    · have hik' : i < (p.coeffs.extract 0 (k + 1)).size := by linarith
+      rw [Array.getElem?_eq_getElem hik', Option.getD_some, Array.getElem_extract]
+      simp only [zero_add]
 
 theorem coeff_eq_getD [LawfulBEq R] (p : UniPoly R) (i : ℕ) :
   p.trim.coeffs.getD i 0 = p.coeffs.getD i 0 := by

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -106,7 +106,8 @@ def zsmul [Ring R] (z : ℤ) (p : UniPoly R) : UniPoly R :=
   .mk (Array.map (fun a => z * a) p.coeffs)
 
 /-- Negation of a `UniPoly`. -/
-def neg [Ring R] (p : UniPoly R) : UniPoly R := p.smul (-1)
+def neg [Ring R] (p : UniPoly R) : UniPoly R :=
+  ⟨ p.coeffs.map (fun a => -a) ⟩
 
 /-- Subtraction of two `UniPoly`s. -/
 def sub [Ring R] (p q : UniPoly R) : UniPoly R := p.add q.neg

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -108,14 +108,18 @@ theorem size_le_size (p : UniPoly R) : p.trim.size ≤ p.size := by
 theorem coeff_eq_getD_lt [LawfulBEq R] {p : UniPoly R} {i} (hi: i < p.size) :
   p.trim.coeffs.getD i 0 = p.coeffs[i] := by
   unfold trim last_non_zero
-  by_cases h: ∀ a ∈ p.coeffs, a = 0
-  · rw [Array.findIdxRev?_eq_none]
-    simp [h, Array.getElem?_eq]
-    symm
-    rw [h p.coeffs[i] (Array.getElem_mem hi)]
-    intro a ha
-    simp [h a ha]
-  sorry
+  by_cases h: ∀ a ∈ p.coeffs, ¬ (a != 0)
+  · rw [Array.findIdxRev?_eq_none h]
+    simp [Array.getElem?_eq]
+    set a := p.coeffs[i]
+    specialize h a (Array.getElem_mem hi)
+    rw [bne_iff_ne, ne_eq, not_not] at h
+    exact Eq.symm h
+  · have h' : ∃ a ∈ p.coeffs, a != 0 := by push_neg at h; assumption
+    obtain ⟨ k, hk ⟩ := Array.findIdxRev?_eq_some h'
+    simp [hk]
+    have h_zero_after_k := Array.findIdxRev?_maximal hk
+    -- split between i <= k and i > k
 
 theorem coeff_eq_getD [LawfulBEq R] (p : UniPoly R) (i : ℕ) :
   p.trim.coeffs.getD i 0 = p.coeffs.getD i 0 := by

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -91,7 +91,75 @@ def degree [BEq R] (p : UniPoly R) : Nat :=
 or `0` if the trimmed array is empty. -/
 def leadingCoeff [BEq R] (p : UniPoly R) : R := p.trim.coeffs.getLastD 0
 
-namespace trim
+namespace Trim
+
+-- characterize .last_non_zero
+theorem last_non_zero_none [LawfulBEq R] {p : UniPoly R} :
+  (∀ i, (hi : i < p.size) → p.coeffs[i] = 0) → p.last_non_zero = none
+:= by
+  intro h
+  apply Array.findIdxRev?_eq_none
+  intro a ha
+  suffices a = 0 by rwa [bne_iff_ne, ne_eq, not_not]
+  -- translate index access to array membership
+  -- TODO if this is nicer to use then we should use index access in `Array.findIdxRev?` theorems
+  obtain ⟨ i, hi, rfl: p.coeffs[i] = a ⟩ := Array.mem_iff_getElem.mp ha
+  exact h i hi
+
+theorem last_non_zero_some [LawfulBEq R] {p : UniPoly R} {i} (hi: i < p.size) (h: p.coeffs[i] ≠ 0) :
+  ∃ k, p.last_non_zero = some k
+:= Array.findIdxRev?_eq_some ⟨p.coeffs[i], Array.getElem_mem _, bne_iff_ne.mpr h⟩
+
+-- theorem to pass to `cases` when reasoning about last_non_zero and trim
+theorem last_none_zero_cases [LawfulBEq R] (p : UniPoly R) :
+  (p.last_non_zero = none ∧ (∀ i, (hi : i < p.size) → p.coeffs[i] = 0))
+  ∨ (∃ k, p.last_non_zero = some k)
+:= by
+  by_cases h : ∀ i, (hi : i < p.size) → p.coeffs[i] = 0
+  · left; exact ⟨last_non_zero_none h, h⟩
+  · right
+    push_neg at h
+    rcases h with ⟨ i, hi, h ⟩
+    exact last_non_zero_some hi h
+
+theorem last_non_zero_spec [LawfulBEq R] {p : UniPoly R} {k} :
+  p.last_non_zero = some k
+  → p.coeffs[k] ≠ 0 ∧ (∀ j, (hj : j < p.size) → j > k → p.coeffs[j] = 0)
+:= by
+  intro (h : p.last_non_zero = some k)
+  constructor
+  · by_contra
+    have h : p.coeffs[k] != 0 := Array.findIdxRev?_def h
+    rwa [‹p.coeffs[k] = 0›, bne_self_eq_false, Bool.false_eq_true] at h
+  · intro j hj j_gt_k
+    have h : ¬(p.coeffs[j] != 0) := Array.findIdxRev?_maximal h ⟨ j, hj ⟩ j_gt_k
+    rwa [bne_iff_ne, ne_eq, not_not] at h
+
+-- the property of `last_non_zero_spec` uniquely identifies an element,
+-- and that allows us to prove the reverse as well
+def last_non_zero_prop {p : UniPoly R} (k: Fin p.size) : Prop :=
+  p.coeffs[k] ≠ 0 ∧ (∀ j, (hj : j < p.size) → j > k → p.coeffs[j] = 0)
+
+lemma last_non_zero_unique {p : UniPoly Q} {k k' : Fin p.size} :
+  last_non_zero_prop k → last_non_zero_prop k' → k = k'
+:= by
+  suffices weaker : ∀ k k', last_non_zero_prop k → last_non_zero_prop k' → k ≤ k' by
+    intro h h'
+    exact Fin.le_antisymm (weaker k k' h h') (weaker k' k h' h)
+  intro k k' ⟨ h_nonzero, h ⟩ ⟨ h_nonzero', h' ⟩
+  by_contra k_not_le
+  have : p.coeffs[k] = 0 := h' k k.is_lt (Nat.lt_of_not_ge k_not_le)
+  contradiction
+
+theorem last_non_zero_some_iff [LawfulBEq R]  {p : UniPoly R} {k} :
+  p.last_non_zero = some k ↔ (p.coeffs[k] ≠ 0 ∧ (∀ j, (hj : j < p.size) → j > k → p.coeffs[j] = 0))
+:= by
+  constructor
+  · apply last_non_zero_spec
+  intro h_prop
+  have ⟨ k', h_some'⟩ := last_non_zero_some k.is_lt h_prop.left
+  have k_is_k' := last_non_zero_unique (last_non_zero_spec h_some') h_prop
+  rwa [← k_is_k']
 
 theorem size_eq_degree (p : UniPoly R) : p.trim.size = p.degree := by
   unfold trim degree
@@ -147,15 +215,43 @@ lemma getD_eq_getElem {p : UniPoly Q} {i} (hp : i < p.size) :
 def equiv (p q : UniPoly R) : Prop :=
   ∀ i, p.coeffs.getD i 0 = q.coeffs.getD i 0
 
-lemma eq_degree_of_equiv {p q : UniPoly R} : equiv p q → p.degree = q.degree := by
-  unfold equiv degree last_non_zero
-  sorry
+lemma getD_eq_zero {p : UniPoly Q} :
+    (∀ i, (hi : i < p.size) → p.coeffs[i] = 0) ↔ ∀ i, p.coeffs.getD i 0 = 0
+:= by
+  constructor <;> intro h i
+  · cases Nat.lt_or_ge i p.size <;> simp [h, *]
+  · intro hi; specialize h i; simp [hi] at h; assumption
 
--- def equiv₂ (p q : UniPoly R) : Prop :=
---   ∀ i,
---     ((hp : i < p.size) → (hq : i < q.size) → p.coeffs[i] = q.coeffs[i])
---   ∧ ((hp : i ≥ p.size) → (hq : i < q.size) → q.coeffs[i] = 0)
---   ∧ ((hp : i < p.size) → (hq : i ≥ q.size) → p.coeffs[i] = 0)
+lemma eq_degree_of_equiv [LawfulBEq R] {p q : UniPoly R} : equiv p q → p.degree = q.degree := by
+  unfold equiv degree
+  intro h_equiv
+  rcases last_none_zero_cases p with ⟨ h_none, h_all_zero ⟩ | h_some
+  · rw [h_none]
+    have h_zero_p : ∀ i, p.coeffs.getD i 0 = 0 := getD_eq_zero.mp h_all_zero
+    have h_zero_q : ∀ i, q.coeffs.getD i 0 = 0 := by intro i; rw [← h_equiv, h_zero_p]
+    have h_none_q : q.last_non_zero = none := last_non_zero_none (getD_eq_zero.mpr h_zero_q)
+    rw [h_none_q]
+  obtain ⟨ k, h_some_p ⟩ := h_some
+  have h_equiv_k := h_equiv k
+  have ⟨ h_nonzero_p, h_max_p ⟩ := last_non_zero_spec h_some_p
+  have k_lt_q : k < q.size := by
+    rcases Nat.lt_or_ge k q.size with h_lt | h_ge
+    · exact h_lt
+    simp [h_ge] at h_equiv_k
+    contradiction
+  simp [k_lt_q] at h_equiv_k
+  have h_nonzero_q : q.coeffs[k.val] ≠ 0 := by rwa [← h_equiv_k]
+  have h_max_q : ∀ j, (hj : j < q.size) → j > k → q.coeffs[j] = 0 := by
+    intro j hj j_gt_k
+    have h_eq := h_equiv j
+    simp [hj] at h_eq
+    rw [← h_eq]
+    rcases Nat.lt_or_ge j p.size with hj | hj
+    · simp [hj, h_max_p j hj j_gt_k]
+    · simp [hj]
+  have h_some_q : q.last_non_zero = some ⟨ k, k_lt_q ⟩ :=
+    last_non_zero_some_iff.mpr ⟨ h_nonzero_q, h_max_q ⟩
+  rw [h_some_p, h_some_q]
 
 theorem eq_of_equiv [LawfulBEq R] {p q : UniPoly R} : equiv p q → p.trim = q.trim := by
   unfold equiv
@@ -167,7 +263,7 @@ theorem eq_of_equiv [LawfulBEq R] {p q : UniPoly R} : equiv p q → p.trim = q.t
   rw [← getD_eq_getElem, ← getD_eq_getElem]
   rw [coeff_eq_getD, coeff_eq_getD, h _]
 
-end trim
+end Trim
 
 section Operations
 
@@ -350,9 +446,9 @@ theorem add_coeff? (p q : UniPoly Q) (i: ℕ) :
 
 -- TODO generalize to matchSize + zipWith f for any f
 lemma trim_add_trim [LawfulBEq R] (p q : UniPoly R) : p.trim + q = p + q := by
-  apply trim.eq_of_equiv
+  apply Trim.eq_of_equiv
   intro i
-  rw [add_coeff?, add_coeff?, trim.coeff_eq_getD]
+  rw [add_coeff?, add_coeff?, Trim.coeff_eq_getD]
 
 -- algebra theorems about add
 

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -26,15 +26,6 @@ the same polynomial via zero-padding, for example `#[1,2,3] = #[1,2,3,0,0,0,...]
 @[reducible, inline, specialize]
 def UniPoly (R : Type*) := Array R
 
--- instance {R : Type*} : GetElem (UniPoly R) Nat R fun xs i => i < xs.size where
---   getElem xs i h := xs.get i h
-
--- @[ext, specialize]
--- structure UniPoly' (R : Type*) [Ring R] where
---   mk::
---   coeffs : Array R
--- deriving Inhabited, DecidableEq, Repr
-
 namespace UniPoly
 
 @[reducible]
@@ -45,11 +36,6 @@ def coeffs {R : Type*} (p : UniPoly R) : Array R := p
 
 variable {R : Type*} [Ring R] [BEq R]
 variable {Q : Type*} [Ring Q]
-
--- /-- The size of the underlying array. This may not correspond to the degree of the corresponding
---   polynomial if the array has leading zeroes. -/
--- @[reducible]
--- def size (p : UniPoly R) : Nat := p.size
 
 /-- The constant polynomial `C r`. -/
 def C (r : R) : UniPoly R := #[r]
@@ -297,7 +283,7 @@ theorem canonical_empty : (UniPoly.mk #[]).trim = UniPoly.mk (R:=R) #[] := by
 
 theorem canonical_of_size_zero {p : UniPoly R} : p.size = 0 → p.trim = p := by
   intro h
-  suffices h_empty : p = .mk #[] by rw [h_empty]; exact canonical_empty
+  suffices h_empty : p = #[] by rw [h_empty]; exact canonical_empty
   exact Array.eq_empty_of_size_eq_zero h
 
 theorem canonical_nonempty_iff [LawfulBEq R] {p : UniPoly R} (hp: p.size > 0) :
@@ -443,7 +429,7 @@ def pow (p : UniPoly R) (n : Nat) : UniPoly R := (mul p)^[n] (C 1)
 
 -- TODO: define repeated squaring version of `pow`
 
-instance : Zero (UniPoly R) := ⟨UniPoly.mk #[]⟩
+instance : Zero (UniPoly R) := ⟨#[]⟩
 instance : One (UniPoly R) := ⟨UniPoly.C 1⟩
 instance : Add (UniPoly R) := ⟨UniPoly.add⟩
 instance : SMul R (UniPoly R) := ⟨UniPoly.smul⟩

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -372,7 +372,7 @@ theorem nsmul_zero [LawfulBEq R] (p : UniPoly R) : nsmul 0 p = 0 := by
   unfold last_non_zero
   apply Array.findIdxRev?_eq_none
   intro a ha
-  suffices a = 0 by simp only [bne_self_eq_false, *]
+  suffices a = 0 by simp [*]
   rw [nsmul_raw, Array.mem_map] at ha
   simp only [Nat.cast_zero, zero_mul] at ha
   tauto


### PR DESCRIPTION
This provides a sorry-free proof of `AddCommGroup` for `UniPolyC`, the canonical subtype of `UniPoly` which I defined as
```lean
{ p : UniPoly R // p.trim = p }
```

Addition is defined by first adding element-wise, and then trimming the array.

For trimming, I added a new custom primitive `Array.findIdxRev?` that traverses the array backwards, to search for the last non-zero element. Previously, it was defined using well-founded recursion which supposedly is slow at runtime.

Many new theorems are added that characterize the behavior of `Array.findIdxRev?`, `UniPoly.last_nonzero` and `UniPoly.trim`.

Note, this might not be the final way we prefer to represent polynomials in, either for computation or for proofs, but the added theorem infrastructure is likely reusable