### PR TITLE
Close Plonk infrastructure sorrys: SendWitness completeness, perm construction, grand product identity

### DIFF
--- a/ArkLib/OracleReduction/Execution.lean
+++ b/ArkLib/OracleReduction/Execution.lean
@@ -465,15 +465,7 @@ theorem Reduction.run_of_prover_first [ProverOnly pSpec] (stmt : StmtIn) (wit : 
         let stmtOut ← (reduction.verifier.verify stmt transcript).run
         return (⟨transcript, ctxOut⟩, ← stmtOut.getM)) := by
   simp only [Reduction.run, Verifier.run]
-  rw [Prover.run_of_prover_first]
-  simp only [liftComp_eq_liftM, bind_assoc, pure_bind, monadLift_bind, monadLift_pure]
-  sorry
-  -- conv =>
-  --   enter [1, 2, a, 1]
-  --   rw [map_eq_pure_bind]
-  --   rw [loggingOracle.simulateQ_bind_fst
-  --     (reduction.verifier.verify stmt _) (fun a_1_1 => pure (a_1_1, _))]
-  -- simp
+  simp [Prover.run_of_prover_first]
 
 end SingleMessage
 

--- a/ArkLib/ProofSystem/Component/SendWitness.lean
+++ b/ArkLib/ProofSystem/Component/SendWitness.lean
@@ -40,6 +40,9 @@ def pSpec : ProtocolSpec 1 := ⟨!v[.P_to_V], !v[Witness]⟩
 
 instance : ∀ i, VCVCompatible ((pSpec Witness).Challenge i) | ⟨0, h⟩ => nomatch h
 
+instance : ProverOnly (pSpec Witness) where
+  prover_first' := rfl
+
 @[inline, specialize]
 def prover : Prover oSpec Statement Witness (Statement × Witness) Unit (pSpec Witness) where
   PrvState
@@ -67,14 +70,40 @@ variable {Statement} {Witness}
 def toRelOut : Set ((Statement × Witness) × Unit) :=
   Prod.fst ⁻¹' relIn
 
+set_option maxHeartbeats 800000 in
 open Classical in
 /-- The `SendWitness` reduction satisfies perfect completeness. -/
 @[simp]
 theorem reduction_completeness :
     (reduction oSpec Statement Witness).perfectCompleteness init impl relIn (toRelOut relIn) := by
-  unfold Reduction.perfectCompleteness Reduction.completeness
+  simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
   intro stmtIn witIn hIn
