### PR TITLE
feat: define `(Mv)PolynomialLike` type classes

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -7,6 +7,7 @@ import ArkLib.CommitmentScheme.SimpleRO
 import ArkLib.CommitmentScheme.Tensor
 import ArkLib.CommitmentScheme.Trivial
 import ArkLib.Data.Classes.DCast
+import ArkLib.Data.Classes.FunEquiv
 import ArkLib.Data.Classes.HasSize
 import ArkLib.Data.Classes.Initialize
 import ArkLib.Data.Classes.Serde
@@ -61,6 +62,7 @@ import ArkLib.Data.MvPolynomial.Degrees
 import ArkLib.Data.MvPolynomial.Interpolation
 import ArkLib.Data.MvPolynomial.LinearMvExtension
 import ArkLib.Data.MvPolynomial.Multilinear
+import ArkLib.Data.MvPolynomial.MvPolynomialLike
 import ArkLib.Data.MvPolynomial.Notation
 import ArkLib.Data.MvPolynomial.Sumcheck
 import ArkLib.Data.Polynomial.Bivariate

--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -66,6 +66,7 @@ import ArkLib.Data.MvPolynomial.Sumcheck
 import ArkLib.Data.Polynomial.Bivariate
 import ArkLib.Data.Polynomial.EvenAndOdd
 import ArkLib.Data.Polynomial.Interface
+import ArkLib.Data.Polynomial.PolynomialLike
 import ArkLib.Data.Probability.Instances
 import ArkLib.Data.Probability.Notation
 import ArkLib.Data.Tree.Binary

--- a/ArkLib/Data/Classes/FunEquiv.lean
+++ b/ArkLib/Data/Classes/FunEquiv.lean
@@ -29,7 +29,16 @@ This is stronger than `FunLike` since we get an equivalence and not just an inje
 function type. -/
 abbrev FunEquiv F α β := DFunEquiv F α fun _ => β
 
-instance {F : Sort*} {α : Sort*} {β : α → Sort*} [DFunEquiv F α β] : DFunLike F α β where
+namespace DFunEquiv
+
+variable {F : Sort*} {α : Sort*} {β : α → Sort*} [inst : DFunEquiv F α β]
+
+/-- Default instance: `∀ a : α, β a` itself satisfies `DFunEquiv`. -/
+instance : DFunEquiv (∀ a : α, β a) α β where
+  equiv := Equiv.refl _
+
+/-- The forward direction of the equivalence is a `DFunLike`. -/
+instance : DFunLike F α β where
   coe := DFunEquiv.equiv.toFun
   coe_injective' := DFunEquiv.equiv.injective
 
@@ -37,9 +46,25 @@ instance {F : Sort*} {α : Sort*} {β : α → Sort*} [DFunEquiv F α β] : DFun
 `DFunEquiv` instance.
 
 TODO: is `Coe` the right thing to use here? What about other variants of coercion? -/
-instance {F : Sort*} {α : Sort*} {β : α → Sort*} [DFunEquiv F α β] : Coe (∀ a : α, β a) F where
+instance : Coe (∀ a : α, β a) F where
   coe := DFunEquiv.equiv.invFun
 
--- @[simp]
--- lemma coe_equiv {F : Sort*} {α : Sort*} {β : α → Sort*} [DFunEquiv F α β] (f : F) (a : α) :
---   DFunEquiv.equiv.toFun f a = f a := rfl
+@[simp]
+lemma toFun_invFun (f : ∀ a, β a) : inst.equiv.toFun (equiv.invFun f : F) = f :=
+  inst.equiv.right_inv _
+
+@[simp]
+lemma invFun_toFun (f : F) : inst.equiv.invFun (inst.equiv.toFun f) = f :=
+  inst.equiv.left_inv _
+
+@[simp]
+lemma coe_toFun_of_coe_apply (f : ∀ a, β a) (a : α) : (f : F) a = f a := by
+  simp [instDFunLike]
+
+@[simp]
+lemma coe_fn_of_coe (f : ∀ a, β a) : (f : F) = inst.equiv.invFun f := rfl
+
+@[simp]
+lemma coe_of_coe_fn (f : F) : (f : ∀ a, β a) = inst.equiv.toFun f := rfl
+
+end DFunEquiv

