### PR TITLE
fix(BCIKS20): correct modified GS rate bound

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
@@ -78,7 +78,7 @@ structure ModifiedGuruswami
     degreeX Q < D_X ((k + 1) / (n : ℚ)) n m
   /-- The Y-degree bound. -/
   Q_D_Y :
-    D_Y Q < D_X (k + 1 / (n : ℚ)) n m / k
+    D_Y Q < D_X ((k + 1 : ℚ) / n) n m / k
   /-- The YZ-degree bound. -/
   Q_D_YZ :
     D_YZ Q ≤ n * (m + 1/(2 : ℚ))^3 / (6 * Real.sqrt ((k + 1) / n))


### PR DESCRIPTION
## Summary
- correct `ModifiedGuruswami.Q_D_Y` to use `(k + 1) / n` instead of `k + 1 / n`
- align the Y-degree bound with the surrounding BCIKS20 Guruswami-Sudan rate bounds

## Non-goals
- this does not migrate the BCIKS20 list-decoding skeleton to the newer `gs_*` APIs using `k / n`; that would require a coordinated refactor of the related bounds

## Tests
- `git diff --check`
- `lake build ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.ListDecoding.Guruswami`
- `lake build ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.ListDecoding.Agreement`
