### PR TITLE
feat: add VSCode settings configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+    "editor.rulers" : [100],
+    "editor.acceptSuggestionOnEnter": "off",
+    "files.encoding": "utf8",
+    "files.eol": "\n",
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true,
+    "git.ignoreLimitWarning": true,
+    "files.readonlyInclude": {
+      "**/.elan/**": true,
+      "**/.lake/**": true
+    }
+  }
+  


### PR DESCRIPTION
This PR copies (most of) the Mathlib vscode workspace configuration settings. Some nice things this provides:

* A ruler to see where the line size linter will start triggering.
* Make `/.lake` files read-only, so that I do not change them by accident.

Note: I did not include git branch protection, because perhaps we sometimes want to commit directly to main, IDK.