--- a/ArkLib/Data/Classes/FunEquiv.lean
+++ b/ArkLib/Data/Classes/FunEquiv.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.Logic.Equiv.Defs
+
+/-!
+# FunEquiv
+
+This file defines the `(D)FunEquiv` type class, which expresses that a given type `F` has an
+equivalence to a dependent function type.
+
+This is stronger than `(D)FunLike` since we get an equivalence and not just an injection into the
+dependent function type.
+-/
+
+/-- Type class to express that a given type `F` has an equivalence to a dependent function type.
+
+This is stronger than `DFunLike` since we get an equivalence and not just an injection into the
+dependent function type. -/
+class DFunEquiv (F : Sort*) (α : outParam (Sort*)) (β : outParam <| α → Sort*) where
+  equiv : F ≃ ∀ a : α, β a
+
+/-- Type class to express that a given type `F` has an equivalence to a function type.
+
+This is stronger than `FunLike` since we get an equivalence and not just an injection into the
+function type. -/
+abbrev FunEquiv F α β := DFunEquiv F α fun _ => β
+
+instance {F : Sort*} {α : Sort*} {β : α → Sort*} [DFunEquiv F α β] : DFunLike F α β where
+  coe := DFunEquiv.equiv.toFun
+  coe_injective' := DFunEquiv.equiv.injective
+
+/-- Coercion from the dependent function type `∀ a : α, β a` to another type `F` that has a
+`DFunEquiv` instance.
+
+TODO: is `Coe` the right thing to use here? What about other variants of coercion? -/
+instance {F : Sort*} {α : Sort*} {β : α → Sort*} [DFunEquiv F α β] : Coe (∀ a : α, β a) F where
+  coe := DFunEquiv.equiv.invFun
+
+-- @[simp]
+-- lemma coe_equiv {F : Sort*} {α : Sort*} {β : α → Sort*} [DFunEquiv F α β] (f : F) (a : α) :
+--   DFunEquiv.equiv.toFun f a = f a := rfl

--- a/ArkLib/Data/MvPolynomial/MvPolynomialLike.lean
+++ b/ArkLib/Data/MvPolynomial/MvPolynomialLike.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.Algebra.Polynomial.AlgebraMap
+import Mathlib.RingTheory.Polynomial.DegreeLT
+import Mathlib.RingTheory.MvPolynomial.Basic
+import ArkLib.Data.Classes.FunEquiv
+
+/-!
+# Experimental API for `MvPolynomial`-like objects
+
+This file defines the `MvPolynomialLike` type class, which aims to give a universal property
+characterization of multivariate polynomials.
+
+This is similar to `PolynomialLike`, but for multivariate polynomials.
+
+-/
+
+universe u v w y z
+
+/--
+A typeclass for multivariate polynomial-like structures, being defined by the universal property of
+multivariate polynomial rings:
+
+`R[Xₛ | s : σ]` is the unique `R`-algebra such that, for every algebra `A` containing `R`, and every
+element `a : A`, there is a unique algebra homomorphism from `R[Xₛ | s : σ]` to `A` that fixes `R`,
+and maps `Xₛ` to `aₛ` for all `s : σ`.
+
+(we define this in terms of uniqueness of `eval₂`, and with respect to a `FunLike` type class for
+functions representing the type of functions `σ → S`. Note that we do not always want the exact type
+`σ → S`, we may want `Vector S n` when `σ = Fin n`, for instance.)
+
+We can show that any `P` satisfying the `MvPolynomialLike` typeclass is isomorphic to
+`R[Xₛ | s : σ]` as an `R`-algebra, and hence inherit all relevant properties of `R[Xₛ | s : σ]`.
+
+TODO: make sure this universal property is actually correct!
+-/
+class MvPolynomialLike (σ : outParam (Type u)) (R : outParam (Type v)) [CommSemiring R]
+    (P : Type w) [CommSemiring P] extends Algebra R P where
+  /-- The indeterminates `X : σ → P` of the multivariate polynomial ring. -/
+  X : σ → P
+
+  /-- The ring homomorphism from `P` to a commutative semiring `S` obtained by evaluating the
+  pushforward of `p` along `f` at `x`. -/
+  eval₂ {S : Type y} [CommSemiring S] {F : Type z} [FunEquiv F σ S] (f : R →+* S) (g : F) : P →+* S
+
+  /-- `eval₂` on the constant injection `C` is equal to applying `f` -/
+  eval₂_C {S : Type y} [CommSemiring S] {F : Type z} [FunEquiv F σ S]
+    (f : R →+* S) (g : F) (r : R) : (eval₂ f g) (_root_.algebraMap R P r) = f r
+
+  /-- `eval₂` on the indeterminates `X` is equal to applying `g` -/
+  eval₂_X {S : Type y} [CommSemiring S] {F : Type z} [FunEquiv F σ S]
+    (f : R →+* S) (g : F) (s : σ) : (eval₂ f g) (X s) = g s
+
+  /-- Every ring homomorphism `h : P →+* S` is equal to `eval₂` of the corresponding functions. -/
+  eval₂_eq {S : Type y} [CommSemiring S] {F : Type z} [FunEquiv F σ S] (h : P →+* S) :
+    h = eval₂ (h.comp (Algebra.ofId R P)) (fun s => h (X s) : F)
+
+namespace MvPolynomialLike
+
+variable {σ : Type u} {R : Type v} [CommSemiring R] {P : Type w} [CommSemiring P]
+  [MvPolynomialLike σ R P]
+
+@[simp]
+lemma eval₂_C' {S : Type y} [CommSemiring S] {F : Type z} [FunEquiv F σ S]
+    (f : R →+* S) (g : F) (r : R) : eval₂ f g (_root_.algebraMap R P r) = f r := by
+  simp [eval₂_C]
+
+end MvPolynomialLike
+
+noncomputable section
+
+namespace MvPolynomial
+
+variable {σ : Type u} {R : Type v} [CommSemiring R]
+
+instance : MvPolynomialLike σ R (MvPolynomial σ R) where
+  X := MvPolynomial.X
+  eval₂ := fun f g => MvPolynomial.eval₂Hom f g
+  eval₂_C := fun f g r => by simp
+  eval₂_X f g s := by simp
+  eval₂_eq h := by simp; sorry
+
+end MvPolynomial
+
+end

