### PR TITLE
Unipoly conversion

### DIFF
--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -689,6 +689,15 @@ noncomputable def toPoly (p : UniPoly R) : Polynomial R :=
 
 alias ofPoly := Polynomial.toImpl
 
+theorem eval_toPoly_eq_eval (x : Q) (p : UniPoly Q) : p.toPoly.eval x = p.eval x := by
+  unfold toPoly eval eval₂
+  rw [← Array.foldl_hom (Polynomial.eval x)
+    (fun acc (t : Q × ℕ) ↦ acc + Polynomial.C t.1 * Polynomial.X ^ t.2)
+    (fun acc (a, i) ↦ acc + a * x ^ i) ]
+  congr
+  exact Polynomial.eval_zero
+  simp
+
 theorem toPoly_add {p q : UniPoly R} : (add_raw p q).toPoly = p.toPoly + q.toPoly := by
   dsimp [toPoly]
   sorry

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -687,6 +687,17 @@ variable {S: Type} [Semiring S]
 noncomputable def toPoly (p : UniPoly R) : Polynomial R :=
   p.eval₂ Polynomial.C Polynomial.X
 
+-- this is more low-level and simple, maybe a better definition
+noncomputable def toPoly' (p : UniPoly R) : Polynomial R :=
+  Polynomial.ofFinsupp (Finsupp.onFinset (Finset.range p.size) (fun i => p.getD i 0) (by
+    intro n hn
+    simp only at hn
+    rw [Finset.mem_range]
+    by_contra! h
+    have h' : p.getD n 0 = 0 := by simp [h]
+    contradiction
+  ))
+
 alias ofPoly := Polynomial.toImpl
 
 theorem eval_toPoly_eq_eval (x : Q) (p : UniPoly Q) : p.toPoly.eval x = p.eval x := by

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -711,7 +711,27 @@ theorem eval_toPoly_eq_eval (x : Q) (p : UniPoly Q) : p.toPoly.eval x = p.eval x
 
 lemma coeff_toPoly (p : UniPoly Q) (n : ℕ) : p.toPoly.coeff n = p.getD n 0 := by
   unfold toPoly eval₂
-  sorry
+
+  let motive (k: ℕ) (a: Polynomial Q) := a.coeff n = if (k ≤ n) then 0 else Array.getD p n 0
+
+  let as := p.zipIdx
+  let f := fun (acc: Polynomial Q) ((a,i): Q × ℕ) ↦ acc + Polynomial.C a * Polynomial.X ^ i
+  show (Array.foldl f 0 as).coeff n = p.getD n 0
+
+  have h0 : motive 0 0 := by simp [motive]
+
+  have hf : ∀ (i : Fin as.size) acc, motive (↑i) acc → motive (↑i + 1) (f acc as[i]) := by
+    unfold motive
+    intros i acc h
+    rcases (Nat.lt_trichotomy i n) with hlt | heq | hgt
+    · sorry
+    · sorry
+    · sorry
+
+  rw [Array.foldl_induction motive h0 hf, ite_eq_right_iff]
+  intro hn
+  simp [as, Array.zipIdx] at hn
+  simp [hn]
 
 theorem ofPoly_toPoly (p : Polynomial Q) : p = p.toImpl.toPoly := by
   ext n

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -28,7 +28,7 @@ def UniPoly (R : Type*) := Array R
 
 /-- Convert a `Polynomial` to a `UniPoly`. -/
 def Polynomial.toImpl {R : Type*} [Semiring R] (p : Polynomial R) : UniPoly R :=
-  .ofFn (fun i : Fin p.natDegree => p.coeff i)
+  .ofFn (fun i : Fin (p.natDegree + 1) => p.coeff i)
 
 namespace UniPoly
 
@@ -698,18 +698,25 @@ theorem eval_toPoly_eq_eval (x : Q) (p : UniPoly Q) : p.toPoly.eval x = p.eval x
   exact Polynomial.eval_zero
   simp
 
