### PR TITLE
Fix knowledge base audit references

### DIFF
--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -64,7 +64,7 @@ The BibTeX key is the canonical identifier for a paper across:
 
 If a paper is cited in Lean as `[KEY]`, the preferred landing page for it is:
 
-- [`papers/KEY.md`](papers/README.md)
+- `docs/kb/papers/KEY.md`
 
 ## Content Types
 

--- a/docs/kb/audits/open-problems-list-decoding-and-correlated-agreement.md
+++ b/docs/kb/audits/open-problems-list-decoding-and-correlated-agreement.md
@@ -1,7 +1,7 @@
-# Paper Audit: `paper.pdf`
+# Paper Audit: Open Problems in List Decoding and Correlated Agreement
 
-This page records a paper-to-ArkLib audit for the local source `paper.pdf`,
-*Open Problems in List Decoding and Correlated Agreement* (dated April 8, 2026).
+This page records a paper-to-ArkLib audit for *Open Problems in List Decoding and Correlated
+Agreement* (dated April 8, 2026).
 
 The goal is to list the paper's named formal items and check whether each one is already present in
 ArkLib, missing, or present in a materially different form.

--- a/docs/kb/index.md
+++ b/docs/kb/index.md
@@ -43,7 +43,8 @@ used in `ArkLib/**/*.lean`, including:
 - [`audits/README.md`](audits/README.md) - audit conventions and migration notes for paper-to-code
   comparison pages.
 - [`audits/open-problems-list-decoding-and-correlated-agreement.md`](audits/open-problems-list-decoding-and-correlated-agreement.md)
-  - detailed paper-to-ArkLib matrix for `paper.pdf`.
+  - detailed paper-to-ArkLib matrix for *Open Problems in List Decoding and Correlated Agreement*
+    (dated April 8, 2026).
 
 ## Query Pages
 

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -16,8 +16,8 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
 - [`knowledge-base.md`](knowledge-base.md) - when to use `docs/kb/` and how it relates to the
   agent wiki and bibliography.
 - [`../kb/audits/open-problems-list-decoding-and-correlated-agreement.md`](../kb/audits/open-problems-list-decoding-and-correlated-agreement.md)
-  - paper-to-ArkLib matrix for `paper.pdf`, with status labels, Lean references, and a follow-up
-    roadmap.
+  - paper-to-ArkLib matrix for *Open Problems in List Decoding and Correlated Agreement*, with
+    status labels, Lean references, and a follow-up roadmap.
 
 ## Maintenance Contract
 


### PR DESCRIPTION
Posted by the assistant on behalf of Quang Dao. AI-authored using GPT-5.

## Summary

- Replace the placeholder `paper.pdf` audit label with the paper title/date in KB navigation.
- Make the cited-paper landing page reference explicit instead of linking `papers/KEY.md` to `papers/README.md`.

## Validation

- `python3 ./scripts/check-docs-integrity.py`
- `python3 ./scripts/kb/lint.py --strict-cited-pages`
- `python3 ./scripts/kb/check_generated.py`