### PR TITLE
Plonk PIOP: gate-check and permutation check protocols with completeness proofs

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -151,6 +151,7 @@ import ArkLib.ProofSystem.Fri.RoundConsistency
 import ArkLib.ProofSystem.Fri.Spec.General
 import ArkLib.ProofSystem.Fri.Spec.SingleRound
 import ArkLib.ProofSystem.Plonk.Basic
+import ArkLib.ProofSystem.Plonk.PermutationCheck
 import ArkLib.ProofSystem.Spartan.Basic
 import ArkLib.ProofSystem.Stir.Combine
 import ArkLib.ProofSystem.Stir.Folding

--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -172,6 +172,7 @@ import ArkLib.ProofSystem.Fri.RoundConsistency
 import ArkLib.ProofSystem.Fri.Spec.General
 import ArkLib.ProofSystem.Fri.Spec.SingleRound
 import ArkLib.ProofSystem.Plonk.Basic
+import ArkLib.ProofSystem.Plonk.PermutationCheck
 import ArkLib.ProofSystem.Spartan.Basic
 import ArkLib.ProofSystem.Stir.Combine
 import ArkLib.ProofSystem.Stir.MainThm

--- a/ArkLib/OracleReduction/Execution.lean
+++ b/ArkLib/OracleReduction/Execution.lean
@@ -465,15 +465,7 @@ theorem Reduction.run_of_prover_first [ProverOnly pSpec] (stmt : StmtIn) (wit : 
         let stmtOut ← (reduction.verifier.verify stmt transcript).run
         return (⟨transcript, ctxOut⟩, ← stmtOut.getM)) := by
   simp only [Reduction.run, Verifier.run]
-  rw [Prover.run_of_prover_first]
-  simp only [liftComp_eq_liftM, bind_assoc, pure_bind, monadLift_bind, monadLift_pure]
-  sorry
-  -- conv =>
-  --   enter [1, 2, a, 1]
-  --   rw [map_eq_pure_bind]
-  --   rw [loggingOracle.simulateQ_bind_fst
-  --     (reduction.verifier.verify stmt _) (fun a_1_1 => pure (a_1_1, _))]
-  -- simp
+  simp [Prover.run_of_prover_first]
 
 end SingleMessage
 

--- a/ArkLib/ProofSystem/Component/SendWitness.lean
+++ b/ArkLib/ProofSystem/Component/SendWitness.lean
@@ -40,6 +40,9 @@ def pSpec : ProtocolSpec 1 := ⟨!v[.P_to_V], !v[Witness]⟩
 
 instance : ∀ i, VCVCompatible ((pSpec Witness).Challenge i) | ⟨0, h⟩ => nomatch h
 
+instance : ProverOnly (pSpec Witness) where
+  prover_first' := rfl
+
 @[inline, specialize]
 def prover : Prover oSpec Statement Witness (Statement × Witness) Unit (pSpec Witness) where
   PrvState
@@ -67,14 +70,40 @@ variable {Statement} {Witness}
 def toRelOut : Set ((Statement × Witness) × Unit) :=
   Prod.fst ⁻¹' relIn
 
+set_option maxHeartbeats 800000 in
 open Classical in
 /-- The `SendWitness` reduction satisfies perfect completeness. -/
 @[simp]
 theorem reduction_completeness :
     (reduction oSpec Statement Witness).perfectCompleteness init impl relIn (toRelOut relIn) := by
-  unfold Reduction.perfectCompleteness Reduction.completeness
+  simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
   intro stmtIn witIn hIn