+lemma coeff_toPoly (p : UniPoly Q) (n : ℕ) : p.toPoly.coeff n = p.getD n 0 := by
+  unfold toPoly eval₂
+  sorry
+
+theorem ofPoly_toPoly (p : Polynomial Q) : p = p.toImpl.toPoly := by
+  ext n
+  rw [coeff_toPoly]
+  unfold Polynomial.toImpl
+  simp only [Array.getD_eq_get?, Array.getElem?_ofFn]
+  by_cases h : n < p.natDegree + 1
+  · simp only [h, Option.getD_some, reduceDIte]
+  simp [h, reduceDIte, Option.getD_none]
+  rw [not_lt] at h
+  replace h := Nat.lt_of_succ_le h
+  exact coeff_eq_zero_of_natDegree_lt h
+
 theorem toPoly_add {p q : UniPoly R} : (add_raw p q).toPoly = p.toPoly + q.toPoly := by
   dsimp [toPoly]
   sorry
-
-theorem ofPoly_toPoly (p : Polynomial R) : p = p.toImpl.toPoly := by
-  induction p using Polynomial.induction_on' with
-  | h_add p q hp hq =>
-    rw [hp, hq]
-    simp [toPoly, toImpl, eval₂]
-    sorry
-  | h_monomial n a =>
-    sorry
 
 end ToPoly
 

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -749,24 +749,33 @@ lemma coeff_toPoly {p : UniPoly Q} {n : ℕ} : p.toPoly.coeff n = p.getD n 0 := 
     have h2 : n < i + 1 := by linarith
     simp [hgt, h1, h2]
 