-  sorry
+  have hrun : (reduction oSpec Statement Witness).run stmtIn witIn =
+      (pure (⟨fun | ⟨0, _⟩ => witIn, (stmtIn, witIn), ()⟩, (stmtIn, witIn)) :
+        OptionT (OracleComp _) _) := by
+    rw [Reduction.run_of_prover_first]
+    simp [reduction, prover, verifier]
+    rfl
+  simp only [hrun]
+  rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
+  refine ⟨?_, ?_⟩
+  · rw [OptionT.probFailure_eq, OptionT.run_mk]
+    simp only [probFailure_eq_zero, zero_add]
+    apply probOutput_eq_zero_of_not_mem_support
+    simp only [support_bind, Set.mem_iUnion, not_exists]
+    intro s _
+    erw [simulateQ_pure]
+    rw [StateT.run'_eq, StateT.run_pure]
+    simp [map_pure, support_pure]
+  · intro x hx
+    rw [OptionT.mem_support_iff] at hx
+    simp only [OptionT.run_mk, support_bind, Set.mem_iUnion] at hx
+    obtain ⟨s, _, hx⟩ := hx
+    erw [simulateQ_pure] at hx
+    rw [StateT.run'_eq, StateT.run_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff] at hx
+    cases hx
+    exact ⟨hIn, rfl⟩
 
 theorem reduction_rbr_knowledge_soundness : True := trivial
 

--- a/ArkLib/ProofSystem/Component/SendWitness.lean
+++ b/ArkLib/ProofSystem/Component/SendWitness.lean
@@ -40,6 +40,9 @@ def pSpec : ProtocolSpec 1 := ⟨!v[.P_to_V], !v[Witness]⟩
 
 instance : ∀ i, VCVCompatible ((pSpec Witness).Challenge i) | ⟨0, h⟩ => nomatch h
 
+instance : ProverOnly (pSpec Witness) where
+  prover_first' := rfl
+
 @[inline, specialize]
 def prover : Prover oSpec Statement Witness (Statement × Witness) Unit (pSpec Witness) where
   PrvState
@@ -67,14 +70,41 @@ variable {Statement} {Witness}
 def toRelOut : Set ((Statement × Witness) × Unit) :=
   Prod.fst ⁻¹' relIn
 
+set_option maxHeartbeats 800000 in
 open Classical in
 /-- The `SendWitness` reduction satisfies perfect completeness. -/
 @[simp]
 theorem reduction_completeness :
     (reduction oSpec Statement Witness).perfectCompleteness init impl relIn (toRelOut relIn) := by
-  unfold Reduction.perfectCompleteness Reduction.completeness
+  simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
   intro stmtIn witIn hIn
-  sorry
+  have hrun : (reduction oSpec Statement Witness).run stmtIn witIn =
+      (pure (⟨fun | ⟨0, _⟩ => witIn, (stmtIn, witIn), ()⟩, (stmtIn, witIn)) :
+        OptionT (OracleComp _) _) := by
+    rw [Reduction.run_of_prover_first]
+    simp [reduction, prover, verifier]
+    rfl
+  simp only [hrun]
+  rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
+  refine ⟨?_, ?_⟩
+  · rw [OptionT.probFailure_eq, OptionT.run_mk]
+    simp only [probFailure_eq_zero, zero_add]
+    apply probOutput_eq_zero_of_not_mem_support
+    simp only [support_bind, Set.mem_iUnion, not_exists]
+    intro s _
+    erw [simulateQ_pure]
+    rw [StateT.run'_eq, StateT.run_pure]
+    simp [map_pure, support_pure]
+    tauto
+  · intro x hx
+    rw [OptionT.mem_support_iff] at hx
+    simp only [OptionT.run_mk, support_bind, Set.mem_iUnion] at hx
+    obtain ⟨s, _, hx⟩ := hx
+    erw [simulateQ_pure] at hx
+    rw [StateT.run'_eq, StateT.run_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff] at hx
+    cases hx
+    exact ⟨hIn, rfl⟩
 
 theorem reduction_rbr_knowledge_soundness : True := trivial
 

--- a/ArkLib/ProofSystem/ConstraintSystem/Plonk.lean
+++ b/ArkLib/ProofSystem/ConstraintSystem/Plonk.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import CompPoly.Data.MvPolynomial.Notation
+import Mathlib.GroupTheory.Perm.List
 
 /-! # The Plonk relation
 
@@ -141,8 +142,14 @@ def partition (cs : ConstraintSystem 𝓡 numWires numGates) :
       else if j.1 = 1 then (cs j.2).b = i else (cs j.2).c = i)
     (Finset.univ : Finset (Fin 3 × Fin numGates)))
 
-/-- The permutation corresponding to the partition induced by a constraint system. -/
-def perm (cs : ConstraintSystem 𝓡 numWires numGates) : Equiv.Perm (Fin (3 * numGates)) := sorry
+/-- The permutation corresponding to the partition induced by a constraint system.
+
+For each wire index `i`, the positions in `Fin (3 * numGates)` referencing wire `i` form a
+partition block. The permutation cycles through each block (sorted by position), ensuring that
+copy constraints can be enforced: all positions in the same block must carry the same wire value. -/
+def perm (cs : ConstraintSystem 𝓡 numWires numGates) : Equiv.Perm (Fin (3 * numGates)) :=
+  (List.finRange numWires).foldr
+    (fun i acc => ((cs.partition i).sort (· ≤ ·)).formPerm * acc) 1
 
 /-- A constraint system is prepared for `ℓ` public inputs, for some `ℓ ≤ numGates, numWires`,
   if for all `i ∈ [ℓ]`, the `i`-th gate constrains the `i`-th wire to be some public value. -/
@@ -151,6 +158,27 @@ def isPreparedFor (ℓ : ℕ) (hℓ : ℓ ≤ numGates) (hℓ' : ℓ ≤ numWire
   ∀ i : Fin ℓ, ∃ c, cs (Fin.castLE hℓ i) = Gate.eq (Fin.castLE hℓ' i) c
 
 end ConstraintSystem
+
+section CopyConstraints
+
+variable {n : ℕ} {𝓡 : Type} [CommRing 𝓡]
+
+/-- Copy constraints are satisfied when the wire assignment is constant on orbits of
+the permutation: every position that references the same wire carries the same value. -/
+def CopyConstraintsSatisfied (f : Fin n → 𝓡) (σ : Equiv.Perm (Fin n)) : Prop :=
+  ∀ i, f (σ i) = f i
+
+/-- The grand product identity: when copy constraints hold, the product with permuted
+indices equals the product with identity indices. This is the completeness direction of
+the Plonk permutation argument — the honest prover's accumulator telescopes to 1. -/
+theorem prod_eq_of_copyConstraints (f g : Fin n → 𝓡) (σ : Equiv.Perm (Fin n)) (β γ : 𝓡)
+    (hf : CopyConstraintsSatisfied f σ) :
+    ∏ i : Fin n, (f i + β * g (σ i) + γ) =
+    ∏ i : Fin n, (f i + β * g i + γ) := by
+  conv_lhs => arg 2; ext i; rw [← hf i]
+  exact Equiv.prod_comp σ (fun j => f j + β * g j + γ)
+
+end CopyConstraints
 
 -- Finally, we define the Plonk relation.
 


### PR DESCRIPTION
## Summary

- **`SendWitness.reduction_completeness`**: prove perfect completeness for the
  SendWitness reduction via `Reduction.run_of_prover_first` + `probEvent_eq_one_iff`.
  Add `ProverOnly` instance for `pSpec Witness`.
- **`ConstraintSystem.perm`**: close sorry with `List.formPerm` over sorted partition
  blocks, folded across wire indices.
- **`CopyConstraintsSatisfied`** + **`prod_eq_of_copyConstraints`**: define copy
  constraint predicate and prove the grand product identity (completeness direction
  of the Plonk permutation argument) via `Equiv.prod_comp`.
- **`Reduction.run_of_prover_first`**: simplify proof to single `simp`.

3 sorrys closed, 2 new theorems.

## Files changed

- `ArkLib/ProofSystem/Component/SendWitness.lean`
- `ArkLib/ProofSystem/ConstraintSystem/Plonk.lean`
- `ArkLib/OracleReduction/Execution.lean`

## Validation

- `lake build` passes (3626 jobs)