-  sorry
+  have hrun : (reduction oSpec Statement Witness).run stmtIn witIn =
+      (pure (⟨fun | ⟨0, _⟩ => witIn, (stmtIn, witIn), ()⟩, (stmtIn, witIn)) :
+        OptionT (OracleComp _) _) := by
+    rw [Reduction.run_of_prover_first]
+    simp [reduction, prover, verifier]
+    rfl
+  simp only [hrun]
+  rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
+  refine ⟨?_, ?_⟩
+  · rw [OptionT.probFailure_eq, OptionT.run_mk]
+    simp only [probFailure_eq_zero, zero_add]
+    apply probOutput_eq_zero_of_not_mem_support
+    simp only [support_bind, Set.mem_iUnion, not_exists]
+    intro s _
+    erw [simulateQ_pure]
+    rw [StateT.run'_eq, StateT.run_pure]
+    simp [map_pure, support_pure]
+  · intro x hx
+    rw [OptionT.mem_support_iff] at hx
+    simp only [OptionT.run_mk, support_bind, Set.mem_iUnion] at hx
+    obtain ⟨s, _, hx⟩ := hx
+    erw [simulateQ_pure] at hx
+    rw [StateT.run'_eq, StateT.run_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff] at hx
+    cases hx
+    exact ⟨hIn, rfl⟩
 
 theorem reduction_rbr_knowledge_soundness : True := trivial
 

--- a/ArkLib/ProofSystem/Component/SendWitness.lean
+++ b/ArkLib/ProofSystem/Component/SendWitness.lean
@@ -40,6 +40,9 @@ def pSpec : ProtocolSpec 1 := ⟨!v[.P_to_V], !v[Witness]⟩
 
 instance : ∀ i, VCVCompatible ((pSpec Witness).Challenge i) | ⟨0, h⟩ => nomatch h
 
+instance : ProverOnly (pSpec Witness) where
+  prover_first' := rfl
+
 @[inline, specialize]
 def prover : Prover oSpec Statement Witness (Statement × Witness) Unit (pSpec Witness) where
   PrvState
@@ -67,14 +70,41 @@ variable {Statement} {Witness}
 def toRelOut : Set ((Statement × Witness) × Unit) :=
   Prod.fst ⁻¹' relIn
 
+set_option maxHeartbeats 800000 in
 open Classical in
 /-- The `SendWitness` reduction satisfies perfect completeness. -/
 @[simp]
 theorem reduction_completeness :
     (reduction oSpec Statement Witness).perfectCompleteness init impl relIn (toRelOut relIn) := by
-  unfold Reduction.perfectCompleteness Reduction.completeness
+  simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
   intro stmtIn witIn hIn
-  sorry
+  have hrun : (reduction oSpec Statement Witness).run stmtIn witIn =
+      (pure (⟨fun | ⟨0, _⟩ => witIn, (stmtIn, witIn), ()⟩, (stmtIn, witIn)) :
+        OptionT (OracleComp _) _) := by
+    rw [Reduction.run_of_prover_first]
+    simp [reduction, prover, verifier]
+    rfl
+  simp only [hrun]
+  rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
+  refine ⟨?_, ?_⟩
+  · rw [OptionT.probFailure_eq, OptionT.run_mk]
+    simp only [probFailure_eq_zero, zero_add]
+    apply probOutput_eq_zero_of_not_mem_support
+    simp only [support_bind, Set.mem_iUnion, not_exists]
+    intro s _
+    erw [simulateQ_pure]
+    rw [StateT.run'_eq, StateT.run_pure]
+    simp [map_pure, support_pure]
+    tauto
+  · intro x hx
+    rw [OptionT.mem_support_iff] at hx
+    simp only [OptionT.run_mk, support_bind, Set.mem_iUnion] at hx
+    obtain ⟨s, _, hx⟩ := hx
+    erw [simulateQ_pure] at hx
+    rw [StateT.run'_eq, StateT.run_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff] at hx
+    cases hx
+    exact ⟨hIn, rfl⟩
 
 theorem reduction_rbr_knowledge_soundness : True := trivial
 

--- a/ArkLib/ProofSystem/ConstraintSystem/Plonk.lean
+++ b/ArkLib/ProofSystem/ConstraintSystem/Plonk.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import CompPoly.Data.MvPolynomial.Notation
+import Mathlib.GroupTheory.Perm.List
 
 /-! # The Plonk relation
 
@@ -141,8 +142,14 @@ def partition (cs : ConstraintSystem 𝓡 numWires numGates) :
       else if j.1 = 1 then (cs j.2).b = i else (cs j.2).c = i)
     (Finset.univ : Finset (Fin 3 × Fin numGates)))
 
-/-- The permutation corresponding to the partition induced by a constraint system. -/
-def perm (cs : ConstraintSystem 𝓡 numWires numGates) : Equiv.Perm (Fin (3 * numGates)) := sorry
+/-- The permutation corresponding to the partition induced by a constraint system.
+
+For each wire index `i`, the positions in `Fin (3 * numGates)` referencing wire `i` form a
+partition block. The permutation cycles through each block (sorted by position), ensuring that
+copy constraints can be enforced: all positions in the same block must carry the same wire value. -/
+def perm (cs : ConstraintSystem 𝓡 numWires numGates) : Equiv.Perm (Fin (3 * numGates)) :=
+  (List.finRange numWires).foldr
+    (fun i acc => ((cs.partition i).sort (· ≤ ·)).formPerm * acc) 1
 
 /-- A constraint system is prepared for `ℓ` public inputs, for some `ℓ ≤ numGates, numWires`,
   if for all `i ∈ [ℓ]`, the `i`-th gate constrains the `i`-th wire to be some public value. -/
@@ -151,6 +158,27 @@ def isPreparedFor (ℓ : ℕ) (hℓ : ℓ ≤ numGates) (hℓ' : ℓ ≤ numWire
   ∀ i : Fin ℓ, ∃ c, cs (Fin.castLE hℓ i) = Gate.eq (Fin.castLE hℓ' i) c
 
 end ConstraintSystem
+
+section CopyConstraints
+
+variable {n : ℕ} {𝓡 : Type} [CommRing 𝓡]
+
+/-- Copy constraints are satisfied when the wire assignment is constant on orbits of
+the permutation: every position that references the same wire carries the same value. -/
+def CopyConstraintsSatisfied (f : Fin n → 𝓡) (σ : Equiv.Perm (Fin n)) : Prop :=
+  ∀ i, f (σ i) = f i
+
+/-- The grand product identity: when copy constraints hold, the product with permuted
+indices equals the product with identity indices. This is the completeness direction of
+the Plonk permutation argument — the honest prover's accumulator telescopes to 1. -/
+theorem prod_eq_of_copyConstraints (f g : Fin n → 𝓡) (σ : Equiv.Perm (Fin n)) (β γ : 𝓡)
+    (hf : CopyConstraintsSatisfied f σ) :
+    ∏ i : Fin n, (f i + β * g (σ i) + γ) =
+    ∏ i : Fin n, (f i + β * g i + γ) := by
+  conv_lhs => arg 2; ext i; rw [← hf i]
+  exact Equiv.prod_comp σ (fun j => f j + β * g j + γ)
+
+end CopyConstraints
 
 -- Finally, we define the Plonk relation.
 

--- a/ArkLib/ProofSystem/Plonk/Basic.lean
+++ b/ArkLib/ProofSystem/Plonk/Basic.lean
@@ -9,14 +9,23 @@ import ArkLib.ProofSystem.ConstraintSystem.Plonk
 
 /-!
 
-# The Plonk Protocol
+# Plonk Gate-Check Protocol
 
-We aim to formalize the Plonk protocol (as a polynomial IOP) as stated in the original
-Plonk paper [GWZC19].
+The Plonk gate-check is the first component of the Plonk PIOP: the prover sends the
+wire assignment, the verifier checks all gate equations in the constraint system.
 
-As we do so, we will break down Plonk into modular components, such as . We also plan to formalize
-various extensions of Plonk, such as Maller's optimization trick (which can be seen as a change on
-the PIOP level), integration with lookup arguments (i.e. logup), high-degree constraints, and more.
+Modeled as a 1-round `Reduction` using ArkLib's OracleReduction framework. This
+protocol forms the foundation for the full Plonk PIOP — composition with the
+permutation argument (copy constraints) is handled separately in
+`ArkLib.ProofSystem.Plonk.PermutationCheck`.
+
+## Protocol structure
+
+- **ProtocolSpec**: 1 round, P → V, message type `Fin numWires → 𝓡`
+- **Statement**: `Plonk.ConstraintSystem 𝓡 numWires numGates`
+- **Witness**: `Fin numWires → 𝓡` (wire assignment)
+- **Input relation**: `cs.accepts w` (all gate equations satisfied)
+- **Output**: `(cs, w)` pair (for composition with downstream reductions)
 
 ## References
 
@@ -25,19 +34,121 @@ the PIOP level), integration with lookup arguments (i.e. logup), high-degree con
 
 -/
 
+noncomputable section
+
 namespace Plonk
 
-section AuxiliaryPolynomials
+open OracleComp OracleSpec ProtocolSpec
 
-/-! ## Auxiliary polynomials in Plonk-/
+section GateCheck
 
+variable (𝓡 : Type) [CommRing 𝓡] (numWires numGates : ℕ)
 
+@[reducible]
+def gateCheckPSpec : ProtocolSpec 1 :=
+  ⟨!v[.P_to_V], !v[Fin numWires → 𝓡]⟩
 
-end AuxiliaryPolynomials
+instance : ∀ i, VCVCompatible ((gateCheckPSpec 𝓡 numWires).Challenge i)
+  | ⟨0, h⟩ => nomatch h
 
-/-! ## Protocol Structure
+instance : ∀ i, SampleableType ((gateCheckPSpec 𝓡 numWires).Challenge i)
+  | ⟨0, h⟩ => nomatch h
 
-The Plonk protocol
--/
+instance : ProverOnly (gateCheckPSpec 𝓡 numWires) where
+  prover_first' := rfl
+
+variable {𝓡} {numWires} {numGates}
+
+@[inline, specialize]
+def gateCheckProver :
+    Prover []ₒ
+      (ConstraintSystem 𝓡 numWires numGates) (Fin numWires → 𝓡)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)) Unit
+      (gateCheckPSpec 𝓡 numWires) where
+  PrvState
+  | 0 => ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)
+  | 1 => ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)
+  input := id
+  sendMessage | ⟨0, _⟩ => fun ⟨cs, w⟩ => pure (w, ⟨cs, w⟩)
+  receiveChallenge | ⟨0, h⟩ => nomatch h
+  output := fun ⟨cs, w⟩ => pure (⟨cs, w⟩, ())
+
+variable [DecidableEq 𝓡]
+
+instance acceptsDecidable (cs : ConstraintSystem 𝓡 numWires numGates) (w : Fin numWires → 𝓡) :
+    Decidable (cs.accepts w) :=
+  inferInstanceAs (Decidable (∀ i : Fin numGates, (cs i).eval w = 0))
+
+@[inline, specialize]
+def gateCheckVerifier :
+    Verifier []ₒ
+      (ConstraintSystem 𝓡 numWires numGates)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡))
+      (gateCheckPSpec 𝓡 numWires) where
+  verify := fun cs transcript => do
+    let w : Fin numWires → 𝓡 := transcript 0
+    guard (cs.accepts w)
+    return ⟨cs, w⟩
+
+@[inline, specialize]
+def gateCheckReduction :
+    Reduction []ₒ
+      (ConstraintSystem 𝓡 numWires numGates) (Fin numWires → 𝓡)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)) Unit
+      (gateCheckPSpec 𝓡 numWires) where
+  prover := gateCheckProver
+  verifier := gateCheckVerifier
+
+@[reducible, simp]
+def gateCheckRelIn :
+    Set (ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)) :=
+  { p | p.1.accepts p.2 }
+
+@[reducible, simp]
+def gateCheckRelOut :
+    Set ((ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)) × Unit) :=
+  Prod.fst ⁻¹' gateCheckRelIn
+
+variable {σ : Type} (init : ProbComp σ) (impl : QueryImpl []ₒ (StateT σ ProbComp))
+
+set_option maxHeartbeats 1600000 in
+open Classical in
+theorem gateCheck_perfectCompleteness :
+    (gateCheckReduction (𝓡 := 𝓡) (numWires := numWires) (numGates := numGates)).perfectCompleteness
+      init impl gateCheckRelIn gateCheckRelOut := by
+  simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
+  intro cs w hIn
+  simp only [gateCheckRelIn, Set.mem_setOf_eq] at hIn
+  have hrun : (gateCheckReduction (𝓡 := 𝓡) (numWires := numWires)
+      (numGates := numGates)).run cs w =
+      OptionT.mk (pure (some (⟨fun | ⟨0, _⟩ => w, (cs, w), ()⟩, (cs, w)))) := by
+    simp only [Reduction.run, Verifier.run, Prover.run_of_prover_first,
+      gateCheckReduction, gateCheckProver, gateCheckVerifier, guard, if_pos hIn, id,
+      OracleComp.liftComp_pure, pure_bind, map_pure, bind_pure_comp, monadLift_pure,
+      OptionT.run_pure, Option.getM]; rfl
+  simp only [hrun]
+  rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
+  refine ⟨?_, ?_⟩
+  · rw [OptionT.probFailure_eq, OptionT.run_mk]
+    simp only [probFailure_eq_zero, zero_add]
+    apply probOutput_eq_zero_of_not_mem_support
+    simp only [support_bind, Set.mem_iUnion, not_exists]
+    intro s _
+    erw [simulateQ_pure]
+    rw [StateT.run'_eq, StateT.run_pure]
+    simp [map_pure, support_pure]
+  · intro x hx
+    rw [OptionT.mem_support_iff] at hx
+    simp only [OptionT.run_mk, support_bind, Set.mem_iUnion] at hx
+    obtain ⟨s, _, hx⟩ := hx
+    erw [simulateQ_pure] at hx
+    rw [StateT.run'_eq, StateT.run_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff] at hx
+    cases hx
+    exact ⟨hIn, rfl⟩
+
+end GateCheck
 
 end Plonk
+
+end

--- a/ArkLib/ProofSystem/Plonk/Basic.lean
+++ b/ArkLib/ProofSystem/Plonk/Basic.lean
@@ -9,14 +9,23 @@ import ArkLib.ProofSystem.ConstraintSystem.Plonk
 
 /-!
 
-# The Plonk Protocol
+# Plonk Gate-Check Protocol
 
-We aim to formalize the Plonk protocol (as a polynomial IOP) as stated in the original
-Plonk paper [GWZC19].
+The Plonk gate-check is the first component of the Plonk PIOP: the prover sends the
+wire assignment, the verifier checks all gate equations in the constraint system.
 
-As we do so, we will break down Plonk into modular components, such as . We also plan to formalize
-various extensions of Plonk, such as Maller's optimization trick (which can be seen as a change on
-the PIOP level), integration with lookup arguments (i.e. logup), high-degree constraints, and more.
+Modeled as a 1-round `Reduction` using ArkLib's OracleReduction framework. This
+protocol forms the foundation for the full Plonk PIOP — composition with the
+permutation argument (copy constraints) is handled separately in
+`ArkLib.ProofSystem.Plonk.PermutationCheck`.
+
+## Protocol structure
+
+- **ProtocolSpec**: 1 round, P → V, message type `Fin numWires → 𝓡`
+- **Statement**: `Plonk.ConstraintSystem 𝓡 numWires numGates`
+- **Witness**: `Fin numWires → 𝓡` (wire assignment)
+- **Input relation**: `cs.accepts w` (all gate equations satisfied)
+- **Output**: `(cs, w)` pair (for composition with downstream reductions)
 
 ## References
 
@@ -25,19 +34,120 @@ the PIOP level), integration with lookup arguments (i.e. logup), high-degree con
 
 -/
 
