### PR TITLE
fix(proximity-gap): sample affine spaces uniformly

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -22,7 +22,6 @@ section CoreResults
 variable {ι : Type} [Fintype ι] [Nonempty ι] [DecidableEq ι]
 variable {F : Type} [Field F] [Fintype F] [DecidableEq F]
 
-omit [DecidableEq ι] in
 /-- Theorem 1.6 (Correlated agreement over affine spaces) in [BCIKS20].
 
 Take a Reed-Solomon code of length `ι` and degree `deg`, a proximity-error parameter

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ReedSolomonGap.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ReedSolomonGap.lean
@@ -224,7 +224,7 @@ theorem proximity_gap_RSCodes {k t : ℕ} [NeZero k] [NeZero t] {deg : ℕ} {dom
       -- Apply Thm 1.6 at k := m + 1 to get jointAgreement (W := u').
       have hja_u' : jointAgreement (C := (ReedSolomon.code domain deg : Set (ι → F)))
           (δ := δ) (W := u') :=
-        correlatedAgreement_affine_spaces (k := m + 1) (u := u') hδ u' hPr_aff
+        correlatedAgreement_affine_spaces (k := m + 1) hδ u' hPr_aff
       -- Convert jointAgreement (W := u') → jointAgreement (W := C i).
       -- Witnesses: v_0 for C i 0 stays, v_{j+1} + v_0 ∈ RS.code (submodule closure)
       -- agrees with C i (j+1) on S because v_{j+1} agrees with u'(j+1) = C i (j+1) - C i 0

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ReedSolomonGap.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ReedSolomonGap.lean
@@ -60,7 +60,7 @@ theorem proximity_gap_RSCodes {k t : ℕ} [NeZero k] [NeZero t] {deg : ℕ} {dom
       exact_mod_cast hε
     exact (not_lt_of_ge hcase) hε_lt_one_ENN
   · -- Left Xor' branch: `Pr = 1 ∧ ¬(Pr ≤ ε)`.
-    push_neg at hcase
+    push Not at hcase
     refine Or.inl ⟨?_, not_le.mpr hcase⟩
     -- Goal: `Pr = 1`. Suffices every point of `S` is δ-close to the RS code.
     suffices h_all : ∀ x : ↥S,
@@ -114,7 +114,7 @@ theorem proximity_gap_RSCodes {k t : ℕ} [NeZero k] [NeZero t] {deg : ℕ} {dom
       have hCi0_close :
           δᵣ(C i 0, (ReedSolomon.code domain deg : Set (ι → F))) ≤ δ := by
         by_contra hnotclose
-        push_neg at hnotclose
+        push Not at hnotclose
         -- All elements of S equal C i 0, which is NOT δ-close, so Pr = 0.
         have hPr_eq :
             Pr_{let x ← $ᵖ S}[δᵣ(x.val, (ReedSolomon.toFinset domain deg)) ≤ δ] = 0 := by

--- a/ArkLib/Data/CodingTheory/ProximityGap/Basic.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Basic.lean
@@ -145,12 +145,17 @@ noncomputable def δ_ε_correlatedAgreementCurves {k : ℕ}
 For `k+1` words `u₀, u₁, ..., uₖ ∈ A^ι` let `U = u₀ + span{u₁, ..., uₖ} ⊂ A^ι` be an affine subspace
 (note that `span` here means linear span, so this formulation is not same as the default
 affine span/affine hull). If the probability that a random point in `U` is `δ`-close to `C`
-exceeds `ε`, then the words `u₀, u₁, ..., uₖ` have correlated agreement. -/
+exceeds `ε`, then the words `u₀, u₁, ..., uₖ` have correlated agreement.
+
+This samples uniformly from the generated affine subspace. An equivalent coefficient-sampling
+formulation would sample `r : Fin k → F` and test `u₀ + ∑ i, r i • uᵢ₊₁`; proving that
+equivalence requires showing the coefficient map has constant-size fibers. -/
 noncomputable def δ_ε_correlatedAgreementAffineSpaces
     {A : Type 0} [AddCommGroup A] [Module F A] [Fintype A] [DecidableEq A]
     (C : Set (ι → A)) (δ ε : ℝ≥0) : Prop :=
     ∀ (u : WordStack (A := A) (κ := Fin (k + 1)) (ι := ι)),
-    Pr_{let r ← $ᵖ (Fin k → F)}[ δᵣ(u 0 + ∑ i : Fin k, r i • u i.succ, C) ≤ δ ] > ε →
+    Pr_{let y ← $ᵖ ↥(Affine.affineSubspaceAtOrigin (F := F) (u 0) (Fin.tail u))}[
+      δᵣ(y.1, C) ≤ δ] > ε →
     jointAgreement (F := A) (κ := Fin (k + 1)) (ι := ι) (C := C) (W := u) (δ := δ)
 
 end CoreSecurityDefinitions


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5.5) on behalf of the user (Quang Dao) with approval.

## Summary
- Align affine-space correlated agreement with its docstring by sampling uniformly from the generated affine subspace.
- Update the Reed-Solomon proximity gap proof to pass the existing affine-subspace probability bridge directly.
- Remove a stale `omit [DecidableEq ι]` that no longer applies after the definition mentions affine subspaces.

## Test plan
- `lake build ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.ReedSolomonGap`
- `lake build ArkLib` passed locally before the final docstring-only note.

Made with [Cursor](https://cursor.com)