### PR TITLE
feat(SendClaim): prove perfect completeness

### DIFF
--- a/ArkLib/ProofSystem/Component/SendClaim.lean
+++ b/ArkLib/ProofSystem/Component/SendClaim.lean
@@ -133,7 +133,9 @@ theorem completeness [Nonempty σ] :
     init impl relIn (relOut OStatement) := by
   simp only [OracleReduction.perfectCompleteness, oracleReduction, relOut]
   simp only [Reduction.perfectCompleteness_eq_prob_one]
-  intro ⟨stmt, oStmt⟩ wit hIn
+  -- `relIn` membership is unused: SendClaim is a deterministic forwarding component
+  -- whose computation succeeds unconditionally, independent of the input relation.
+  intro ⟨stmt, oStmt⟩ wit _
   -- 1. Unfold (run_of_prover_first absorbs Verifier.run for P_to_V)
   simp only [OracleReduction.toReduction, Reduction.run_of_prover_first,
     oracleProver, oracleVerifier, OracleVerifier.toVerifier]

--- a/ArkLib/ProofSystem/Component/SendClaim.lean
+++ b/ArkLib/ProofSystem/Component/SendClaim.lean
@@ -107,9 +107,149 @@ it also holds in the ideal setting, etc.
 instance : ProverOnly (pSpec OStatement) where
   prover_first' := by simp
 
+/-- Bridge lemma: `none` is never in the support of a computation that maps through `some`.
+This is the key missing piece for SendClaim completeness: every layer of `liftM`/`simulateQ`
+preserves the `some <$> _` structure, so `none` can never appear in the output support.
+TODO: upstream to VCVio as a general `support_simulateQ` or `none_not_mem_support_map_some`. -/
+private lemma none_not_mem_support_map_some {m : Type _ → Type _}
+    [Monad m] [LawfulMonad m] [HasEvalSet m]
+    {α : Type _} (mx : m α) :
+    none ∉ support (Option.some <$> mx : m (Option α)) := by
+  rw [support_map]; rintro ⟨_, _, ⟨⟩⟩
+
+
+set_option synthInstance.maxHeartbeats 800000 in
+set_option maxHeartbeats 1600000 in
+set_option maxRecDepth 2000 in
 theorem completeness [Nonempty σ] :
     (oracleReduction oSpec Statement OStatement relComp).perfectCompleteness
     init impl relIn (relOut OStatement) := by
