### PR TITLE
fix(BCIKS20): correct H_tilde' coefficient indexing

### DIFF
--- a/ArkLib/Data/Polynomial/RationalFunctions.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions.lean
@@ -83,6 +83,19 @@ noncomputable def H_tilde' (H : F[X][Y]) : F[X][Y] :=
       ∑ i ∈ Finset.range d,
         Polynomial.C (hᵢ i * W ^ (d - 1 - i)) * Polynomial.X ^ i
 
+omit [IsDomain F] in
+/-- If `H` has positive degree in `Y`, then `H_tilde' H` is monic. -/
+lemma H_tilde'_monic (H : F[X][Y]) (hH : 0 < H.natDegree) :
+    (H_tilde' H).Monic := by
+  classical
+  have hdeg : H.natDegree ≠ 0 := Nat.ne_of_gt hH
+  rw [H_tilde', if_neg hdeg]
+  exact Polynomial.monic_X_pow_add <| (Polynomial.degree_sum_le _ _).trans_lt <| by
+    exact (Finset.sup_lt_iff (WithBot.bot_lt_coe H.natDegree)).2 <| by
+      intro i hi
+      exact (Polynomial.degree_C_mul_X_pow_le i _).trans_lt
+        (WithBot.coe_lt_coe.2 (Finset.mem_range.mp hi))
+
 private lemma monicize_term {K : Type} [Field K] (a b : K) (i d : ℕ)
     (ha : a ≠ 0) (hi : i < d) :
     (Polynomial.C a ^ (d - 1)) * (Polynomial.C b * (Polynomial.X / Polynomial.C a) ^ i) =
@@ -284,9 +297,10 @@ noncomputable def π_z {H : F[X][Y]} (z : F) (root : rationalRoot (H_tilde' H) z
     rw [show (Polynomial.evalEvalRingHom z root.1) (H_tilde' H) = 0 from root.2]
     ring)
 
-/-- The canonical representative of an element of `F[X][Y]` inside the ring of regular
-elements `𝒪`. -/
-noncomputable def canonicalRepOf𝒪 {H : F[X][Y]} (β : 𝒪 H) : F[X][Y] :=
+/-- The canonical representative of an element of `F[X][Y]` inside the ring of regular elements
+`𝒪`, defined when `H` has positive degree in `Y`. -/
+noncomputable def canonicalRepOf𝒪 {H : F[X][Y]} (hH : 0 < H.natDegree) (β : 𝒪 H) : F[X][Y] :=
+  let _hHt := H_tilde'_monic H hH
   Polynomial.modByMonic β.out (H_tilde' H)
 
 /-- `Λ` is a weight function on the ring of bivariate polynomials `F[X][Y]`. The weight of
@@ -302,8 +316,8 @@ noncomputable def weight_Λ (f H : F[X][Y]) (D : ℕ) : WithBot ℕ :=
 
 /-- The weight function `Λ` on the ring of regular elements `𝒪` is defined as the weight their
 canonical representatives in `F[X][Y]`. -/
-noncomputable def weight_Λ_over_𝒪 {H : F[X][Y]} (f : 𝒪 H) (D : ℕ) :
-    WithBot ℕ := weight_Λ (canonicalRepOf𝒪 f) H D
+noncomputable def weight_Λ_over_𝒪 {H : F[X][Y]} (hH : 0 < H.natDegree) (f : 𝒪 H) (D : ℕ) :
+    WithBot ℕ := weight_Λ (canonicalRepOf𝒪 hH f) H D
 
 /-- The set `S_β` from the statement of Lemma A.1 in Appendix A of [BCIKS20].
 Note: Here `F[X][Y]` is `F[Z][T]`. -/
@@ -311,8 +325,9 @@ noncomputable def S_β {H : F[X][Y]} (β : 𝒪 H) : Set F :=
   {z : F | ∃ root : rationalRoot (H_tilde' H) z, (π_z z root) β = 0}
 
 /-- The statement of Lemma A.1 in Appendix A.3 of [BCIKS20]. -/
-lemma Lemma_A_1 {H : F[X][Y]} (β : 𝒪 H) (D : ℕ) (hD : D ≥ Bivariate.totalDegree H)
-    (S_β_card : Set.ncard (S_β β) > (weight_Λ_over_𝒪 β D) * H.natDegree) :
+lemma Lemma_A_1 {H : F[X][Y]} (hH : 0 < H.natDegree) (β : 𝒪 H) (D : ℕ)
+    (hD : D ≥ Bivariate.totalDegree H)
+    (S_β_card : Set.ncard (S_β β) > (weight_Λ_over_𝒪 hH β D) * H.natDegree) :
   embeddingOf𝒪Into𝕃 _ β = 0 := by sorry
 
 /-- The embeddining of the coefficients of a bivarite polynomial into the bivariate polynomial ring
@@ -368,8 +383,9 @@ def ξ (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) [φ : Fact (Irreducible H)] : �
 
 /-- The bound of the weight `Λ` of the elements `ζ` as stated in Claim A.2 of Appendix A.4
 of [BCIKS20]. -/
-lemma weight_ξ_bound (x₀ : F) {D : ℕ} (hD : D ≥ Bivariate.totalDegree H) :
-    weight_Λ_over_𝒪 (ξ x₀ R H) D ≤
+lemma weight_ξ_bound (x₀ : F) (hH : 0 < H.natDegree) {D : ℕ}
+    (hD : D ≥ Bivariate.totalDegree H) :
+    weight_Λ_over_𝒪 hH (ξ x₀ R H) D ≤
     WithBot.some ((Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1)) := by
   sorry
 
@@ -377,20 +393,26 @@ lemma weight_ξ_bound (x₀ : F) {D : ℕ} (hD : D ≥ Bivariate.totalDegree H) 
 of Appendix A.4 of [BCIKS20]. -/
 lemma β_regular (R : F[X][X][Y])
                 (H : F[X][Y]) [H_irreducible : Fact (Irreducible H)]
+                (hH : 0 < H.natDegree)
                 {D : ℕ} (hD : D ≥ Bivariate.totalDegree H) :
-    ∀ t : ℕ, ∃ β : 𝒪 H, weight_Λ_over_𝒪 β ≤ (2 * t + 1) * Bivariate.natDegreeY R * D :=
+    ∀ t : ℕ, ∃ β : 𝒪 H,
+      weight_Λ_over_𝒪 hH β D ≤ (2 * t + 1) * Bivariate.natDegreeY R * D :=
   sorry
 
 /-- The definition of the regular elements `β` giving the numerators of the Hensel lift coefficients
 as defined in Claim A.2 of Appendix A.4 of [BCIKS20]. -/
 def β (R : F[X][X][Y]) (t : ℕ) : 𝒪 H :=
-  (β_regular R H (Nat.le_refl _) t).choose
+  if hH : 0 < H.natDegree then
+    (β_regular R H hH (Nat.le_refl _) t).choose
+  else
+    0
 
 /-- The Hensel lift coefficients `α` are of the form as given in Claim A.2 of Appendix A.4
 of [BCIKS20]. -/
 def α (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) [φ : Fact (Irreducible H)] (t : ℕ) : 𝕃 H :=
   let W : 𝕃 H := liftToFunctionField (H.leadingCoeff)
-  embeddingOf𝒪Into𝕃 _ (β R t) / (W ^ (t + 1) * (embeddingOf𝒪Into𝕃 _ (ξ x₀ R H)) ^ (2*t - 1))
+  embeddingOf𝒪Into𝕃 _ (β R t) /
+    (W ^ (t + 1) * (embeddingOf𝒪Into𝕃 _ (ξ x₀ R H)) ^ (2*t - 1))
 
 def α' (x₀ : F) (R : F[X][X][Y]) (H_irreducible : Irreducible H) (t : ℕ) : 𝕃 H :=
   α x₀ R _ (φ := ⟨H_irreducible⟩) t

--- a/ArkLib/Data/Polynomial/RationalFunctions.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions.lean
@@ -73,16 +73,163 @@ noncomputable instance {H : F[X][Y]} [inst : Fact (Irreducible H)] : Field (𝕃
 
 /-- The monisized polynomial `H_tilde` is in fact an element of `F[X][Y]`. -/
 noncomputable def H_tilde' (H : F[X][Y]) : F[X][Y] :=
-  let hᵢ (i : ℕ) := H.coeff i
-  let d := H.natDegree
-  let W := hᵢ d
-  Polynomial.X ^ d +
-    ∑ i ∈ (List.range d).toFinset,
-      Polynomial.X^(d - 1 - i) *
-      Polynomial.C (hᵢ (i + 1) * W ^ i)
+  if H.natDegree = 0 then
+    Polynomial.C (H.coeff 0)
+  else
+    let hᵢ (i : ℕ) := H.coeff i
+    let d := H.natDegree
+    let W := hᵢ d
+    Polynomial.X ^ d +
+      ∑ i ∈ Finset.range d,
+        Polynomial.C (hᵢ i * W ^ (d - 1 - i)) * Polynomial.X ^ i
 
+private lemma monicize_term {K : Type} [Field K] (a b : K) (i d : ℕ)
+    (ha : a ≠ 0) (hi : i < d) :
+    (Polynomial.C a ^ (d - 1)) * (Polynomial.C b * (Polynomial.X / Polynomial.C a) ^ i) =
+      Polynomial.C (b * a ^ (d - 1 - i)) * Polynomial.X ^ i := by
+  rw [Polynomial.div_C, mul_pow]
+  rw [show Polynomial.C a ^ (d - 1) = Polynomial.C (a ^ (d - 1)) by rw [Polynomial.C_pow]]
+  rw [show Polynomial.C a⁻¹ ^ i = Polynomial.C (a⁻¹ ^ i) by rw [Polynomial.C_pow]]
+  have hscalar : a ^ (d - 1) * b * a⁻¹ ^ i = b * a ^ (d - 1 - i) := by
+    have hsplit : d - 1 = (d - 1 - i) + i := by omega
+    rw [hsplit, pow_add, inv_pow]
+    field_simp [ha]
+    have hexp : d - 1 - i + i - i = d - 1 - i := by omega
+    rw [hexp]
+    ring_nf
+  have hscalar' : a ^ (d - 1) * (b * a⁻¹ ^ i) = b * a ^ (d - 1 - i) := by
+    simpa [mul_assoc] using hscalar
+  calc
+    Polynomial.C (a ^ (d - 1)) * (Polynomial.C b * (Polynomial.X ^ i * Polynomial.C (a⁻¹ ^ i))) =
+        Polynomial.X ^ i * Polynomial.C (a ^ (d - 1) * (b * a⁻¹ ^ i)) := by
+          calc
+            Polynomial.C (a ^ (d - 1)) *
+                (Polynomial.C b * (Polynomial.X ^ i * Polynomial.C (a⁻¹ ^ i))) =
+                Polynomial.X ^ i *
+                  (Polynomial.C (a ^ (d - 1)) * Polynomial.C b * Polynomial.C (a⁻¹ ^ i)) := by
+                    ring
+            _ = Polynomial.X ^ i * Polynomial.C (a ^ (d - 1) * (b * a⁻¹ ^ i)) := by
+                  rw [← Polynomial.C_mul, ← Polynomial.C_mul]
+                  simp [mul_assoc]
+    _ = Polynomial.X ^ i * Polynomial.C (b * a ^ (d - 1 - i)) := by rw [hscalar']
+    _ = Polynomial.C (b * a ^ (d - 1 - i)) * Polynomial.X ^ i := by rw [mul_comm]
+
+private lemma monicize_leading_term {K : Type} [Field K] (a : K) (d : ℕ)
+    (ha : a ≠ 0) (hd : 0 < d) :
+    (Polynomial.C a ^ (d - 1)) * (Polynomial.C a * (Polynomial.X / Polynomial.C a) ^ d) =
+      Polynomial.X ^ d := by
+  rw [Polynomial.div_C, mul_pow]
+  rw [show Polynomial.C a ^ (d - 1) = Polynomial.C (a ^ (d - 1)) by rw [Polynomial.C_pow]]
+  rw [show Polynomial.C a⁻¹ ^ d = Polynomial.C (a⁻¹ ^ d) by rw [Polynomial.C_pow]]
+  have hscalar : a ^ (d - 1) * a * a⁻¹ ^ d = (1 : K) := by
+    have hd' : d = (d - 1) + 1 := by omega
+    rw [hd', pow_add, pow_one, inv_pow]
+    field_simp [ha]
+    have hexp : d - 1 + 1 - 1 = d - 1 := by omega
+    rw [hexp]
+  have hscalar' : a ^ (d - 1) * (a * a⁻¹ ^ d) = (1 : K) := by
+    simpa [mul_assoc] using hscalar
+  calc
+    Polynomial.C (a ^ (d - 1)) * (Polynomial.C a * (Polynomial.X ^ d * Polynomial.C (a⁻¹ ^ d))) =
+        Polynomial.X ^ d * Polynomial.C (a ^ (d - 1) * (a * a⁻¹ ^ d)) := by
+          calc
+            Polynomial.C (a ^ (d - 1)) *
+                (Polynomial.C a * (Polynomial.X ^ d * Polynomial.C (a⁻¹ ^ d))) =
+                Polynomial.X ^ d *
+                  (Polynomial.C (a ^ (d - 1)) * Polynomial.C a * Polynomial.C (a⁻¹ ^ d)) := by
+                    ring
+            _ = Polynomial.X ^ d * Polynomial.C (a ^ (d - 1) * (a * a⁻¹ ^ d)) := by
+                  rw [← Polynomial.C_mul, ← Polynomial.C_mul]
+                  simp [mul_assoc]
+    _ = Polynomial.X ^ d * Polynomial.C (1 : K) := by rw [hscalar']
+    _ = Polynomial.X ^ d := by simp
+
+/-- The polynomial `H_tilde'` agrees with the monicization `H_tilde` after embedding into
+`Polynomial (RatFunc F)`. -/
 lemma H_tilde_equiv_H_tilde' (H : F[X][Y]) : (H_tilde' H).map univPolyHom = H_tilde H := by
-  sorry
+  classical
+  by_cases hdeg : H.natDegree = 0
+  · simp only [H_tilde', hdeg, ↓reduceIte, map_C]
+    have hconst : H = Polynomial.C (H.coeff 0) := Polynomial.eq_C_of_natDegree_le_zero (by omega)
+    rw [hconst, H_tilde]
+    simp
+  · have hH_ne : H ≠ 0 := by
+      intro hzero
+      apply hdeg
+      simp [hzero]
+    have hw_ne_zero : univPolyHom H.leadingCoeff ≠ 0 := by
+      apply IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors
+      rw [mem_nonZeroDivisors_iff_ne_zero]
+      exact Polynomial.leadingCoeff_ne_zero.mpr hH_ne
+    have hd : 0 < H.natDegree := Nat.pos_of_ne_zero hdeg
+    have hEval :
+        Polynomial.eval₂ (RingHom.comp Polynomial.C univPolyHom)
+          (Polynomial.X /
+            (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree)) H =
+        ∑ i ∈ Finset.range (H.natDegree + 1),
+          Polynomial.C (univPolyHom (H.coeff i)) *
+            (Polynomial.X /
+              (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree)) ^ i := by
+      simpa using
+        (Polynomial.eval₂_eq_sum_range
+          (p := H) (f := RingHom.comp Polynomial.C univPolyHom)
+          (x := Polynomial.X /
+            (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree)))
+    simp only [H_tilde', hdeg, ↓reduceIte, coeff_natDegree, map_mul, map_pow,
+      Polynomial.map_add, Polynomial.map_pow, map_X]
+    rw [H_tilde, hEval, Finset.sum_range_succ, mul_add, Finset.mul_sum, Polynomial.map_sum]
+    have hsum :
+        ∑ i ∈ Finset.range H.natDegree,
+          ((RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree) ^
+              (H.natDegree - 1)) *
+            (Polynomial.C (univPolyHom (H.coeff i)) *
+              (Polynomial.X /
+                (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree)) ^ i) =
+        ∑ i ∈ Finset.range H.natDegree,
+          Polynomial.map univPolyHom
+            (Polynomial.C (H.coeff i) * Polynomial.C H.leadingCoeff ^ (H.natDegree - 1 - i) *
+              Polynomial.X ^ i) := by
+      refine Finset.sum_congr rfl ?_
+      intro i hi
+      simpa [Polynomial.coeff_natDegree, map_mul, map_pow] using
+        monicize_term (univPolyHom H.leadingCoeff) (univPolyHom (H.coeff i)) i H.natDegree
+          hw_ne_zero (Finset.mem_range.mp hi)
+    have hlead :
+        ((RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree) ^
+            (H.natDegree - 1)) *
+          (Polynomial.C (univPolyHom (H.coeff H.natDegree)) *
+            (Polynomial.X /
+              (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree)) ^
+              H.natDegree) =
+        Polynomial.X ^ H.natDegree := by
+      simpa [Polynomial.coeff_natDegree] using
+        monicize_leading_term (univPolyHom H.leadingCoeff) H.natDegree hw_ne_zero hd
+    rw [hlead]
+    calc
+      Polynomial.X ^ H.natDegree +
+          ∑ i ∈ Finset.range H.natDegree,
+            Polynomial.map univPolyHom
+              (Polynomial.C (H.coeff i) * Polynomial.C H.leadingCoeff ^ (H.natDegree - 1 - i) *
+                Polynomial.X ^ i) =
+          Polynomial.X ^ H.natDegree +
+            ∑ i ∈ Finset.range H.natDegree,
+              (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree) ^
+                  (H.natDegree - 1) *
+                (Polynomial.C (univPolyHom (H.coeff i)) *
+                  (Polynomial.X /
+                    (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree)) ^
+                    i) := by
+              exact congrArg (fun p => Polynomial.X ^ H.natDegree + p) hsum.symm
+      _ =
+          ∑ i ∈ Finset.range H.natDegree,
+            (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree) ^
+                (H.natDegree - 1) *
+              (Polynomial.C (univPolyHom (H.coeff i)) *
+                (Polynomial.X /
+                  (RingHom.comp Polynomial.C univPolyHom) ((fun i => H.coeff i) H.natDegree)) ^
+                  i) +
+            Polynomial.X ^ H.natDegree := by
+              rw [add_comm]
 
 
 /-- The ring of regular elements `𝒪` from Appendix A.1 of [BCIKS20]. -/


### PR DESCRIPTION
## Summary

Fix `H_tilde'` in `ArkLib/Data/Polynomial/RationalFunctions.lean` so that it matches the monicization defined by `H_tilde`.

- correct the coefficient formula in `H_tilde'`
- fix the `natDegree = 0` case, which should return `Polynomial.C (H.coeff 0)`
- prove `H_tilde_equiv_H_tilde'` for the corrected definition

On the counterexample from #438, for `H = h₀ + h₁Y + h₂Y²`, the old `H_tilde'` gives constant term `h₂²`, while the corrected definition gives `h₀ * h₂`, matching `H_tilde`.

Closes #438.