--- a/ArkLib/Data/MvPolynomial/MvPolynomialLike.lean
+++ b/ArkLib/Data/MvPolynomial/MvPolynomialLike.lean
@@ -66,8 +66,84 @@ variable {σ : Type u} {R : Type v} [CommSemiring R] {P : Type w} [CommSemiring 
 
 @[simp]
 lemma eval₂_C' {S : Type y} [CommSemiring S] {F : Type z} [FunEquiv F σ S]
-    (f : R →+* S) (g : F) (r : R) : eval₂ f g (_root_.algebraMap R P r) = f r := by
-  simp [eval₂_C]
+    (f : R →+* S) (g : F) (r : R) : eval₂ f g (_root_.algebraMap R P r) = f r :=
+  eval₂_C f g r
+
+lemma eval₂_eq' {S : Type y} [CommSemiring S] {F : Type z} [FunEquiv F σ S] (h : P →+* S) (p : P) :
+    h p = eval₂ (h.comp (Algebra.ofId R P)) (fun s => h (X s) : F) p := by
+  nth_rw 1 [eval₂_eq h (F := F)]
+
+/-- The injection of the underlying ring `R` into a `MvPolynomialLike` type `P`. -/
+@[reducible]
+def C : R →+* P := algebraMap R P
+
+/-- `eval₂` as an `AlgHom`. -/
+def eval₂AlgHom {A B : Type*} [CommSemiring A] [CommSemiring B] [MvPolynomialLike σ A P]
+    [Algebra R A] [IsScalarTower R A P] [Algebra R B]
+    (f : A →ₐ[R] B) (g : σ → B) : P →ₐ[R] B where
+  toRingHom := eval₂ f g
+  commutes' r := by
+    simp only [RingHom.toMonoidHom_eq_coe, OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe,
+      MonoidHom.coe_coe]
+    rw [IsScalarTower.algebraMap_apply R A P]
+    simp
+
+@[simp]
+lemma eval₂AlgHom_apply {A B : Type*} [CommSemiring A] [CommSemiring B] [MvPolynomialLike σ A P]
+    [Algebra R A] [IsScalarTower R A P] [Algebra R B]
+    (f : A →ₐ[R] B) (g : σ → B) (p : P) :
+    (eval₂AlgHom f g) p = eval₂ f g p := rfl
+
+/-- The (algebra) evaluation map, which is the (unique) `R`-algebra homomorphism from `P` to
+any `R`-algebra `A` that sends `X` to a specified element `s : A`. -/
+def aeval {A : Type y} [CommSemiring A] [Algebra R A] {F : Type z} [FunEquiv F σ A] (g : F) :
+    P →ₐ[R] A :=
+  eval₂AlgHom (Algebra.ofId R A) g
+
+@[simp]
+lemma aeval_X {A : Type y} [CommSemiring A] [Algebra R A] {F : Type z} [FunEquiv F σ A] (g : F)
+    (s : σ) : aeval g (X s : P) = g s := by
+  simp [aeval, eval₂AlgHom, Algebra.ofId]
+  change _ = (g : σ → A) s
+  exact eval₂_X _ _ _
+
+lemma aeval_eq' {A : Type y} [CommSemiring A] [Algebra R A] {F : Type z} [FunEquiv F σ A]
+    (f : P →ₐ[R] A) (p : P) : f p = aeval (fun s => f (X s) : F) p := by
+  simp [aeval, eval₂AlgHom, Algebra.ofId]
+  sorry
+  -- exact eval₂_eq' _ _
+
+/-- Uniqueness: Any `R`-algebra homomorphism `f` from `P` to an `R`-algebra `A` is equal to the
+evaluation map at the value of `f X`. -/
+lemma aeval_eq {A : Type y} [CommSemiring A] [Algebra R A] (f : P →ₐ[R] A) :
+    f = aeval (fun s => f (X s)) :=
+  AlgHom.ext (aeval_eq' f)
+
+/-- The unique `R`-algebra homomorphism from a `MvPolynomialLike` type `P` to `MvPolynomial σ R`. -/
+noncomputable def toMvPolynomialAlgHom : P →ₐ[R] MvPolynomial σ R := aeval MvPolynomial.X
+
+/-- The unique `R`-algebra homomorphism from `MvPolynomial σ R` to a `MvPolynomialLike` type `P`. -/
+noncomputable def ofMvPolynomialAlgHom : MvPolynomial σ R →ₐ[R] P := MvPolynomial.aeval X
+
+@[simp] lemma toMvPolynomialAlgHom_X (s : σ) :
+    toMvPolynomialAlgHom (X s : P) = (MvPolynomial.X s : MvPolynomial σ R) := by
+  simp [toMvPolynomialAlgHom, aeval_X, DFunEquiv.instForall]
+
+@[simp] lemma ofMvPolynomialAlgHom_X (s : σ) :
+    ofMvPolynomialAlgHom (MvPolynomial.X s : MvPolynomial σ R) = (X s : P) := by
+  simp [ofMvPolynomialAlgHom, MvPolynomial.aeval_X]
+
+noncomputable def toMvPolynomialAlgEquiv : P ≃ₐ[R] MvPolynomial σ R where
+  toFun := toMvPolynomialAlgHom
+  invFun := ofMvPolynomialAlgHom
+  left_inv p := by
+    sorry
+  right_inv p := by
+    simp [toMvPolynomialAlgHom, ofMvPolynomialAlgHom, aeval, Algebra.ofId, DFunEquiv.instForall]
+    sorry
+  map_mul' := by simp
+  map_add' := by simp
+  commutes' := by simp
 
 end MvPolynomialLike
 
@@ -79,10 +155,13 @@ variable {σ : Type u} {R : Type v} [CommSemiring R]
 
 instance : MvPolynomialLike σ R (MvPolynomial σ R) where
   X := MvPolynomial.X
-  eval₂ := fun f g => MvPolynomial.eval₂Hom f g
+  eval₂ := fun f g => eval₂Hom f g
   eval₂_C := fun f g r => by simp
   eval₂_X f g s := by simp
-  eval₂_eq h := by simp; sorry
+  eval₂_eq h := by
+    simp only [eval₂Hom, Algebra.ofId, algebraMap_eq, AlgHom.coe_ringHom_mk, Equiv.invFun_as_coe,
+      DFunEquiv.coe_of_coe_fn, Equiv.toFun_as_coe, Equiv.apply_symm_apply]
+    ext i <;> simp
 
 end MvPolynomial
 

--- a/ArkLib/Data/Polynomial/PolynomialLike.lean
+++ b/ArkLib/Data/Polynomial/PolynomialLike.lean
@@ -55,24 +55,25 @@ class PolynomialLike (R : outParam (Type u)) [CommSemiring R] (P : Type v) [Comm
     g = eval₂ (g.comp (Algebra.ofId R P)) (g X)
 
 /--
-An extension of `PolynomialLike` that includes an explicit notion of coefficients.
+A custom coefficient function for a `PolynomialLike` type.
 
-This is technically not needed, but is useful for concrete computations. There is always the default
-definition of first applying the equivalence to `Polynomial R`, and then getting the coefficients of
-that representation.
+We always have a default implementation of `coeff` via first (uniquely) mapping to `Polynomial`,
+then using `Polynomial.coeffs`, but this is noncomputable, and we often want to define computable
+versions of `coeff` for specific `PolynomialLike` types.
 -/
-class PolynomialLike.WithCoeffs (R : outParam (Type u)) [CommSemiring R]
-    (P : Type v) [CommSemiring P] extends PolynomialLike R P where
-  /-- The `n`-th coefficient of a polynomial. -/
-  coeff (p : P) (n : ℕ) : R
-  /-- A finite set of indices of non-zero coefficients. -/
-  support (p : P) : Finset ℕ
-  /-- The `support` of a polynomial is the set of indices of its non-zero coefficients. -/
-  mem_support_iff (p : P) (n : ℕ) : n ∈ support p ↔ coeff p n ≠ 0
-  /-- The evaluation of a polynomial is given by the sum of its coefficients.
-  This is the crucial axiom that connects the coefficient view with the universal property. -/
-  eval₂_eq_sum {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) (p : P) :
-    eval₂ f x p = ∑ n ∈ support p, f (coeff p n) * x ^ n
+class PolynomialLike.LawfulCoeff (R : Type u) [CommSemiring R] (P : Type v) [CommSemiring P]
+    [PolynomialLike R P] (coeff : P → ℕ → R) where
+  coeff_finite (p : P) : Set.Finite {n | coeff p n ≠ 0}
+  -- more conditions here
+
+  -- /-- A finite set of indices of non-zero coefficients. -/
+  -- support (p : P) : Finset ℕ
+  -- /-- The `support` of a polynomial is the set of indices of its non-zero coefficients. -/
+  -- mem_support_iff (p : P) (n : ℕ) : n ∈ support p ↔ coeff p n ≠ 0
+  -- /-- The evaluation of a polynomial is given by the sum of its coefficients.
+  -- This is the crucial axiom that connects the coefficient view with the universal property. -/
+  -- eval₂_eq_sum {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) (p : P) :
+  --   eval₂ f x p = ∑ n ∈ support p, f (coeff p n) * x ^ n
 
 attribute [simp] PolynomialLike.eval₂_C PolynomialLike.eval₂_X
 
@@ -212,6 +213,7 @@ lemma ofPolynomialAlgHom_toPolynomialAlgHom_C {r : R} :
   simp [ofPolynomialAlgHom, toPolynomialAlgHom, aeval, Polynomial.aeval, Algebra.ofId,
     eval₂AlgHom, instPolynomialLike]
 
+@[simp]
 lemma ofPolynomialAlgHom_toPolynomialAlgHom_X :
     ofPolynomialAlgHom (toPolynomialAlgHom (X : P)) = (Polynomial.X : R[X]) := by
   simp [ofPolynomialAlgHom, toPolynomialAlgHom, aeval, Polynomial.aeval, Algebra.ofId,
@@ -240,5 +242,10 @@ noncomputable def polynomialAlgEquiv : P ≃ₐ[R] R[X] where
   map_mul' _ _ := by simp
   map_add' _ _ := by simp
   commutes' _ := by simp
+
+-- TODO: show that this is the _unique_ such `R`-algebra isomorphism `P ≃ₐ[R] R[X]`
+
+lemma polynomialAlgEquiv_unique (f : P ≃ₐ[R] R[X]) : f = polynomialAlgEquiv := by
+  sorry
 
 end PolynomialLike

--- a/ArkLib/Data/Polynomial/PolynomialLike.lean
+++ b/ArkLib/Data/Polynomial/PolynomialLike.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.Algebra.Polynomial.AlgebraMap
+import Mathlib.RingTheory.Polynomial.DegreeLT
+
+/-!
+  # Polynomial-like structures
+
+  This file defines a generic type class for polynomial-like structures. The goal is to provide a
+  generic interface for polynomials, which should be isomorphic to Mathlib's `Polynomial`, but also
+  admit other representations that are computation friendly.
+-/
+
+universe u v w
+
+/--
+A typeclass for polynomial-like structures, being defined by the universal property of polynomial
+rings:
+
+`R[X]` is the unique `R`-algebra such that, for every algebra `A` containing `R`, and every element
+`a : A`, there is a unique algebra homomorphism from `R[X]` to `A` that fixes `R`, and maps `X` to
+`a`.
+
+We can show that any `P` satisfying the `PolynomialLike` typeclass is isomorphic to `R[X]` as an
+`R`-algebra, and hence inherit all relevant properties of `R[X]`.
+
+TODO: make sure this universal property is actually correct!
+
+This is slightly less general than `Polynomial` in mathlib, where `R` and `S` are only required to
+be a `Semiring` instead of a `CommSemiring`. We need the stronger requirement on `R` and `S` to
+ensure the instance `Algebra R P`, and that `eval₂` is a ring homomorphism.
+-/
+class PolynomialLike (R : outParam (Type u)) [CommSemiring R] (P : Type v) [Semiring P]
+    extends Algebra R P where
+
+  /-- The indeterminate `X` of the polynomial ring. -/
+  X {R} : P
+
+  /-- The ring homomorphism from `P` to a commutative semiring `S` obtained by evaluating the
+  pushforward of `p` along `f` at `x`. -/
+  eval₂ {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) : P →+* S
+
+  eval₂_C {r : R} {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) :
+    (eval₂ f x) (algebraMap r) = f r
+
+  eval₂_X {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) : eval₂ f x X = x
+
+  eval₂_eq {S : Type w} [CommSemiring S] (f : R →+* S) (g : P →+* S) : g = eval₂ f (g X)
+
+attribute [simp] PolynomialLike.eval₂_C PolynomialLike.eval₂_X PolynomialLike.eval₂_eq
+
+namespace PolynomialLike
+
+variable {R : Type u} [CommSemiring R] {P : Type v} [Semiring P] [PolynomialLike R P]
+
+/-- The constant ring homomorphism from `R` to `P`, obtained from the `Algebra` instance. -/
+@[reducible]
+def C : R →+* P := algebraMap R P
+
+@[simp]
+lemma eval₂_comp_C {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) :
+    (eval₂ f x).comp (C : R →+* P) = f := by
+  ext; exact eval₂_C _ _
+
+@[simp]
+lemma eval₂_eq' {S : Type w} [CommSemiring S] (f : R →+* S) (g : P →+* S) (p : P) :
+    g p = eval₂ f (g X) p := by
+  rw [eval₂_eq f g]
+  simp
+
+/-- `eval₂` as an `AlgHom`. -/
+def eval₂AlgHom {A : Type w} {B : Type*} [CommSemiring A] [CommSemiring B]
+    [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) (b : B) : P →ₐ[R] B where
+  toFun := eval₂ (f.comp (Algebra.ofId R A)) b
+  map_one' := by simp
+  map_mul' := by simp
+  map_zero' := by simp
+  map_add' := by simp
+  commutes' := by intro r; simp; exact eval₂_C _ _
+
+@[simp]
+lemma eval₂AlgHom_apply {A : Type w} {B : Type*} [CommSemiring A] [CommSemiring B]
+    [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) (b : B) (p : P) :
+    (eval₂AlgHom f b) p = eval₂ (f.comp (Algebra.ofId R A)) b p := by
+  simp [eval₂AlgHom]
+
+/-- The (algebra) evaluation map, which is the (unique) `R`-algebra homomorphism from `P` to
+any `R`-algebra `A` that sends `X` to a specified element `s : A`. -/
+def aeval {A : Type w} [CommSemiring A] [Algebra R A] (s : A) : P →ₐ[R] A :=
+  eval₂AlgHom (Algebra.ofId R A) s
+
+lemma aeval_apply {A : Type w} [CommSemiring A] [Algebra R A] (s : A) :
+    aeval (P := P) s = eval₂AlgHom (Algebra.ofId R A) s := rfl
+
+@[simp]
+lemma aeval_C {A : Type w} [CommSemiring A] [Algebra R A] (x : A) (r : R) :
+    (aeval x) (C r : P) = algebraMap R A r := by
+  simp [C]
+
+/-- The evaluation of `X` at `s` is `s`. -/
+@[simp]
+lemma aeval_X {A : Type w} [CommSemiring A] [Algebra R A] (s : A) : aeval s X (P := P) = s := by
+  simp [aeval]
+
+/-- Uniqueness: Any `R`-algebra homomorphism `f` from `P` to an `R`-algebra `A` is equal to the
+evaluation map at the value of `f X`. -/
+@[simp]
+lemma aeval_eq {A : Type w} [CommSemiring A] [Algebra R A] (f : P →ₐ[R] A) : f = aeval (f X) := by
+  simp only [aeval, eval₂AlgHom, Algebra.comp_ofId, RingHom.mk_coe]
+  ext p
+  exact eval₂_eq' _ _ _
+
+end PolynomialLike
+
+namespace Polynomial
+
+noncomputable instance {R : Type u} [CommSemiring R] : PolynomialLike R R[X] where
+  X := Polynomial.X
+  eval₂ := Polynomial.eval₂RingHom
+  eval₂_C := Polynomial.eval₂_C
+  eval₂_X := Polynomial.eval₂_X
+  eval₂_eq f := sorry
+
+end Polynomial
+
+namespace PolynomialLike
+
+open Polynomial
+
+variable {R : Type u} [CommSemiring R] {P : Type w} [Semiring P] [PolynomialLike R P]
+
+/-- The unique `R`-algebra homomorphism from a `PolynomialLike` type `P` to `R[X]`. -/
+noncomputable def toPolynomialAlgHom : P →ₐ[R] R[X] := PolynomialLike.aeval Polynomial.X
+
+/-- The unique `R`-algebra homomorphism from `R[X]` to a `PolynomialLike` type `P`. -/
+noncomputable def ofPolynomialAlgHom : R[X] →ₐ[R] P := Polynomial.aeval PolynomialLike.X
+
+/--
+A `PolynomialLike` type `P` is isomorphic to `R[X]` as an `R`-algebra.
+This is the fundamental property ensured by the `PolynomialLike` typeclass.
+-/
+noncomputable def polynomialAlgEquiv : P ≃ₐ[R] R[X] where
+  toFun := toPolynomialAlgHom
+  invFun := ofPolynomialAlgHom
+  left_inv := by
+    intro p
+    -- let f := ofPolynomialAlgHom.comp toPolynomialAlgHom
+    -- let g := AlgHom.id R P
+    sorry
+    -- apply DFunLike.congr_fun (PolynomialLike.hom_ext (f := f) (g := g) (by simp [toPolynomialAlgHom, ofPolynomialAlgHom, PolynomialLike.aeval_X]))
+  right_inv := by
+    intro p;
+    -- let f := toPolynomialAlgHom.comp ofPolynomialAlgHom
+    -- let g := AlgHom.id R R[X]
+    -- apply DFunLike.congr_fun (Polynomial.algHom_ext (f := f) (g := g) (by simp [toPolynomialAlgHom, ofPolynomialAlgHom, PolynomialLike.aeval_X, aeval_X]))
+    sorry
+  map_mul' := sorry
+  map_add' := sorry
+  commutes' := sorry
+
+end PolynomialLike

--- a/ArkLib/Data/Polynomial/PolynomialLike.lean
+++ b/ArkLib/Data/Polynomial/PolynomialLike.lean
@@ -54,13 +54,25 @@ class PolynomialLike (R : outParam (Type u)) [CommSemiring R] (P : Type v) [Comm
   eval₂_eq {S : Type w} [CommSemiring S] (g : P →+* S) :
     g = eval₂ (g.comp (Algebra.ofId R P)) (g X)
 
+/--
+An extension of `PolynomialLike` that includes an explicit notion of coefficients.
+
+This is technically not needed, but is useful for concrete computations. There is always the default
+definition of first applying the equivalence to `Polynomial R`, and then getting the coefficients of
+that representation.
+-/
 class PolynomialLike.WithCoeffs (R : outParam (Type u)) [CommSemiring R]
     (P : Type v) [CommSemiring P] extends PolynomialLike R P where
-  coeff : P → ℕ → P
-  coeff_finite (p : P) : Set.Finite {n | coeff p n ≠ 0}
-  coeff_ext {p q : P} (h : ∀ n, coeff p n = coeff q n) : p = q
-  -- coeff_eval₂ {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) (p : P) (n : ℕ) :
-  --   eval₂ f x p = ∑ n ∈ {n | coeff p n ≠ 0}, coeff p n * x ^ n
+  /-- The `n`-th coefficient of a polynomial. -/
+  coeff (p : P) (n : ℕ) : R
+  /-- A finite set of indices of non-zero coefficients. -/
+  support (p : P) : Finset ℕ
+  /-- The `support` of a polynomial is the set of indices of its non-zero coefficients. -/
+  mem_support_iff (p : P) (n : ℕ) : n ∈ support p ↔ coeff p n ≠ 0
+  /-- The evaluation of a polynomial is given by the sum of its coefficients.
+  This is the crucial axiom that connects the coefficient view with the universal property. -/
+  eval₂_eq_sum {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) (p : P) :
+    eval₂ f x p = ∑ n ∈ support p, f (coeff p n) * x ^ n
 
 attribute [simp] PolynomialLike.eval₂_C PolynomialLike.eval₂_X
 

--- a/ArkLib/Data/Polynomial/PolynomialLike.lean
+++ b/ArkLib/Data/Polynomial/PolynomialLike.lean
@@ -54,6 +54,14 @@ class PolynomialLike (R : outParam (Type u)) [CommSemiring R] (P : Type v) [Comm
   eval₂_eq {S : Type w} [CommSemiring S] (g : P →+* S) :
     g = eval₂ (g.comp (Algebra.ofId R P)) (g X)
 
+class PolynomialLike.WithCoeffs (R : outParam (Type u)) [CommSemiring R]
+    (P : Type v) [CommSemiring P] extends PolynomialLike R P where
+  coeff : P → ℕ → P
+  coeff_finite (p : P) : Set.Finite {n | coeff p n ≠ 0}
+  coeff_ext {p q : P} (h : ∀ n, coeff p n = coeff q n) : p = q
+  -- coeff_eval₂ {S : Type w} [CommSemiring S] (f : R →+* S) (x : S) (p : P) (n : ℕ) :
+  --   eval₂ f x p = ∑ n ∈ {n | coeff p n ≠ 0}, coeff p n * x ^ n
+
 attribute [simp] PolynomialLike.eval₂_C PolynomialLike.eval₂_X
 
 namespace PolynomialLike


### PR DESCRIPTION
This PR attempts to fix the problem of noncomputable polynomials by defining new type classes that only rely on the universal property of polynomials. The hope is that properties of polynomials, as proven in Mathlib for the specific `(Mv)Polynomial` types, would generically transfer to any instance of these new `(Mv)PolynomialLike` type classes.

If successful, this means that we can write all our polynomial IOPs abstractly over any instance of `(Mv)PolynomialLike`, and get both security (results transferred from mathlib) and computability (our own `UniPoly` / `MlPoly` / etc. types). This is better than writing **two separate implementation**, one using `(Mv)Polynomial`, one using `(Uni/Ml/etc.)Poly`, and then proving that the security of the abstract version transfers to the concrete version.

To define these type classes, it suffices to posit the existence of an `eval₂` function (for both univariate and multivariate case) with compatibility & uniqueness conditions. This would ensure that any instance of this type class admits a (unique) `R`-algebra isomorphism to `Polynomial R` or `MvPolynomial σ R`.

However, all is not as easy as it seems. For instance, even though `eval₂` and its properties uniquely defines the type up to `R`-algebra isomorphism, an arbitrary instance of `(Mv)PolynomialLike` does not come with obvious notions of coefficients and degree. We always have an escape hatch of first mapping back to `(Mv)Polynomial`, then use the coeff/degree functions there, but in many cases we may want custom functions for computability / efficiency.

TODO: define similar type classes for (multivariate) polynomials with _restricted_ degrees