+/-- lemma to argue about toImpl by cases -/
+lemma toImpl_elim (p : Q[X]) :
+    (p = 0 ∧ p.toImpl = #[])
+  ∨ (p ≠ 0 ∧ p.toImpl = .ofFn (fun i : Fin (p.natDegree + 1) => p.coeff i)) := by
+  unfold toImpl
+  by_cases hbot : p.degree = ⊥
+  · left
+    use degree_eq_bot.mp hbot
+    rw [hbot]
+  right
+  use degree_ne_bot.mp hbot
+  have hnat : p.degree = p.natDegree := degree_eq_natDegree (degree_ne_bot.mp hbot)
+  simp [hnat]
+
 theorem ofPoly_toPoly {p : Q[X]} : p.toImpl.toPoly = p := by
   ext n
   rw [coeff_toPoly]
-  unfold Polynomial.toImpl
-  simp only [Array.getD_eq_get?, Array.getElem?_ofFn]
-  by_cases hbot : p.degree = ⊥
-  · rw [hbot, degree_eq_bot.mp hbot, coeff_zero]
-    simp
-  have hd : p.degree = p.natDegree := degree_eq_natDegree (degree_ne_bot.mp hbot)
-  rw [hd]
-  simp only
+  rcases toImpl_elim p with ⟨rfl, h⟩ | ⟨_, h⟩
+  · simp [h]
+  rw [h]
   by_cases h : n < p.natDegree + 1
   · simp [h]
-  rw [Array.getElem?_ofFn, Nat.cast_id]
+  simp only [Array.getD_eq_get?, Array.getElem?_ofFn]
   simp only [h, reduceDIte, Option.getD_none]
-  rw [not_lt] at h
-  replace h := Nat.lt_of_succ_le h
-  exact coeff_eq_zero_of_natDegree_lt h |> Eq.symm
+  replace h := Nat.lt_of_succ_le (not_lt.mp h)
+  symm
+  exact coeff_eq_zero_of_natDegree_lt h
 
 theorem toPoly_add {p q : UniPoly Q} : (add_raw p q).toPoly = p.toPoly + q.toPoly := by
   ext n

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -815,49 +815,6 @@ theorem trim_toImpl [LawfulBEq R] (p : R[X]) : p.toImpl.trim = p.toImpl := by
   rw [getLast_toImpl h_nz]
   exact Polynomial.leadingCoeff_ne_zero.mpr h_nz
 
-lemma toPoly_induct (p: UniPoly Q) (motive : (p : UniPoly Q) → (q: Q[X] := p.toPoly) → (i: ℕ := p.size) → Prop)
-  (init : motive 0 0 0)
-  (induct : ∀ a : Q, ∀ p acc (i : Fin p.size), motive p acc i
-    → motive (p.push a) (acc + Polynomial.C a * Polynomial.X ^ (i : ℕ)) (i + 1))
-  : motive p := by
-  sorry
-
-theorem toPoly_degree [LawfulBEq R] (p: UniPoly R) :
-  p.toPoly.degree = match p.last_nonzero with
-    | none => ⊥
-    | some k => k
-   := by
-  induction p using Trim.last_nonzero_induct with
-  | case1 p h_none h_all_zero =>
-    rw [h_none]; dsimp only
-    suffices h : p.toPoly = 0 by
-      rw [h]
-      exact Polynomial.degree_zero
-    -- could extract this case into a lemma
-    -- `∀ (i : ℕ) (hi : i < Array.size p), p[i] = 0 → p.toPoly = 0`
-    unfold toPoly eval₂
-    let motive (size: ℕ) (acc: R[X]) := acc = 0
-    apply Array.foldl_induction motive
-    · simp [motive]
-    unfold motive
-    intro i acc ih
-    have zipIdx_getElem : p.zipIdx[i] = (p[i], ↑i) := by simp [Array.getElem_zipIdx]
-    have zipIdx_size : p.zipIdx.size = p.size := by simp [Array.zipIdx]
-    have i_lt : i < p.size := by linarith [i.is_lt]
-    rw [zipIdx_getElem, ih]
-    simp [h_all_zero i i_lt]
-  | case2 p k h_some h_nonzero h_max =>
-    rw [h_some]; dsimp only
-    have ⟨ k', h_some', h ⟩ := toPoly_induct p
-      (fun p q i => ∃ k, p.last_nonzero = some k ∧ q.degree = k)
-      ?h0 ?ih
-    have h_k_eq_k' : k = k' := by
-      suffices h' : some k = some k' by injections
-      rw [← h_some, ← h_some']
-    rw [h_k_eq_k', h]
-    sorry
-    sorry
-
 theorem toImpl_toPoly_of_canonical [LawfulBEq R] (p: UniPoly R) (hp: p.trim = p) :
     p.toPoly.toImpl = p := by
   -- we will show something slightly more general: `toPoly` is injective on canonical polynomials

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -27,8 +27,10 @@ the same polynomial via zero-padding, for example `#[1,2,3] = #[1,2,3,0,0,0,...]
 def UniPoly (R : Type*) := Array R
 
 /-- Convert a `Polynomial` to a `UniPoly`. -/
-def Polynomial.toImpl {R : Type*} [Semiring R] (p : Polynomial R) : UniPoly R :=
-  .ofFn (fun i : Fin (p.natDegree + 1) => p.coeff i)
+def Polynomial.toImpl {R : Type*} [Semiring R] (p : R[X]) : UniPoly R :=
+  match p.degree with
+  | ⊥ => #[]
+  | some d  => .ofFn (fun i : Fin (d + 1) => p.coeff i)
 
 namespace UniPoly
 
@@ -752,9 +754,16 @@ theorem ofPoly_toPoly {p : Q[X]} : p.toImpl.toPoly = p := by
   rw [coeff_toPoly]
   unfold Polynomial.toImpl
   simp only [Array.getD_eq_get?, Array.getElem?_ofFn]
+  by_cases hbot : p.degree = ⊥
+  · rw [hbot, degree_eq_bot.mp hbot, coeff_zero]
+    simp
+  have hd : p.degree = p.natDegree := degree_eq_natDegree (degree_ne_bot.mp hbot)
+  rw [hd]
+  simp only
   by_cases h : n < p.natDegree + 1
   · simp [h]
-  simp only [h, Option.getD_none, reduceDIte]
+  rw [Array.getElem?_ofFn, Nat.cast_id]
+  simp only [h, reduceDIte, Option.getD_none]
   rw [not_lt] at h
   replace h := Nat.lt_of_succ_le h
   exact coeff_eq_zero_of_natDegree_lt h |> Eq.symm

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -687,7 +687,7 @@ variable {S: Type} [Semiring S]
 noncomputable def toPoly (p : UniPoly R) : Polynomial R :=
   p.eval₂ Polynomial.C Polynomial.X
 
--- this is more low-level and direct, maybe a better definition
+/-- this is more low-level and direct, maybe a better definition than `toPoly` -/
 noncomputable def toPoly' (p : UniPoly R) : Polynomial R :=
   Polynomial.ofFinsupp (Finsupp.onFinset (Finset.range p.size) (fun i => p.getD i 0) (by
     intro n hn
@@ -709,7 +709,7 @@ theorem eval_toPoly_eq_eval (x : Q) (p : UniPoly Q) : p.toPoly.eval x = p.eval x
   exact Polynomial.eval_zero
   simp
 
-lemma coeff_toPoly (p : UniPoly Q) (n : ℕ) : p.toPoly.coeff n = p.getD n 0 := by
+lemma coeff_toPoly {p : UniPoly Q} {n : ℕ} : p.toPoly.coeff n = p.getD n 0 := by
   unfold toPoly eval₂
 
   let f := fun (acc: Q[X]) ((a,i): Q × ℕ) ↦ acc + Polynomial.C a * Polynomial.X ^ i
@@ -747,21 +747,25 @@ lemma coeff_toPoly (p : UniPoly Q) (n : ℕ) : p.toPoly.coeff n = p.getD n 0 := 
     have h2 : n < i + 1 := by linarith
     simp [hgt, h1, h2]
 
-theorem ofPoly_toPoly (p : Polynomial Q) : p = p.toImpl.toPoly := by
+theorem ofPoly_toPoly {p : Q[X]} : p.toImpl.toPoly = p := by
   ext n
   rw [coeff_toPoly]
   unfold Polynomial.toImpl
   simp only [Array.getD_eq_get?, Array.getElem?_ofFn]
   by_cases h : n < p.natDegree + 1
-  · simp only [h, Option.getD_some, reduceDIte]
+  · simp [h]
   simp only [h, Option.getD_none, reduceDIte]
   rw [not_lt] at h
   replace h := Nat.lt_of_succ_le h
-  exact coeff_eq_zero_of_natDegree_lt h
+  exact coeff_eq_zero_of_natDegree_lt h |> Eq.symm
 
 theorem toPoly_add {p q : UniPoly Q} : (add_raw p q).toPoly = p.toPoly + q.toPoly := by
   ext n
   rw [coeff_add, coeff_toPoly, coeff_toPoly, coeff_toPoly, add_coeff?]
+
+theorem toPoly_trim [LawfulBEq R] {p : UniPoly R} : p.trim.toPoly = p.toPoly := by
+  ext n
+  rw [coeff_toPoly, coeff_toPoly, Trim.getD_eq_getD]
 
 end ToPoly
 

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -785,6 +785,26 @@ theorem toPoly_trim [LawfulBEq R] {p : UniPoly R} : p.trim.toPoly = p.toPoly := 
   ext n
   rw [coeff_toPoly, coeff_toPoly, Trim.getD_eq_getD]
 
+lemma toImpl_nonzero {p : Q[X]} (hp: p ≠ 0) : p.toImpl.size > 0 := by
+  rcases toImpl_elim p with ⟨rfl, h⟩ | ⟨_, h⟩
+  · contradiction
+  suffices h : p.toImpl ≠ #[] from Array.size_pos.mpr h
+  simp [h]
+
+lemma getLast_toImpl {p : Q[X]} (hp: p ≠ 0) : let h : p.toImpl.size > 0 := toImpl_nonzero hp;
+    p.toImpl[p.toImpl.size - 1] = p.leadingCoeff := by
+  rcases toImpl_elim p with ⟨rfl, h⟩ | ⟨h_nz, h⟩
+  · contradiction
+  simp [h]
+
+theorem trim_toImpl [LawfulBEq R] (p : R[X]) : p.toImpl.trim = p.toImpl := by
+  rcases toImpl_elim p with ⟨rfl, h⟩ | ⟨h_nz, h⟩
+  · rw [h]; exact Trim.canonical_empty
+  rw [Trim.canonical_iff]
+  unfold Array.getLast
+  intro
+  rw [getLast_toImpl h_nz]
+  exact Polynomial.leadingCoeff_ne_zero.mpr h_nz
 end ToPoly
 
 section Equiv

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -369,6 +369,15 @@ theorem non_zero_map [LawfulBEq R] (f : R → R) (hf : ∀ r, f r = 0 → r = 0)
   have : p.size = 0 := by linarith
   have : fp.size = 0 := by simp [this, fp]
   apply canonical_of_size_zero this
+
+/-- Canonical polynomials enjoy a stronger extensionality theorem:
+  they just need to agree at all values, without any hypothesis about equal sizes
+-/
+theorem canonical_ext [LawfulBEq R] {p q : UniPoly R} (hp: p.trim = p) (hq: q.trim = q) :
+    equiv p q → p = q := by
+  intro h_equiv
+  rw [← hp, ← hq]
+  exact eq_of_equiv h_equiv
 end Trim
 
 /-- canonical version of UniPoly -/
@@ -849,17 +858,21 @@ theorem toPoly_degree [LawfulBEq R] (p: UniPoly R) :
     sorry
     sorry
 
--- theorem toImpl_toPoly_of_canonical [LawfulBEq R] (p: UniPoly R) (hp: p.trim = p) :
---     p.toPoly.toImpl = p := by
---   -- we will show something slightly more general: toImpl is injective on canonical polynomials
---   suffices h_inj : ∀ q : UniPoly R, q.trim = q → p.toPoly = q.toPoly → p = q by
---     have : p.toPoly = p.toPoly.toImpl.toPoly := by rw [toPoly_toImpl]
---     exact Eq.symm <| h_inj p.toPoly.toImpl (trim_toImpl p.toPoly) this
+theorem toImpl_toPoly_of_canonical [LawfulBEq R] (p: UniPoly R) (hp: p.trim = p) :
+    p.toPoly.toImpl = p := by
+  -- we will show something slightly more general: `toPoly` is injective on canonical polynomials
+  suffices h_inj : ∀ q : UniPoly R, q.trim = q → p.toPoly = q.toPoly → p = q by
+    have : p.toPoly = p.toPoly.toImpl.toPoly := by rw [toPoly_toImpl]
+    exact Eq.symm <| h_inj p.toPoly.toImpl (trim_toImpl p.toPoly) this
+  intro q hq hpq
+  apply Trim.canonical_ext hp hq
+  intro i
+  rw [← coeff_toPoly, ← coeff_toPoly]
+  congr
 
---   intro q hq hpq
---   -- unfold toPoly eval₂ at hpq
---   ext i hip hiq
-
+theorem toImpl_toPoly [LawfulBEq R] (p: UniPoly R) : p.toPoly.toImpl = p.trim := by
+  rw [← toPoly_trim]
+  exact toImpl_toPoly_of_canonical p.trim (Trim.trim_twice p)
 end ToPoly
 
 section Equiv

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -697,6 +697,7 @@ instance [LawfulBEq R] : AddCommGroup (UniPolyC R) where
 end OperationsC
 
 section ToPoly
+
 /-- Convert a `UniPoly` to a (mathlib) `Polynomial`. -/
 noncomputable def toPoly (p : UniPoly R) : Polynomial R :=
   p.eval₂ Polynomial.C Polynomial.X
@@ -854,6 +855,7 @@ theorem eval_toImpl_eq_eval [LawfulBEq R] (x : R) (p : R[X]) : p.toImpl.eval x =
 /-- corollary: evaluation stays the same after trimming -/
 lemma eval_trim_eq_eval [LawfulBEq R] (x : R) (p : UniPoly R) : p.trim.eval x = p.eval x := by
   rw [← toImpl_toPoly, eval_toImpl_eq_eval, eval_toPoly_eq_eval]
+
 end ToPoly
 
 section Equiv

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -447,25 +447,6 @@ instance : Pow (UniPoly R) Nat := ⟨UniPoly.pow⟩
 instance : NatCast (UniPoly R) := ⟨fun n => UniPoly.C (n : R)⟩
 instance : IntCast (UniPoly R) := ⟨fun n => UniPoly.C (n : R)⟩
 
-/-- Convert a `UniPoly` to a `Polynomial`. -/
-noncomputable def toPoly (p : UniPoly R) : Polynomial R :=
-  p.eval₂ Polynomial.C Polynomial.X
-
-alias ofPoly := Polynomial.toImpl
-
--- theorem toPoly_add {p q : UniPoly R} : (p + q).toPoly = p.toPoly + q.toPoly := by
---   simp [toPoly, eval₂]
---   sorry
-
--- theorem ofPoly_toPoly (p : Polynomial R) : p = p.toImpl.toPoly := by
---   induction p using Polynomial.induction_on' with
---   | h_add p q hp hq =>
---     rw [hp, hq]
---     simp [toPoly, toImpl, eval₂]
---     sorry
---   | h_monomial n a =>
---     sorry
-
 /-- Return a bound on the degree of a `UniPoly` as the size of the underlying array
 (and `⊥` if the array is empty). -/
 def degreeBound (p : UniPoly R) : WithBot Nat :=
@@ -699,6 +680,29 @@ instance [LawfulBEq R] : AddCommGroup (UniPolyC R) where
 
 end OperationsC
 
+section ToPoly
+variable {S: Type} [Semiring S]
+
+/-- Convert a `UniPoly` to a `Polynomial`. -/
+noncomputable def toPoly (p : UniPoly R) : Polynomial R :=
+  p.eval₂ Polynomial.C Polynomial.X
+
+alias ofPoly := Polynomial.toImpl
+
+theorem toPoly_add {p q : UniPoly R} : (add_raw p q).toPoly = p.toPoly + q.toPoly := by
+  dsimp [toPoly]
+  sorry
+
+theorem ofPoly_toPoly (p : Polynomial R) : p = p.toImpl.toPoly := by
+  induction p using Polynomial.induction_on' with
+  | h_add p q hp hq =>
+    rw [hp, hq]
+    simp [toPoly, toImpl, eval₂]
+    sorry
+  | h_monomial n a =>
+    sorry
+
+end ToPoly
 
 section Equiv
 

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -759,9 +759,9 @@ theorem ofPoly_toPoly (p : Polynomial Q) : p = p.toImpl.toPoly := by
   replace h := Nat.lt_of_succ_le h
   exact coeff_eq_zero_of_natDegree_lt h
 
-theorem toPoly_add {p q : UniPoly R} : (add_raw p q).toPoly = p.toPoly + q.toPoly := by
-  dsimp [toPoly]
-  sorry
+theorem toPoly_add {p q : UniPoly Q} : (add_raw p q).toPoly = p.toPoly + q.toPoly := by
+  ext n
+  rw [coeff_add, coeff_toPoly, coeff_toPoly, coeff_toPoly, add_coeff?]
 
 end ToPoly
 

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -720,7 +720,7 @@ theorem ofPoly_toPoly (p : Polynomial Q) : p = p.toImpl.toPoly := by
   simp only [Array.getD_eq_get?, Array.getElem?_ofFn]
   by_cases h : n < p.natDegree + 1
   · simp only [h, Option.getD_some, reduceDIte]
-  simp [h, reduceDIte, Option.getD_none]
+  simp only [h, Option.getD_none, reduceDIte]
   rw [not_lt] at h
   replace h := Nat.lt_of_succ_le h
   exact coeff_eq_zero_of_natDegree_lt h

--- a/ZKLib/Data/UniPoly/Basic.lean
+++ b/ZKLib/Data/UniPoly/Basic.lean
@@ -830,8 +830,7 @@ theorem trim_toImpl [LawfulBEq R] (p : R[X]) : p.toImpl.trim = p.toImpl := by
 
 /-- on canonical `UniPoly`s, `toImpl` is also a left-inverse of `toPoly`.
   in particular, `toPoly` is a bijection from `UniPolyC` to `Polynomial`. -/
-lemma toImpl_toPoly_of_canonical [LawfulBEq R] (p: UniPolyC R) :
-    p.toPoly.toImpl = p := by
+lemma toImpl_toPoly_of_canonical [LawfulBEq R] (p: UniPolyC R) : p.toPoly.toImpl = p := by
   -- we will show something slightly more general: `toPoly` is injective on canonical polynomials
   suffices h_inj : ∀ q : UniPolyC R, p.toPoly = q.toPoly → p = q by
     have : p.toPoly = p.toPoly.toImpl.toPoly := by rw [toPoly_toImpl]


### PR DESCRIPTION
this PR shows that conversion between `UniPoly` and mathlib's `Polynomial` satisfies many properties you'd expect:
* converting a `UniPoly` to mathlib and back yields the trimmed representative
* converting a mathlib poly to a `UniPoly` and back is the identity
* in particular, the conversion is a bijection between `UniPolyC` and `Polynomial`
* the conversion preserves evaluation at a point
* the conversion preserves addition

following mathlib, we define the coefficient at any Nat index (i.e. of any monomial) for UniPoly:
```lean
coeff : UniPoly R → ℕ → R
```
and we show that it coincides with mathlib's definition of `coeff`.

**Left for future PRs:**
* conversion preserves other poly operations like (scalar) multiplication
* I noticed the current definition of `eval` is suboptimal: $O(n^2)$ instead of $O(n)$, because the computation of powers $x ^ i$ is not cached. I still went with the current definition for now and will address this in a follow-up PR
* I think more effort should be spent to align definitions with mathlib. for example, `UniPoly.degree` behaves slightly different than `Polynomial.degree` (maps to `ℕ` instead of `ℕ | ⊥`)