-  sorry
+  simp only [OracleReduction.perfectCompleteness, oracleReduction, relOut]
+  simp only [Reduction.perfectCompleteness_eq_prob_one]
+  intro ⟨stmt, oStmt⟩ wit hIn
+  -- 1. Unfold (run_of_prover_first absorbs Verifier.run for P_to_V)
+  simp only [OracleReduction.toReduction, Reduction.run_of_prover_first,
+    oracleProver, oracleVerifier, OracleVerifier.toVerifier]
+  -- 2. Bridge OptionT.pure → OracleComp.pure (some x) so simulateQ_pure fires
+  simp_rw [show (pure : _ → OptionT (OracleComp _) _) = fun x => (pure (some x) :
+    OracleComp _ _) from rfl]
+  -- 3. Peel prover binds (all pure — erw matches through definitional eq)
+  erw [simulateQ_bind]; erw [simulateQ_pure]; simp only [pure_bind]
+  erw [simulateQ_bind]; erw [simulateQ_pure]; simp only [pure_bind]
+  -- 4. Peel verifier bind
+  erw [simulateQ_bind]
+  -- 5. Probability decomposition via probEvent_eq_one_iff
+  rw [probEvent_eq_one_iff]
+  simp only [OptionT.probFailure_eq, probOutput_eq_zero_iff, OptionT.mem_support_iff,
+    OptionT.run_mk]
+  simp only [support_bind, Set.mem_iUnion, support_pure, Set.mem_singleton_iff,
+    support_map, Set.mem_image]
+  exact ⟨by {
+    simp only [HasEvalPMF.probFailure_eq_zero, zero_add, probOutput_eq_zero_iff]
+    intro h
+    rw [mem_support_bind_iff] at h
+    obtain ⟨s, -, hs⟩ := h
+    simp only [StateT.run'_eq, support_map, Set.mem_image] at hs
+    obtain ⟨⟨_, s'⟩, hs, rfl⟩ := hs
+    simp only [StateT.run_bind] at hs
+    rw [mem_support_bind_iff] at hs
+    obtain ⟨⟨x, s''⟩, hx, hs⟩ := hs
+    -- Unfold SubSpec liftM + OptionT in hx
+    simp only [MonadLift.monadLift, liftM, monadLift, MonadLiftT.monadLift,
+      OptionT.run_mk, OptionT.run_bind, OptionT.run_lift] at hx
+    -- simulateQ_map rewrites simulateQ impl (some <$> _) → some <$> simulateQ impl _
+    erw [simulateQ_map] at hx
+    -- Peel outer simulateQ layer (OptionT.mk is definitionally transparent)
+    erw [simulateQ_map] at hx
+    -- Bridge: StateT.run_map converts (some <$> m : StateT).run s to map at ProbComp level
+    rw [StateT.run_map] at hx
+    simp only [support_map, Set.mem_image] at hx
+    obtain ⟨⟨val, s₀⟩, hval, heq⟩ := hx
+    obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq
+    -- x = some val, s'' = s₀; hs depends on val : Option (...)
+    dsimp only [] at hs
+    -- Case split on val
+    rcases val with _ | ⟨a⟩
+    · -- val = none: hval has (none, s₀) ∈ support of comp that always returns some
+      exfalso
+      -- Convert innermost pure bind to map, peel through inner simulateQ layers
+      simp only [bind_pure_comp] at hval
+      erw [simulateQ_map] at hval
+      erw [simulateQ_map] at hval
+      erw [simulateQ_map] at hval
+      -- Eliminate Option.elimM, unfold OptionT.run, push simulateQ through bind
+      erw [Option.elimM_map] at hval
+      simp only [Option.elim_some] at hval
+      dsimp only [OptionT.run] at hval
+      -- Use bind_pure_comp to convert bind to map, then simulateQ_map + bridge
+      simp at hval
+    · -- val = some a: hs has (some a).getM = pure a, computation reduces to pure (some ...)
+      simp only [Option.getM, pure_bind] at hs
+      erw [simulateQ_pure] at hs
+      simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hs
+      exact absurd (congr_arg Prod.fst hs) (by simp)
+  }, by {
+    -- Part 2: ∀ x ∈ support computation, event x
+    intro x hx
+    obtain ⟨s, -, hx⟩ := hx
+    simp only [StateT.run'_eq, support_map, Set.mem_image] at hx
+    obtain ⟨⟨xval, s'⟩, hx, rfl⟩ := hx
+    simp only [StateT.run_bind] at hx
+    rw [mem_support_bind_iff] at hx
+    obtain ⟨⟨y, s''⟩, hy, hx⟩ := hx
+    -- Unfold SubSpec liftM + OptionT in hy
+    simp only [MonadLift.monadLift, liftM, monadLift, MonadLiftT.monadLift,
+      OptionT.run_mk, OptionT.run_bind, OptionT.run_lift] at hy
+    -- simulateQ_map: y is always some _
+    erw [simulateQ_map] at hy
+    -- Peel outer simulateQ layer
+    erw [simulateQ_map] at hy
+    -- Bridge: StateT.run_map converts to ProbComp level map
+    rw [StateT.run_map] at hy
+    simp only [support_map, Set.mem_image] at hy
+    obtain ⟨⟨val, s₀⟩, hval, heq⟩ := hy
+    obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq
+    -- y = some val; hx depends on val : Option (...)
+    dsimp only [] at hx
+    -- Case split on val
+    rcases val with _ | ⟨a⟩
+    · -- val = none: contradicts hval (same as Part 1)
+      exfalso
+      simp only [bind_pure_comp] at hval
+      erw [simulateQ_map] at hval
+      erw [simulateQ_map] at hval
+      erw [simulateQ_map] at hval
+      erw [Option.elimM_map] at hval
+      simp only [Option.elim_some] at hval
+      dsimp only [OptionT.run] at hval
+      simp at hval
+    · -- val = some a: getM succeeds, derive event
+      simp only [Option.getM, pure_bind] at hx
+      erw [simulateQ_pure] at hx
+      simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff, Prod.mk.injEq,
+        Option.some.injEq] at hx
+      -- hx is now conjunction: xval = concrete ∧ s' = s₀
+      obtain ⟨rfl, -⟩ := hx
+      -- xval (= x) is now concrete but still contains a
+      -- Peel hval to determine a (same layers as none case)
+      simp only [bind_pure_comp] at hval
+      erw [simulateQ_map] at hval
+      erw [simulateQ_map] at hval
+      erw [simulateQ_map] at hval
+      erw [Option.elimM_map] at hval
+      simp only [Option.elim_some] at hval
+      dsimp only [OptionT.run] at hval
+      simp at hval
+      obtain ⟨_, _, rfl⟩ := hval
+      -- a is now concrete, goal should be provable
+      simp only [Set.mem_setOf_eq]
+      refine ⟨trivial, Prod.ext (Subsingleton.elim _ _) ?_⟩
+      -- Goal: prover oracle fn = verifier oracle fn
+      funext i
+      rcases i with j | j <;> {
+        have hj : j = default := Unique.uniq _ j
+        subst hj; rfl
+      }
+  }⟩
 
 end SendClaim

--- a/ArkLib/ProofSystem/Component/SendClaim.lean
+++ b/ArkLib/ProofSystem/Component/SendClaim.lean
@@ -22,6 +22,26 @@ import ArkLib.OracleReduction.Security.RoundByRound
 
 open OracleSpec OracleComp OracleQuery OracleInterface ProtocolSpec
 
+/-- Peel `simulateQ` map layers from a support membership hypothesis,
+    reducing the computation to its core pure form. -/
+elab "peel_simulateQ" " at " h:ident : tactic => do
+  let n := h.getId.toString
+  let env ← Lean.getEnv
+  let tactics := #[
+    s!"simp only [bind_pure_comp] at {n}",
+    s!"erw [simulateQ_map] at {n}",
+    s!"erw [simulateQ_map] at {n}",
+    s!"erw [simulateQ_map] at {n}",
+    s!"erw [Option.elimM_map] at {n}",
+    s!"simp only [Option.elim_some] at {n}",
+    s!"dsimp only [OptionT.run] at {n}",
+    s!"simp at {n}"]
+  for t in tactics do
+    let stx := Lean.Parser.runParserCategory env `tactic t
+    match stx with
+    | .ok s => Lean.Elab.Tactic.evalTactic s
+    | .error e => throwError "peel_simulateQ: parse error: {e}"
+
 namespace SendClaim
 
 variable {ι : Type} (oSpec : OracleSpec ι) (Statement : Type)
@@ -154,14 +174,8 @@ theorem completeness [Nonempty σ] :
     -- x = some val, s'' = s₀; hs depends on val : Option (...)
     dsimp only [] at hs
     rcases val with _ | ⟨a⟩
-    · -- val = none: contradicts hval (comp always returns some)
-      exfalso
-      simp only [bind_pure_comp] at hval
-      erw [simulateQ_map] at hval; erw [simulateQ_map] at hval; erw [simulateQ_map] at hval
-      erw [Option.elimM_map] at hval; simp only [Option.elim_some] at hval
-      dsimp only [OptionT.run] at hval; simp at hval
-    · -- val = some a: hs has (some a).getM = pure a, computation reduces to pure (some ...)
-      simp only [Option.getM, pure_bind] at hs
+    · exfalso; peel_simulateQ at hval
+    · simp only [Option.getM, pure_bind] at hs
       erw [simulateQ_pure] at hs
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hs
       exact absurd (congr_arg Prod.fst hs) (by simp)
@@ -189,23 +203,13 @@ theorem completeness [Nonempty σ] :
     -- y = some val; hx depends on val : Option (...)
     dsimp only [] at hx
     rcases val with _ | ⟨a⟩
-    · -- val = none: contradicts hval (same decomposition as Part 1)
-      exfalso
-      simp only [bind_pure_comp] at hval
-      erw [simulateQ_map] at hval; erw [simulateQ_map] at hval; erw [simulateQ_map] at hval
-      erw [Option.elimM_map] at hval; simp only [Option.elim_some] at hval
-      dsimp only [OptionT.run] at hval; simp at hval
-    · -- val = some a: getM succeeds, derive event
-      simp only [Option.getM, pure_bind] at hx
+    · exfalso; peel_simulateQ at hval
+    · simp only [Option.getM, pure_bind] at hx
       erw [simulateQ_pure] at hx
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff, Prod.mk.injEq,
         Option.some.injEq] at hx
       obtain ⟨rfl, -⟩ := hx
-      -- Peel hval to determine a
-      simp only [bind_pure_comp] at hval
-      erw [simulateQ_map] at hval; erw [simulateQ_map] at hval; erw [simulateQ_map] at hval
-      erw [Option.elimM_map] at hval; simp only [Option.elim_some] at hval
-      dsimp only [OptionT.run] at hval; simp at hval
+      peel_simulateQ at hval
       obtain ⟨_, _, rfl⟩ := hval
       -- a is now concrete, goal should be provable
       simp only [Set.mem_setOf_eq]

--- a/ArkLib/ProofSystem/Component/SendClaim.lean
+++ b/ArkLib/ProofSystem/Component/SendClaim.lean
@@ -107,20 +107,7 @@ it also holds in the ideal setting, etc.
 instance : ProverOnly (pSpec OStatement) where
   prover_first' := by simp
 
-/-- Bridge lemma: `none` is never in the support of a computation that maps through `some`.
-This is the key missing piece for SendClaim completeness: every layer of `liftM`/`simulateQ`
-preserves the `some <$> _` structure, so `none` can never appear in the output support.
-TODO: upstream to VCVio as a general `support_simulateQ` or `none_not_mem_support_map_some`. -/
-private lemma none_not_mem_support_map_some {m : Type _ → Type _}
-    [Monad m] [LawfulMonad m] [HasEvalSet m]
-    {α : Type _} (mx : m α) :
-    none ∉ support (Option.some <$> mx : m (Option α)) := by
-  rw [support_map]; rintro ⟨_, _, ⟨⟩⟩
-
-
 set_option synthInstance.maxHeartbeats 800000 in
-set_option maxHeartbeats 1600000 in
-set_option maxRecDepth 2000 in
 theorem completeness [Nonempty σ] :
     (oracleReduction oSpec Statement OStatement relComp).perfectCompleteness
     init impl relIn (relOut OStatement) := by
@@ -140,10 +127,8 @@ theorem completeness [Nonempty σ] :
   erw [simulateQ_bind]
   -- 5. Probability decomposition via probEvent_eq_one_iff
   rw [probEvent_eq_one_iff]
-  simp only [OptionT.probFailure_eq, probOutput_eq_zero_iff, OptionT.mem_support_iff,
-    OptionT.run_mk]
-  simp only [support_bind, Set.mem_iUnion, support_pure, Set.mem_singleton_iff,
-    support_map, Set.mem_image]
+  simp only [OptionT.probFailure_eq, OptionT.mem_support_iff, OptionT.run_mk]
+  simp only [support_bind, Set.mem_iUnion]
   exact ⟨by {
     simp only [HasEvalPMF.probFailure_eq_zero, zero_add, probOutput_eq_zero_iff]
     intro h
@@ -168,21 +153,13 @@ theorem completeness [Nonempty σ] :
     obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq
     -- x = some val, s'' = s₀; hs depends on val : Option (...)
     dsimp only [] at hs
-    -- Case split on val
     rcases val with _ | ⟨a⟩
-    · -- val = none: hval has (none, s₀) ∈ support of comp that always returns some
+    · -- val = none: contradicts hval (comp always returns some)
       exfalso
-      -- Convert innermost pure bind to map, peel through inner simulateQ layers
       simp only [bind_pure_comp] at hval
-      erw [simulateQ_map] at hval
-      erw [simulateQ_map] at hval
-      erw [simulateQ_map] at hval
-      -- Eliminate Option.elimM, unfold OptionT.run, push simulateQ through bind
-      erw [Option.elimM_map] at hval
-      simp only [Option.elim_some] at hval
-      dsimp only [OptionT.run] at hval
-      -- Use bind_pure_comp to convert bind to map, then simulateQ_map + bridge
-      simp at hval
+      erw [simulateQ_map] at hval; erw [simulateQ_map] at hval; erw [simulateQ_map] at hval
+      erw [Option.elimM_map] at hval; simp only [Option.elim_some] at hval
+      dsimp only [OptionT.run] at hval; simp at hval
     · -- val = some a: hs has (some a).getM = pure a, computation reduces to pure (some ...)
       simp only [Option.getM, pure_bind] at hs
       erw [simulateQ_pure] at hs
@@ -211,35 +188,24 @@ theorem completeness [Nonempty σ] :
     obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq
     -- y = some val; hx depends on val : Option (...)
     dsimp only [] at hx
-    -- Case split on val
     rcases val with _ | ⟨a⟩
-    · -- val = none: contradicts hval (same as Part 1)
+    · -- val = none: contradicts hval (same decomposition as Part 1)
       exfalso
       simp only [bind_pure_comp] at hval
-      erw [simulateQ_map] at hval
-      erw [simulateQ_map] at hval
-      erw [simulateQ_map] at hval
-      erw [Option.elimM_map] at hval
-      simp only [Option.elim_some] at hval
-      dsimp only [OptionT.run] at hval
-      simp at hval
+      erw [simulateQ_map] at hval; erw [simulateQ_map] at hval; erw [simulateQ_map] at hval
+      erw [Option.elimM_map] at hval; simp only [Option.elim_some] at hval
+      dsimp only [OptionT.run] at hval; simp at hval
     · -- val = some a: getM succeeds, derive event
       simp only [Option.getM, pure_bind] at hx
       erw [simulateQ_pure] at hx
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff, Prod.mk.injEq,
         Option.some.injEq] at hx
-      -- hx is now conjunction: xval = concrete ∧ s' = s₀
       obtain ⟨rfl, -⟩ := hx
-      -- xval (= x) is now concrete but still contains a
-      -- Peel hval to determine a (same layers as none case)
+      -- Peel hval to determine a
       simp only [bind_pure_comp] at hval
-      erw [simulateQ_map] at hval
-      erw [simulateQ_map] at hval
-      erw [simulateQ_map] at hval
-      erw [Option.elimM_map] at hval
-      simp only [Option.elim_some] at hval
-      dsimp only [OptionT.run] at hval
-      simp at hval
+      erw [simulateQ_map] at hval; erw [simulateQ_map] at hval; erw [simulateQ_map] at hval
+      erw [Option.elimM_map] at hval; simp only [Option.elim_some] at hval
+      dsimp only [OptionT.run] at hval; simp at hval
       obtain ⟨_, _, rfl⟩ := hval
       -- a is now concrete, goal should be provable
       simp only [Set.mem_setOf_eq]


### PR DESCRIPTION
Proves `SendClaim.completeness` — perfect completeness for the SendClaim component of the sumcheck oracle reduction chain. This was the last remaining `sorry` in the four-component completeness pipeline (CheckClaim → ReduceClaim → RandomQuery → SendClaim).

### What's proved

`SendClaim.oracleReduction` has perfect completeness: for any valid witness, the verifier accepts with probability 1 in the ideal oracle model.

### Technique

The proof peels through the layered monad stack (OptionT / StateT / OracleComp) using:

- **`simulateQ_map` / `simulateQ_bind` / `simulateQ_pure`** to push `simulateQ` through each prover and verifier bind
- **`Option.elimM_map`** to bridge `OptionT.run` across `simulateQ` boundaries
- **`StateT.run_map`** to convert `Functor.map` inside `StateT` to the underlying `ProbComp` level

The completeness event splits into two obligations: (1) the computation never returns `none` (failure), and (2) every output satisfies the relation. Both reduce to showing that `simulateQ` preserves the `some <$> _` structure at each layer, then closing the oracle equality via `Subsingleton.elim` and `Unique.uniq` on the unit-indexed oracle types.

### Context

Builds on the completeness chain from #444 (CheckClaim + ReduceClaim + RandomQuery) and the upstream `monadLift_liftM_OptionT` coherence lemma contributed in Verified-zkEVM/VCV-io#259.