### PR TITLE
Generalise jointAgreement proximity to linear span over submodule codes

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -98,6 +98,56 @@ theorem jointAgreement_implies_second_proximity {ι : Type} [Fintype ι] [Nonemp
   exact
     (Code.relCloseToCode_iff_relCloseToCodeword_of_minDist (u := W 1) (C := C) (δ := δ)).2 hclose
 
+/-- Generalisation of `jointAgreement_implies_second_proximity` to an arbitrary word stack over a
+submodule code. If a stack `W : Fin k → ι → F` jointly agrees with a submodule `C ⊆ ι → F`, then
+every element of the linear span of the stack is `δ`-close to `C`. The pointwise case
+`W i ∈ C` is the special case `x = W i` (choose coefficients `c` to be the i-th basis vector);
+the original `Fin 2` lemma is the case `k = 2`, `x = W 1`.
+
+The proof bounds the linear combination against the matching linear combination of the agreement
+witnesses: on each agreement column `j ∈ S`, `v i j = W i j` for every `i`, so `∑ cᵢ • vᵢ` and
+`∑ cᵢ • Wᵢ` agree on `S`; `v'` is a codeword by submodule closure; lift via
+`relCloseToCode_iff_relCloseToCodeword_of_minDist`. -/
+theorem jointAgreement_implies_linSpan_proximity {ι : Type} [Fintype ι] [Nonempty ι]
+    {F : Type} [Field F] [DecidableEq F] {k : ℕ}
+    (C : Submodule F (ι → F)) {δ : ℝ≥0} {W : Fin k → ι → F}
+    (h : jointAgreement (C := (C : Set (ι → F))) (δ := δ) (W := W)) :
+    ∀ x ∈ Submodule.span F (Set.range W), δᵣ(x, (C : Set (ι → F))) ≤ δ := by
+  rcases h with ⟨S, hS_card, v, hv⟩
+  intro x hx
+  rw [Submodule.mem_span_range_iff_exists_fun] at hx
+  rcases hx with ⟨c, rfl⟩
+  set v' : ι → F := ∑ i : Fin k, c i • v i with hv'_def
+  have hv'_mem : v' ∈ C := by
+    refine Submodule.sum_mem C (fun i _ => ?_)
+    exact Submodule.smul_mem C (c i) (hv i).1
+  have hagree : ∀ j ∈ S, (∑ i, c i • v i) j = (∑ i, c i • W i) j := by
+    intro j hj
+    simp only [Finset.sum_apply, Pi.smul_apply]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    have h_j_in_filter : j ∈ Finset.filter (fun j => v i j = W i j) Finset.univ :=
+      (hv i).2 hj
+    have : v i j = W i j := by simpa [Finset.mem_filter] using h_j_in_filter
+    rw [this]
+  have hdist : δᵣ(∑ i, c i • W i, v') ≤ δ := by
+    rw [Code.relCloseToWord_iff_exists_agreementCols
+      (u := ∑ i, c i • W i) (v := v') (δ := δ)]
+    refine ⟨S, ?_, ?_⟩
+    · have hS' : (1 - δ) * (Fintype.card ι : ℝ≥0) ≤ (S.card : ℝ≥0) := by
+        simpa [ge_iff_le, mul_comm, mul_left_comm, mul_assoc] using hS_card
+      exact (Code.relDist_floor_bound_iff_complement_bound (n := Fintype.card ι)
+        (upperBound := S.card) (δ := δ)).2 hS'
+    · intro j
+      constructor
+      · intro hj
+        exact (hagree j hj).symm
+      · intro hj_ne hj
+        exact hj_ne (hagree j hj).symm
+  exact
+    (Code.relCloseToCode_iff_relCloseToCodeword_of_minDist
+      (u := ∑ i, c i • W i) (C := (C : Set (ι → F))) (δ := δ)).2
+      ⟨v', hv'_mem, hdist⟩
+
 theorem prob_uniform_congr_equiv {α : Type} [Fintype α] [Nonempty α]
     (e : α ≃ α) (P : α → Prop) :
     Pr_{let x ←$ᵖ α}[P (e x)] = Pr_{let x ←$ᵖ α}[P x] := by


### PR DESCRIPTION
## Summary

Add `jointAgreement_implies_linSpan_proximity` in `ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean` — if a word stack `W : Fin k → ι → F` jointly agrees with a submodule code `C`, every element of `Submodule.span F (Set.range W)` is `δ`-close to `C`.

Generalises the existing `jointAgreement_implies_second_proximity` (the `Fin 2`, single-element case `x = W 1`) to arbitrary word-stack index and arbitrary linear combinations of the stack.

## Proof

For `x = ∑ cᵢ • Wᵢ`, set `v' := ∑ cᵢ • vᵢ` where `v` is the joint-agreement witness (`v i ∈ C`, agreeing with `W i` on agreement set `S`).

- `v' ∈ C` by submodule closure (sum + scalar-mul).
- `x` and `v'` agree pointwise on `S` (since `v i j = W i j` for `j ∈ S`).
- `δᵣ(x, v') ≤ δ` via `relCloseToWord_iff_exists_agreementCols` + `relDist_floor_bound_iff_complement_bound`.
- Lift to `δᵣ(x, C) ≤ δ` via `relCloseToCode_iff_relCloseToCodeword_of_minDist`.

## Downstream use

Section-6 infrastructure for `correlatedAgreement_affine_spaces` (Theorem 1.6, BCIKS20) and `proximity_gap_RSCodes` (Theorem 1.2) closures — every element of an affine span with a `C`-close word stack is itself `C`-close. Direct strengthening of the existing `Fin 2` lemma.