### PR TITLE
fix(BCIKS20): correct curve bad-coordinate set

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/Curves.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/Curves.lean
@@ -65,7 +65,7 @@ theorem large_agreement_set_on_curve_implies_correlated_agreement {l : ℕ}
         ∀ z,
           δᵣ(Curve.polynomialCurveEval (F := F) (A := F) u z,
             Curve.polynomialCurveEval (F := F) (A := F) v z) ≤ δ ∧
-          ({ x : Fin n | Finset.image u ≠ Finset.image v } : Finset _).card ≤ δ * n := by
+          ({ x : Fin n | ∃ i, u i x ≠ v i x } : Finset _).card ≤ δ * n := by
   sorry
 
 /-- The distance bound from [BCIKS20]. -/


### PR DESCRIPTION
## Summary
- correct the bad-coordinate set in `large_agreement_set_on_curve_implies_correlated_agreement` to depend on the coordinate being counted
- count coordinates where some curve coefficient word differs, instead of comparing the global images of the two word families

## Non-goals
- this does not prove the surrounding `sorry` theorem or change the stronger list-decoding curve statement

## Tests
- `git diff --check origin/main...HEAD`
- `/Users/ainta/.elan/bin/lake build ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.Curves`
