### PR TITLE
feat(BCIKS20): add regular weight and function-field lemmas

### DIFF
--- a/ArkLib/Data/Polynomial/RationalFunctions.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions.lean
@@ -379,10 +379,39 @@ noncomputable def weight_Λ (f H : F[X][Y]) (D : ℕ) : WithBot ℕ :=
       WithBot.some <| deg * (D + 1 - Bivariate.natDegreeY H) + (f.coeff deg).natDegree
     )
 
+omit [IsDomain F] in
+/-- The zero polynomial has bottom `Λ`-weight. -/
+@[simp]
+lemma weight_Λ_zero (H : F[X][Y]) (D : ℕ) :
+    weight_Λ (0 : F[X][Y]) H D = ⊥ := by
+  simp [weight_Λ]
+
 /-- The weight function `Λ` on the ring of regular elements `𝒪` is defined as the weight their
 canonical representatives in `F[X][Y]`. -/
 noncomputable def weight_Λ_over_𝒪 {H : F[X][Y]} (hH : 0 < H.natDegree) (f : 𝒪 H) (D : ℕ) :
     WithBot ℕ := weight_Λ (canonicalRepOf𝒪 hH f) H D
+
+omit [IsDomain F] in
+/-- The `𝒪`-weight of zero is bottom. -/
+@[simp]
+lemma weight_Λ_over_𝒪_zero {H : F[X][Y]} (hH : 0 < H.natDegree) (D : ℕ) :
+    weight_Λ_over_𝒪 hH (0 : 𝒪 H) D = ⊥ := by
+  simp [weight_Λ_over_𝒪]
+
+omit [IsDomain F] in
+/-- The `𝒪`-weight of a quotient constructor is computed on its canonical remainder. -/
+lemma weight_Λ_over_𝒪_mk {H : F[X][Y]} (hH : 0 < H.natDegree) (p : F[X][Y])
+    (D : ℕ) :
+    weight_Λ_over_𝒪 hH (Ideal.Quotient.mk (Ideal.span {H_tilde' H}) p : 𝒪 H) D =
+      weight_Λ (p %ₘ H_tilde' H) H D := by
+  simp [weight_Λ_over_𝒪, canonicalRepOf𝒪_mk]
+
+/-- If a representative is already reduced, its `𝒪`-weight is its polynomial `Λ`-weight. -/
+lemma weight_Λ_over_𝒪_mk_eq_self_of_degree_lt {H : F[X][Y]} (hH : 0 < H.natDegree)
+    {p : F[X][Y]} (hp : p.degree < (H_tilde' H).degree) (D : ℕ) :
+    weight_Λ_over_𝒪 hH (Ideal.Quotient.mk (Ideal.span {H_tilde' H}) p : 𝒪 H) D =
+      weight_Λ p H D := by
+  simp [weight_Λ_over_𝒪, canonicalRepOf𝒪_mk_eq_self_of_degree_lt hH hp]
 
 /-- The set `S_β` from the statement of Lemma A.1 in Appendix A of [BCIKS20].
 Note: Here `F[X][Y]` is `F[Z][T]`. -/

--- a/ArkLib/Data/Polynomial/RationalFunctions.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions.lean
@@ -276,6 +276,52 @@ as Type. -/
 def regularElms (H : F[X][Y]) : Type :=
   {a : 𝕃 H // ∃ b : 𝒪 H, a = embeddingOf𝒪Into𝕃 _ b}
 
+/-- Zero is regular. -/
+@[simp]
+lemma regularElms_set_zero (H : F[X][Y]) : (0 : 𝕃 H) ∈ regularElms_set H :=
+  ⟨0, by simp⟩
+
+/-- One is regular. -/
+@[simp]
+lemma regularElms_set_one (H : F[X][Y]) : (1 : 𝕃 H) ∈ regularElms_set H :=
+  ⟨1, by simp⟩
+
+/-- The regular elements are closed under addition. -/
+lemma regularElms_set_add {H : F[X][Y]} {a b : 𝕃 H}
+    (ha : a ∈ regularElms_set H) (hb : b ∈ regularElms_set H) :
+    a + b ∈ regularElms_set H := by
+  rcases ha with ⟨a', rfl⟩
+  rcases hb with ⟨b', rfl⟩
+  exact ⟨a' + b', by simp⟩
+
+/-- The regular elements are closed under negation. -/
+lemma regularElms_set_neg {H : F[X][Y]} {a : 𝕃 H}
+    (ha : a ∈ regularElms_set H) : -a ∈ regularElms_set H := by
+  rcases ha with ⟨a', rfl⟩
+  exact ⟨-a', by simp⟩
+
+/-- The regular elements are closed under subtraction. -/
+lemma regularElms_set_sub {H : F[X][Y]} {a b : 𝕃 H}
+    (ha : a ∈ regularElms_set H) (hb : b ∈ regularElms_set H) :
+    a - b ∈ regularElms_set H := by
+  simpa [sub_eq_add_neg] using regularElms_set_add ha (regularElms_set_neg hb)
+
+/-- The regular elements are closed under multiplication. -/
+lemma regularElms_set_mul {H : F[X][Y]} {a b : 𝕃 H}
+    (ha : a ∈ regularElms_set H) (hb : b ∈ regularElms_set H) :
+    a * b ∈ regularElms_set H := by
+  rcases ha with ⟨a', rfl⟩
+  rcases hb with ⟨b', rfl⟩
+  exact ⟨a' * b', by simp⟩
+
+/-- The regular elements are closed under natural powers. -/
+lemma regularElms_set_pow {H : F[X][Y]} {a : 𝕃 H}
+    (ha : a ∈ regularElms_set H) (n : ℕ) : a ^ n ∈ regularElms_set H := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      simpa [pow_succ] using regularElms_set_mul ih ha
+
 /-- Given an element `z ∈ F`, `t_z ∈ F` is a rational root of a bivariate polynomial if the pair
 `(z, t_z)` is a root of the bivariate polynomial. -/
 def rationalRoot (H : F[X][Y]) (z : F) : Type :=
@@ -436,6 +482,55 @@ noncomputable def liftToFunctionField {H : F[X][Y]} : F[X] →+* 𝕃 H :=
 noncomputable def liftBivariate {H : F[X][Y]} : F[X][Y] →+* 𝕃 H :=
   RingHom.comp (Ideal.Quotient.mk (Ideal.span {H_tilde H})) bivPolyHom
 
+/-- The image of the polynomial variable `T` in the function field `𝕃 H`. -/
+noncomputable def functionFieldT {H : F[X][Y]} : 𝕃 H :=
+  Ideal.Quotient.mk (Ideal.span {H_tilde H}) Polynomial.X
+
+/-- Quotient constructors in `𝒪` embed by applying the bivariate lift. -/
+@[simp]
+lemma embeddingOf𝒪Into𝕃_mk (H : F[X][Y]) (p : F[X][Y]) :
+    embeddingOf𝒪Into𝕃 H (Ideal.Quotient.mk (Ideal.span {H_tilde' H}) p : 𝒪 H) =
+      liftBivariate (H := H) p := by
+  rfl
+
+/-- Every bivariate polynomial representative gives a regular element of the function field. -/
+lemma regular_liftBivariate (H : F[X][Y]) (p : F[X][Y]) :
+    ∃ pre : 𝒪 H, embeddingOf𝒪Into𝕃 H pre = liftBivariate (H := H) p :=
+  ⟨Ideal.Quotient.mk (Ideal.span {H_tilde' H}) p, by simp⟩
+
+/-- Bivariate-polynomial images are regular elements of the function field. -/
+lemma regularElms_set_liftBivariate (H : F[X][Y]) (p : F[X][Y]) :
+    liftBivariate (H := H) p ∈ regularElms_set H := by
+  rcases regular_liftBivariate H p with ⟨pre, hpre⟩
+  exact ⟨pre, hpre.symm⟩
+
+/-- Coefficients embedded into `𝕃` are regular elements. -/
+lemma regular_liftToFunctionField (H : F[X][Y]) (p : F[X]) :
+    ∃ pre : 𝒪 H, embeddingOf𝒪Into𝕃 H pre = liftToFunctionField (H := H) p :=
+  regular_liftBivariate H (Polynomial.C p)
+
+/-- Coefficient-polynomial images are regular elements of the function field. -/
+lemma regularElms_set_liftToFunctionField (H : F[X][Y]) (p : F[X]) :
+    liftToFunctionField (H := H) p ∈ regularElms_set H := by
+  simpa using regularElms_set_liftBivariate H (Polynomial.C p)
+
+/-- The bivariate variable maps to the function-field variable `T`. -/
+@[simp]
+lemma liftBivariate_X {H : F[X][Y]} :
+    liftBivariate (H := H) (Polynomial.X : F[X][Y]) = functionFieldT (H := H) := by
+  simp [liftBivariate, functionFieldT, bivPolyHom]
+
+/-- The function-field variable `T` is regular. -/
+lemma regularElms_set_functionFieldT (H : F[X][Y]) :
+    functionFieldT (H := H) ∈ regularElms_set H := by
+  simpa using regularElms_set_liftBivariate H (Polynomial.X : F[X][Y])
+
+/-- Constant bivariate polynomials map through the coefficient embedding. -/
+@[simp]
+lemma liftBivariate_C {H : F[X][Y]} (p : F[X]) :
+    liftBivariate (H := H) (Polynomial.C p : F[X][Y]) = liftToFunctionField (H := H) p := by
+  rfl
+
 /-- The embeddining of the scalars into the function field `𝕃`. -/
 noncomputable def fieldTo𝕃 {H : F[X][Y]} : F →+* 𝕃 H :=
   RingHom.comp liftToFunctionField Polynomial.C
@@ -458,9 +553,33 @@ variable {F : Type} [CommRing F] [IsDomain F]
 /-- The definition of `ζ` given in Appendix A.4 of [BCIKS20]. -/
 def ζ (R : F[X][X][Y]) (x₀ : F) (H : F[X][Y]) [H_irreducible : Fact (Irreducible H)] : 𝕃 H :=
   let W  : 𝕃 H := liftToFunctionField (H.leadingCoeff);
-  let T : 𝕃 H := liftToFunctionField (Polynomial.X);
+  let T : 𝕃 H := functionFieldT (H := H);
     Polynomial.eval₂ liftToFunctionField (T / W)
       (Bivariate.evalX (Polynomial.C x₀) R.derivative)
+
+/-- If the derivative specialization is constant in the function-field variable, then `ζ` is
+regular. -/
+lemma ζ_regular_of_derivative_evalX_eq_C (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
+    [H_irreducible : Fact (Irreducible H)] {p : F[X]}
+    (hp : Bivariate.evalX (Polynomial.C x₀) R.derivative = Polynomial.C p) :
+    ζ R x₀ H ∈ regularElms_set H := by
+  rw [ζ, hp]
+  simp only [Polynomial.eval₂_C]
+  exact regularElms_set_liftToFunctionField H p
+
+/-- In the constant-derivative, low-`Y`-degree case, the `ξ` regularity witness is explicit. -/
+lemma ξ_regular_of_derivative_evalX_eq_C_of_natDegree_le_one
+    (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) [H_irreducible : Fact (Irreducible H)]
+    {p : F[X]} (hp : Bivariate.evalX (Polynomial.C x₀) R.derivative = Polynomial.C p)
+    (hR : R.natDegree ≤ 1) :
+    ∃ pre : 𝒪 H,
+    let d := R.natDegree
+    let W : 𝕃 H := liftToFunctionField (H.leadingCoeff);
+    embeddingOf𝒪Into𝕃 _ pre = W ^ (d - 2) * ζ R x₀ H := by
+  rcases ζ_regular_of_derivative_evalX_eq_C x₀ R H hp with ⟨pre, hpre⟩
+  refine ⟨pre, ?_⟩
+  have hd : R.natDegree - 2 = 0 := by omega
+  simpa [hd] using hpre.symm
 
 /-- There exist regular elements `ξ = W(Z)^(d-2) * ζ` as defined in Claim A.2 of Appendix A.4
 of [BCIKS20]. -/

--- a/docs/kb/audits/README.md
+++ b/docs/kb/audits/README.md
@@ -13,5 +13,7 @@ The long-term goal is for deep paper audits to live here rather than in ad hoc b
 
 Current audit pages:
 
+- [`bciks20-appendix-a-rational-functions.md`](bciks20-appendix-a-rational-functions.md)
+  - Appendix A rational-function and Hensel-lifting status for `BCIKS20`.
 - [`open-problems-list-decoding-and-correlated-agreement.md`](open-problems-list-decoding-and-correlated-agreement.md)
   - theorem/status matrix for `paper.pdf`.

--- a/docs/kb/audits/bciks20-appendix-a-rational-functions.md
+++ b/docs/kb/audits/bciks20-appendix-a-rational-functions.md
@@ -1,0 +1,49 @@
+# Paper Audit: BCIKS20 Appendix A Rational Functions
+
+This page tracks the local ArkLib status of Appendix A of `BCIKS20`, which supplies the
+rational-function and Hensel-lifting machinery used by the list-decoding branch of the
+Reed-Solomon proximity-gap formalization.
+
+## Scope
+
+The relevant Lean surface is
+[`ArkLib/Data/Polynomial/RationalFunctions.lean`](../../../ArkLib/Data/Polynomial/RationalFunctions.lean).
+Downstream users include the BCIKS20 list-decoding agreement files under
+[`ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/`](../../../ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding).
+
+## Status Legend
+
+- `present`: the item is formalized without a local `sorry`.
+- `present-but-incomplete`: the declaration exists but still has a local `sorry`.
+- `infrastructure`: supporting API is present, but it is not itself a paper theorem.
+- `missing`: no close declaration was found.
+
+## Appendix A Matrix
+
+| Paper item | Status | Lean refs | Notes |
+| --- | --- | --- | --- |
+| Monicization `H_tilde` over `F(Z)[T]` | present | `H_tilde` | Defines the function-field-side monicization. |
+| Polynomial representative `H_tilde'` over `F[Z][T]` | present | `H_tilde'` | The coefficient indexing and zero-degree branch were corrected in #470. |
+| Agreement between `H_tilde'` and `H_tilde` | present | `H_tilde_equiv_H_tilde'` | Proved after the corrected definition. |
+| Positive-degree monicity of `H_tilde'` | present | `H_tilde'_monic` | Explicitly requires `0 < H.natDegree`, matching the `modByMonic` API. |
+| Regular ring `𝒪` and function field `𝕃` | infrastructure | `𝒪`, `𝕃`, `embeddingOf𝒪Into𝕃` | Gives the quotient rings and the embedding used by Appendix A. |
+| Canonical representatives in `𝒪` | infrastructure | `canonicalRepOf𝒪`, `mk_canonicalRepOf𝒪`, `canonicalRepOf𝒪_degree_lt`, `canonicalRepOf𝒪_natDegree_le` | The representative API is now explicit about positive `Y`-degree. |
+| `Λ`-weight on regular elements | infrastructure | `weight_Λ`, `weight_Λ_over_𝒪` | Basic zero and constructor/reduced-representative lemmas exist; more algebraic weight lemmas are still useful. |
+| Lemma A.1 | present-but-incomplete | `Lemma_A_1` | Main regular-function vanishing criterion remains open. |
+| Claim A.2 regularity of `ξ` | present-but-incomplete | `ClaimA2.ξ_regular` | The regularity proof remains open. |
+| Claim A.2 bound for `ξ` | present-but-incomplete | `ClaimA2.weight_ξ_bound` | Depends on stronger `Λ`-weight calculus. |
+| Claim A.2 regular numerator elements `β` | present-but-incomplete | `ClaimA2.β_regular` | Depends on the Hensel-lift and weight-bound layer. |
+| Hensel-lift coefficients `α`, `γ` | present | `ClaimA2.α`, `ClaimA2.α'`, `ClaimA2.γ`, `ClaimA2.γ'` | The definitions exist and are consumed by the list-decoding agreement file. |
+
+## Near-Term Work
+
+The next useful proof work is not to restate all of Appendix A at once. It is to add small reusable
+facts around canonical representatives and `Λ`-weights:
+
+- zero and constructor simplification for `weight_Λ_over_𝒪`;
+- weight bounds for constants and monomials;
+- weight behavior under addition and multiplication by powers of `X`;
+- reduced-representative rewrites that avoid unfolding quotient representatives manually.
+
+These lemmas should make `ClaimA2.weight_ξ_bound` and `β_regular` more approachable while keeping
+each PR reviewable.

--- a/docs/kb/audits/bciks20-appendix-a-rational-functions.md
+++ b/docs/kb/audits/bciks20-appendix-a-rational-functions.md
@@ -26,11 +26,11 @@ Downstream users include the BCIKS20 list-decoding agreement files under
 | Polynomial representative `H_tilde'` over `F[Z][T]` | present | `H_tilde'` | The coefficient indexing and zero-degree branch were corrected in #470. |
 | Agreement between `H_tilde'` and `H_tilde` | present | `H_tilde_equiv_H_tilde'` | Proved after the corrected definition. |
 | Positive-degree monicity of `H_tilde'` | present | `H_tilde'_monic` | Explicitly requires `0 < H.natDegree`, matching the `modByMonic` API. |
-| Regular ring `𝒪` and function field `𝕃` | infrastructure | `𝒪`, `𝕃`, `embeddingOf𝒪Into𝕃` | Gives the quotient rings and the embedding used by Appendix A. |
+| Regular ring `𝒪` and function field `𝕃` | infrastructure | `𝒪`, `𝕃`, `functionFieldT`, `embeddingOf𝒪Into𝕃` | Gives the quotient rings, the function-field `T` variable, and the embedding used by Appendix A. |
 | Canonical representatives in `𝒪` | infrastructure | `canonicalRepOf𝒪`, `mk_canonicalRepOf𝒪`, `canonicalRepOf𝒪_degree_lt`, `canonicalRepOf𝒪_natDegree_le` | The representative API is now explicit about positive `Y`-degree. |
 | `Λ`-weight on regular elements | infrastructure | `weight_Λ`, `weight_Λ_over_𝒪` | Basic zero and constructor/reduced-representative lemmas exist; more algebraic weight lemmas are still useful. |
 | Lemma A.1 | present-but-incomplete | `Lemma_A_1` | Main regular-function vanishing criterion remains open. |
-| Claim A.2 regularity of `ξ` | present-but-incomplete | `ClaimA2.ξ_regular` | The regularity proof remains open. |
+| Claim A.2 regularity of `ξ` | present-but-incomplete | `ClaimA2.ξ_regular`, `ClaimA2.ζ_regular_of_derivative_evalX_eq_C`, `ClaimA2.ξ_regular_of_derivative_evalX_eq_C_of_natDegree_le_one` | The full regularity proof remains open, but the `ζ` substitution now uses the function-field `T` variable and the constant-derivative low-degree case has a concrete witness. |
 | Claim A.2 bound for `ξ` | present-but-incomplete | `ClaimA2.weight_ξ_bound` | Depends on stronger `Λ`-weight calculus. |
 | Claim A.2 regular numerator elements `β` | present-but-incomplete | `ClaimA2.β_regular` | Depends on the Hensel-lift and weight-bound layer. |
 | Hensel-lift coefficients `α`, `γ` | present | `ClaimA2.α`, `ClaimA2.α'`, `ClaimA2.γ`, `ClaimA2.γ'` | The definitions exist and are consumed by the list-decoding agreement file. |
@@ -38,9 +38,9 @@ Downstream users include the BCIKS20 list-decoding agreement files under
 ## Near-Term Work
 
 The next useful proof work is not to restate all of Appendix A at once. It is to add small reusable
-facts around canonical representatives and `Λ`-weights:
+facts around regular elements, canonical representatives, and `Λ`-weights:
 
-- zero and constructor simplification for `weight_Λ_over_𝒪`;
+- denominator-clearing lemmas for evaluating polynomials at `functionFieldT / W`;
 - weight bounds for constants and monomials;
 - weight behavior under addition and multiplication by powers of `X`;
 - reduced-representative rewrites that avoid unfolding quotient representatives manually.

--- a/docs/kb/index.md
+++ b/docs/kb/index.md
@@ -42,6 +42,8 @@ used in `ArkLib/**/*.lean`, including:
 
 - [`audits/README.md`](audits/README.md) - audit conventions and migration notes for paper-to-code
   comparison pages.
+- [`audits/bciks20-appendix-a-rational-functions.md`](audits/bciks20-appendix-a-rational-functions.md)
+  - status matrix for the rational-function and Hensel-lifting layer used by `BCIKS20`.
 - [`audits/open-problems-list-decoding-and-correlated-agreement.md`](audits/open-problems-list-decoding-and-correlated-agreement.md)
   - detailed paper-to-ArkLib matrix for *Open Problems in List Decoding and Correlated Agreement*
     (dated April 8, 2026).

--- a/docs/kb/log.md
+++ b/docs/kb/log.md
@@ -113,3 +113,12 @@ and added a concept hub:
 - `docs/kb/concepts/polishchuk-spielman-lineage.md`
 
 for the corrected-vs-original Polishchuk-Spielman source lineage.
+
+## [2026-05-03] audit | BCIKS20 Appendix A rational functions
+
+Added:
+
+- `docs/kb/audits/bciks20-appendix-a-rational-functions.md`
+
+to track the rational-function and Hensel-lifting declarations supporting the BCIKS20
+list-decoding branch.

--- a/docs/kb/log.md
+++ b/docs/kb/log.md
@@ -122,3 +122,10 @@ Added:
 
 to track the rational-function and Hensel-lifting declarations supporting the BCIKS20
 list-decoding branch.
+
+## [2026-05-03] prove | BCIKS20 function-field regularity API
+
+Updated `ArkLib/Data/Polynomial/RationalFunctions.lean` with an explicit function-field `T`
+variable, regular-element closure lemmas, and a concrete low-degree `ξ` regularity helper.
+The Appendix A rational-functions audit now records this as the next denominator-clearing layer
+toward `ClaimA2.ξ_regular`.

--- a/docs/kb/papers/BCIKS20.md
+++ b/docs/kb/papers/BCIKS20.md
@@ -61,8 +61,9 @@ machinery.
 
 ## Open Formalization Gaps
 
-- Keep a persistent theorem/status matrix in an audit page rather than overloading this landing
-  page.
+- Keep persistent theorem/status matrices in audit pages rather than overloading this landing page.
+  The Appendix A rational-function layer is tracked in
+  [`../audits/bciks20-appendix-a-rational-functions.md`](../audits/bciks20-appendix-a-rational-functions.md).
 - Record when paper-level statements are only represented through more abstract ArkLib interfaces.
 - Revisit once the existing paper audit is migrated or mirrored under `docs/kb/audits/`.
 


### PR DESCRIPTION
## Summary
- add basic zero, constructor, and reduced-representative lemmas for `weight_Λ_over_𝒪`
- add an explicit function-field `T` variable and regular-element closure/lift lemmas for `𝕃`
- fix `ClaimA2.ζ` to evaluate at the function-field `T` variable rather than the coefficient variable
- add constant-derivative `ζ` regularity and low-degree `ξ` regularity helpers
- document the current BCIKS20 Appendix A rational-function/Hensel-lift status in the KB

## Non-goals
- this does not close the full `ClaimA2.ξ_regular`, `weight_ξ_bound`, or `β_regular` proofs; the new API sets up the denominator-clearing and weight-calculus layer needed for those follow-up PRs

## Tests
- `lake build ArkLib.Data.Polynomial.RationalFunctions`
- `lake build ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.ListDecoding.Agreement`
- `python3 scripts/kb/lint.py`
- `python3 scripts/kb/lint.py --strict-cited-pages`
- `python3 scripts/kb/check_generated.py`
- `python3 scripts/check-docs-integrity.py`
- `git diff --check`