+noncomputable section
+
 namespace Plonk
 
-section AuxiliaryPolynomials
+open OracleComp OracleSpec ProtocolSpec
 
-/-! ## Auxiliary polynomials in Plonk-/
+section GateCheck
 
+variable (𝓡 : Type) [CommRing 𝓡] (numWires numGates : ℕ)
 
+@[reducible]
+def gateCheckPSpec : ProtocolSpec 1 :=
+  ⟨!v[.P_to_V], !v[Fin numWires → 𝓡]⟩
 
-end AuxiliaryPolynomials
+instance : ∀ i, VCVCompatible ((gateCheckPSpec 𝓡 numWires).Challenge i)
+  | ⟨0, h⟩ => nomatch h
 
-/-! ## Protocol Structure
+instance : ∀ i, SampleableType ((gateCheckPSpec 𝓡 numWires).Challenge i)
+  | ⟨0, h⟩ => nomatch h
 
-The Plonk protocol
--/
+instance : ProverOnly (gateCheckPSpec 𝓡 numWires) where
+  prover_first' := rfl
+
+variable {𝓡} {numWires} {numGates}
+
+@[inline, specialize]
+def gateCheckProver :
+    Prover []ₒ
+      (ConstraintSystem 𝓡 numWires numGates) (Fin numWires → 𝓡)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)) Unit
+      (gateCheckPSpec 𝓡 numWires) where
+  PrvState
+  | 0 => ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)
+  | 1 => ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)
+  input := id
+  sendMessage | ⟨0, _⟩ => fun ⟨cs, w⟩ => pure (w, ⟨cs, w⟩)
+  receiveChallenge | ⟨0, h⟩ => nomatch h
+  output := fun ⟨cs, w⟩ => pure (⟨cs, w⟩, ())
+
+variable [DecidableEq 𝓡]
+
+instance acceptsDecidable (cs : ConstraintSystem 𝓡 numWires numGates) (w : Fin numWires → 𝓡) :
+    Decidable (cs.accepts w) :=
+  inferInstanceAs (Decidable (∀ i : Fin numGates, (cs i).eval w = 0))
+
+@[inline, specialize]
+def gateCheckVerifier :
+    Verifier []ₒ
+      (ConstraintSystem 𝓡 numWires numGates)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡))
+      (gateCheckPSpec 𝓡 numWires) where
+  verify := fun cs transcript => do
+    let w : Fin numWires → 𝓡 := transcript 0
+    guard (cs.accepts w)
+    return ⟨cs, w⟩
+
+@[inline, specialize]
+def gateCheckReduction :
+    Reduction []ₒ
+      (ConstraintSystem 𝓡 numWires numGates) (Fin numWires → 𝓡)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)) Unit
+      (gateCheckPSpec 𝓡 numWires) where
+  prover := gateCheckProver
+  verifier := gateCheckVerifier
+
+@[reducible, simp]
+def gateCheckRelIn :
+    Set (ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)) :=
+  { p | p.1.accepts p.2 }
+
+@[reducible, simp]
+def gateCheckRelOut :
+    Set ((ConstraintSystem 𝓡 numWires numGates × (Fin numWires → 𝓡)) × Unit) :=
+  Prod.fst ⁻¹' gateCheckRelIn
+
+variable {σ : Type} (init : ProbComp σ) (impl : QueryImpl []ₒ (StateT σ ProbComp))
+
+set_option maxHeartbeats 1600000 in
+open Classical in
+theorem gateCheck_perfectCompleteness :
+    (gateCheckReduction (𝓡 := 𝓡) (numWires := numWires) (numGates := numGates)).perfectCompleteness
+      init impl gateCheckRelIn gateCheckRelOut := by
+  simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
+  intro cs w hIn
+  simp only [gateCheckRelIn, Set.mem_setOf_eq] at hIn
+  have hrun : (gateCheckReduction (𝓡 := 𝓡) (numWires := numWires)
+      (numGates := numGates)).run cs w =
+      (pure (⟨fun | ⟨0, _⟩ => w, (cs, w), ()⟩, (cs, w)) : OptionT (OracleComp _) _) := by
+    rw [Reduction.run_of_prover_first]
+    simp [gateCheckReduction, gateCheckProver, gateCheckVerifier, guard, if_pos hIn]
+    rfl
+  simp only [hrun]
+  rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
+  refine ⟨?_, ?_⟩
+  · rw [OptionT.probFailure_eq, OptionT.run_mk]
+    simp only [probFailure_eq_zero, zero_add]
+    apply probOutput_eq_zero_of_not_mem_support
+    simp only [support_bind, Set.mem_iUnion, not_exists]
+    intro s _
+    erw [simulateQ_pure]
+    rw [StateT.run'_eq, StateT.run_pure]
+    simp [map_pure, support_pure]
+  · intro x hx
+    rw [OptionT.mem_support_iff] at hx
+    simp only [OptionT.run_mk, support_bind, Set.mem_iUnion] at hx
+    obtain ⟨s, _, hx⟩ := hx
+    erw [simulateQ_pure] at hx
+    rw [StateT.run'_eq, StateT.run_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff] at hx
+    cases hx
+    exact ⟨hIn, rfl⟩
+
+end GateCheck
 
 end Plonk
+
+end

--- a/ArkLib/ProofSystem/Plonk/PermutationCheck.lean
+++ b/ArkLib/ProofSystem/Plonk/PermutationCheck.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.OracleReduction.Security.Basic
+import ArkLib.ProofSystem.ConstraintSystem.Plonk
+
+/-!
+
+# Plonk Permutation Check Protocol
+
+The permutation check verifies that copy constraints are satisfied: the extended
+wire assignment is constant on orbits of the permutation induced by the constraint system.
+
+Modeled as a 1-round `Reduction` using ArkLib's OracleReduction framework, parallel
+to the gate-check protocol in `ArkLib.ProofSystem.Plonk.Basic`.
+
+## Protocol structure
+
+- **ProtocolSpec**: 1 round, P → V, message type `Fin (3 * numGates) → 𝓡`
+- **Statement**: `Plonk.ConstraintSystem 𝓡 numWires numGates`
+- **Witness**: `Fin (3 * numGates) → 𝓡` (extended wire assignment)
+- **Input relation**: `CopyConstraintsSatisfied f (cs.perm)`
+- **Output**: `(cs, f)` pair
+
+## References
+
+* [Gabizon, A., Williamson, Z.J., and Ciobotaru, O., *Plonk: Permutations over lagrange-bases
+    for oecumenical noninteractive arguments of knowledge*][GWZC19]
+
+-/
+
+noncomputable section
+
+namespace Plonk
+
+open OracleComp OracleSpec ProtocolSpec
+
+section Extend
+
+variable (𝓡 : Type) [CommRing 𝓡] (numWires numGates : ℕ)
+
+/-- Maps a position in `Fin (3 * numGates)` to the wire index it references.
+Position `(k, g)` via `finProdFinEquiv` references wire `a`/`b`/`c` of gate `g`. -/
+def wireOfPosition (cs : ConstraintSystem 𝓡 numWires numGates)
+    (j : Fin (3 * numGates)) : Fin numWires :=
+  let p := finProdFinEquiv.symm j
+  if p.1 = 0 then (cs p.2).a
+  else if p.1 = 1 then (cs p.2).b
+  else (cs p.2).c
+
+/-- Extends a wire assignment to the full position domain using the constraint system's
+wire routing: position `j` gets value `w (wireOfPosition cs j)`. -/
+def extendWireAssignment (cs : ConstraintSystem 𝓡 numWires numGates)
+    (w : Fin numWires → 𝓡) : Fin (3 * numGates) → 𝓡 :=
+  w ∘ wireOfPosition 𝓡 numWires numGates cs
+
+end Extend
+
+section PermutationCheck
+
+variable (𝓡 : Type) [CommRing 𝓡] (numWires numGates : ℕ)
+
+@[reducible]
+def permCheckPSpec : ProtocolSpec 1 :=
+  ⟨!v[.P_to_V], !v[Fin (3 * numGates) → 𝓡]⟩
+
+instance : ∀ i, VCVCompatible ((permCheckPSpec 𝓡 numGates).Challenge i)
+  | ⟨0, h⟩ => nomatch h
+
+instance : ∀ i, SampleableType ((permCheckPSpec 𝓡 numGates).Challenge i)
+  | ⟨0, h⟩ => nomatch h
+
+instance : ProverOnly (permCheckPSpec 𝓡 numGates) where
+  prover_first' := rfl
+
+variable {𝓡} {numWires} {numGates}
+
+@[inline, specialize]
+def permCheckProver :
+    Prover []ₒ
+      (ConstraintSystem 𝓡 numWires numGates) (Fin (3 * numGates) → 𝓡)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)) Unit
+      (permCheckPSpec 𝓡 numGates) where
+  PrvState
+  | 0 => ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)
+  | 1 => ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)
+  input := id
+  sendMessage | ⟨0, _⟩ => fun ⟨cs, f⟩ => pure (f, ⟨cs, f⟩)
+  receiveChallenge | ⟨0, h⟩ => nomatch h
+  output := fun ⟨cs, f⟩ => pure (⟨cs, f⟩, ())
+
+variable [DecidableEq 𝓡]
+
+instance copyConstraintsDecidable (f : Fin (3 * numGates) → 𝓡)
+    (σ : Equiv.Perm (Fin (3 * numGates))) :
+    Decidable (CopyConstraintsSatisfied f σ) :=
+  inferInstanceAs (Decidable (∀ i, f (σ i) = f i))
+
+@[inline, specialize]
+def permCheckVerifier :
+    Verifier []ₒ
+      (ConstraintSystem 𝓡 numWires numGates)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡))
+      (permCheckPSpec 𝓡 numGates) where
+  verify := fun cs transcript => do
+    let f : Fin (3 * numGates) → 𝓡 := transcript 0
+    guard (CopyConstraintsSatisfied f cs.perm)
+    return ⟨cs, f⟩
+
+@[inline, specialize]
+def permCheckReduction :
+    Reduction []ₒ
+      (ConstraintSystem 𝓡 numWires numGates) (Fin (3 * numGates) → 𝓡)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)) Unit
+      (permCheckPSpec 𝓡 numGates) where
+  prover := permCheckProver
+  verifier := permCheckVerifier
+
+@[reducible, simp]
+def permCheckRelIn :
+    Set (ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)) :=
+  { p | CopyConstraintsSatisfied p.2 p.1.perm }
+
+@[reducible, simp]
+def permCheckRelOut :
+    Set ((ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)) × Unit) :=
+  Prod.fst ⁻¹' permCheckRelIn
+
+variable {σ : Type} (init : ProbComp σ) (impl : QueryImpl []ₒ (StateT σ ProbComp))
+
+set_option maxHeartbeats 1600000 in
+omit [CommRing 𝓡] in
+open Classical in
+theorem permCheck_perfectCompleteness :
+    (permCheckReduction (𝓡 := 𝓡) (numWires := numWires) (numGates := numGates)).perfectCompleteness
+      init impl permCheckRelIn permCheckRelOut := by
+  simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
+  intro cs f hIn
+  simp only [permCheckRelIn, Set.mem_setOf_eq] at hIn
+  have hrun : (permCheckReduction (𝓡 := 𝓡) (numWires := numWires)
+      (numGates := numGates)).run cs f =
+      OptionT.mk (pure (some (⟨fun | ⟨0, _⟩ => f, (cs, f), ()⟩, (cs, f)))) := by
+    simp only [Reduction.run, Verifier.run, Prover.run_of_prover_first,
+      permCheckReduction, permCheckProver, permCheckVerifier, guard, if_pos hIn, id,
+      OracleComp.liftComp_pure, pure_bind, map_pure, bind_pure_comp, monadLift_pure,
+      OptionT.run_pure, Option.getM]; rfl
+  simp only [hrun]
+  rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
+  refine ⟨?_, ?_⟩
+  · rw [OptionT.probFailure_eq, OptionT.run_mk]
+    simp only [probFailure_eq_zero, zero_add]
+    apply probOutput_eq_zero_of_not_mem_support
+    simp only [support_bind, Set.mem_iUnion, not_exists]
+    intro s _
+    erw [simulateQ_pure]
+    rw [StateT.run'_eq, StateT.run_pure]
+    simp [map_pure, support_pure]
+  · intro x hx
+    rw [OptionT.mem_support_iff] at hx
+    simp only [OptionT.run_mk, support_bind, Set.mem_iUnion] at hx
+    obtain ⟨s, _, hx⟩ := hx
+    erw [simulateQ_pure] at hx
+    rw [StateT.run'_eq, StateT.run_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff] at hx
+    cases hx
+    exact ⟨hIn, rfl⟩
+
+end PermutationCheck
+
+end Plonk
+
+end

--- a/ArkLib/ProofSystem/Plonk/PermutationCheck.lean
+++ b/ArkLib/ProofSystem/Plonk/PermutationCheck.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.OracleReduction.Security.Basic
+import ArkLib.ProofSystem.ConstraintSystem.Plonk
+
+/-!
+
+# Plonk Permutation Check Protocol
+
+The permutation check verifies that copy constraints are satisfied: the extended
+wire assignment is constant on orbits of the permutation induced by the constraint system.
+
+Modeled as a 1-round `Reduction` using ArkLib's OracleReduction framework, parallel
+to the gate-check protocol in `ArkLib.ProofSystem.Plonk.Basic`.
+
+## Protocol structure
+
+- **ProtocolSpec**: 1 round, P → V, message type `Fin (3 * numGates) → 𝓡`
+- **Statement**: `Plonk.ConstraintSystem 𝓡 numWires numGates`
+- **Witness**: `Fin (3 * numGates) → 𝓡` (extended wire assignment)
+- **Input relation**: `CopyConstraintsSatisfied f (cs.perm)`
+- **Output**: `(cs, f)` pair
+
+## References
+
+* [Gabizon, A., Williamson, Z.J., and Ciobotaru, O., *Plonk: Permutations over lagrange-bases
+    for oecumenical noninteractive arguments of knowledge*][GWZC19]
+
+-/
+
+noncomputable section
+
+namespace Plonk
+
+open OracleComp OracleSpec ProtocolSpec
+
+section Extend
+
+variable (𝓡 : Type) [CommRing 𝓡] (numWires numGates : ℕ)
+
+/-- Maps a position in `Fin (3 * numGates)` to the wire index it references.
+Position `(k, g)` via `finProdFinEquiv` references wire `a`/`b`/`c` of gate `g`. -/
+def wireOfPosition (cs : ConstraintSystem 𝓡 numWires numGates)
+    (j : Fin (3 * numGates)) : Fin numWires :=
+  let p := finProdFinEquiv.symm j
+  if p.1 = 0 then (cs p.2).a
+  else if p.1 = 1 then (cs p.2).b
+  else (cs p.2).c
+
+/-- Extends a wire assignment to the full position domain using the constraint system's
+wire routing: position `j` gets value `w (wireOfPosition cs j)`. -/
+def extendWireAssignment (cs : ConstraintSystem 𝓡 numWires numGates)
+    (w : Fin numWires → 𝓡) : Fin (3 * numGates) → 𝓡 :=
+  w ∘ wireOfPosition 𝓡 numWires numGates cs
+
+end Extend
+
+section PermutationCheck
+
+variable (𝓡 : Type) [CommRing 𝓡] (numWires numGates : ℕ)
+
+@[reducible]
+def permCheckPSpec : ProtocolSpec 1 :=
+  ⟨!v[.P_to_V], !v[Fin (3 * numGates) → 𝓡]⟩
+
+instance : ∀ i, VCVCompatible ((permCheckPSpec 𝓡 numGates).Challenge i)
+  | ⟨0, h⟩ => nomatch h
+
+instance : ∀ i, SampleableType ((permCheckPSpec 𝓡 numGates).Challenge i)
+  | ⟨0, h⟩ => nomatch h
+
+instance : ProverOnly (permCheckPSpec 𝓡 numGates) where
+  prover_first' := rfl
+
+variable {𝓡} {numWires} {numGates}
+
+@[inline, specialize]
+def permCheckProver :
+    Prover []ₒ
+      (ConstraintSystem 𝓡 numWires numGates) (Fin (3 * numGates) → 𝓡)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)) Unit
+      (permCheckPSpec 𝓡 numGates) where
+  PrvState
+  | 0 => ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)
+  | 1 => ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)
+  input := id
+  sendMessage | ⟨0, _⟩ => fun ⟨cs, f⟩ => pure (f, ⟨cs, f⟩)
+  receiveChallenge | ⟨0, h⟩ => nomatch h
+  output := fun ⟨cs, f⟩ => pure (⟨cs, f⟩, ())
+
+variable [DecidableEq 𝓡]
+
+instance copyConstraintsDecidable (f : Fin (3 * numGates) → 𝓡)
+    (σ : Equiv.Perm (Fin (3 * numGates))) :
+    Decidable (CopyConstraintsSatisfied f σ) :=
+  inferInstanceAs (Decidable (∀ i, f (σ i) = f i))
+
+@[inline, specialize]
+def permCheckVerifier :
+    Verifier []ₒ
+      (ConstraintSystem 𝓡 numWires numGates)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡))
+      (permCheckPSpec 𝓡 numGates) where
+  verify := fun cs transcript => do
+    let f : Fin (3 * numGates) → 𝓡 := transcript 0
+    guard (CopyConstraintsSatisfied f cs.perm)
+    return ⟨cs, f⟩
+
+@[inline, specialize]
+def permCheckReduction :
+    Reduction []ₒ
+      (ConstraintSystem 𝓡 numWires numGates) (Fin (3 * numGates) → 𝓡)
+      (ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)) Unit
+      (permCheckPSpec 𝓡 numGates) where
+  prover := permCheckProver
+  verifier := permCheckVerifier
+
+@[reducible, simp]
+def permCheckRelIn :
+    Set (ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)) :=
+  { p | CopyConstraintsSatisfied p.2 p.1.perm }
+
+@[reducible, simp]
+def permCheckRelOut :
+    Set ((ConstraintSystem 𝓡 numWires numGates × (Fin (3 * numGates) → 𝓡)) × Unit) :=
+  Prod.fst ⁻¹' permCheckRelIn
+
+variable {σ : Type} (init : ProbComp σ) (impl : QueryImpl []ₒ (StateT σ ProbComp))
+
+set_option maxHeartbeats 1600000 in
+omit [CommRing 𝓡] in
+open Classical in
+theorem permCheck_perfectCompleteness :
+    (permCheckReduction (𝓡 := 𝓡) (numWires := numWires) (numGates := numGates)).perfectCompleteness
+      init impl permCheckRelIn permCheckRelOut := by
+  simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
+  intro cs f hIn
+  simp only [permCheckRelIn, Set.mem_setOf_eq] at hIn
+  have hrun : (permCheckReduction (𝓡 := 𝓡) (numWires := numWires)
+      (numGates := numGates)).run cs f =
+      (pure (⟨fun | ⟨0, _⟩ => f, (cs, f), ()⟩, (cs, f)) : OptionT (OracleComp _) _) := by
+    rw [Reduction.run_of_prover_first]
+    simp [permCheckReduction, permCheckProver, permCheckVerifier, guard, if_pos hIn]
+    rfl
+  simp only [hrun]
+  rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
+  refine ⟨?_, ?_⟩
+  · rw [OptionT.probFailure_eq, OptionT.run_mk]
+    simp only [probFailure_eq_zero, zero_add]
+    apply probOutput_eq_zero_of_not_mem_support
+    simp only [support_bind, Set.mem_iUnion, not_exists]
+    intro s _
+    erw [simulateQ_pure]
+    rw [StateT.run'_eq, StateT.run_pure]
+    simp [map_pure, support_pure]
+  · intro x hx
+    rw [OptionT.mem_support_iff] at hx
+    simp only [OptionT.run_mk, support_bind, Set.mem_iUnion] at hx
+    obtain ⟨s, _, hx⟩ := hx
+    erw [simulateQ_pure] at hx
+    rw [StateT.run'_eq, StateT.run_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff] at hx
+    cases hx
+    exact ⟨hIn, rfl⟩
+
+end PermutationCheck
+
+end Plonk
+
+end

--- a/docs/kb/_generated/lean-citations.json
+++ b/docs/kb/_generated/lean-citations.json
@@ -1,8 +1,8 @@
 {
   "counts": {
-    "files_with_citations": 58,
+    "files_with_citations": 59,
     "keys_cited": 20,
-    "total_citation_edges": 68
+    "total_citation_edges": 69
   },
   "files": {
     "ArkLib/AGM/Basic.lean": [
@@ -156,6 +156,9 @@
     "ArkLib/ProofSystem/Plonk/Basic.lean": [
       "GWZC19"
     ],
+    "ArkLib/ProofSystem/Plonk/PermutationCheck.lean": [
+      "GWZC19"
+    ],
     "ArkLib/ProofSystem/Stir/Combine.lean": [
       "ACFY24stir"
     ],
@@ -267,7 +270,8 @@
       "ArkLib/ProofSystem/Fri/Spec/SingleRound.lean"
     ],
     "GWZC19": [
-      "ArkLib/ProofSystem/Plonk/Basic.lean"
+      "ArkLib/ProofSystem/Plonk/Basic.lean",
+      "ArkLib/ProofSystem/Plonk/PermutationCheck.lean"
     ],
     "JM24": [
       "ArkLib/AGM/Basic.lean"


### PR DESCRIPTION
## Summary

Fills the empty `ProofSystem/Plonk/Basic.lean` skeleton with working Plonk PIOP protocol definitions and completeness proofs:

- **Gate-check protocol** (`Basic.lean`): 1-round `Reduction` where the prover sends the wire assignment and the verifier checks all gate equations via `cs.accepts w`. Includes `gateCheck_perfectCompleteness`.
- **Permutation check protocol** (`PermutationCheck.lean`): 1-round `Reduction` where the prover sends the extended wire assignment and the verifier checks `CopyConstraintsSatisfied f cs.perm`. Includes `permCheck_perfectCompleteness`.
- Utility definitions `wireOfPosition` and `extendWireAssignment` for mapping wire assignments to the full `Fin (3 * numGates)` position domain.

Both completeness proofs use the `Reduction.run_of_prover_first` + `probEvent_eq_one_iff` pattern established in `SendWitness.reduction_completeness`.

Depends on #458 for `ConstraintSystem.perm`, `CopyConstraintsSatisfied`, and `prod_eq_of_copyConstraints`.

Downstream consumer [XC0R/CertiPlonk](https://github.com/XC0R/CertiPlonk) uses these protocols to build a formally verified Plonky3 AIR → Plonk CS → Plonk PIOP pipeline.

## Files changed

| File | Change |
|------|--------|
| `ArkLib/ProofSystem/Plonk/Basic.lean` | Replace empty skeleton with gate-check protocol + completeness proof |
| `ArkLib/ProofSystem/Plonk/PermutationCheck.lean` | New file: permutation check protocol + completeness proof |
| `ArkLib.lean` | Add `PermutationCheck` import (via `update-lib.sh`) |