### PR TITLE
`UniPoly` equivalence relation and quotient operations

### DIFF
--- a/ArkLib/Data/UniPoly/Basic.lean
+++ b/ArkLib/Data/UniPoly/Basic.lean
@@ -897,7 +897,6 @@ open Trim
   intro h i
   exact Eq.symm (h i)
 
-open List in
 /-- Transitivity of the equivalence relation. -/
 @[simp] theorem equiv_trans {p q r : UniPoly Q} : Trim.equiv p q → equiv q r → equiv p r := by
   simp_all [Trim.equiv]


### PR DESCRIPTION
## Summary 
This PR:
- [x] proves the equivalence relation defined on `UniPoly` is transitive, using an (assumed) lemma analogous to the (also unproved) lemma used in the List case
- [x] defines functions `add`, `neg`, and `sub` on the resulting quotient and proves that the equivalent operations on `UniPoly` descend

From here, the main TODO would be to show that the remaining operations on `UniPoly` descend to the quotient.

## Related Issue
Related to #7 