### PR TITLE
doc(scripts): refresh dependency analysis README

### DIFF
--- a/scripts/dependency_analysis/README.md
+++ b/scripts/dependency_analysis/README.md
@@ -24,7 +24,8 @@ This directory contains tools and visualizations for analyzing the dependency st
 
 ### 1. `arklib_dependencies.dot` / `arklib_dependencies.png`
 - **Full dependency graph** showing all modules and their import relationships
-- Size depends on the current checkout; the generator prints the current module and edge counts
+- Size depends on the current checkout; the generator prints Lean file and module counts, and the
+  explorer reports node and edge counts when it loads the JSON
 - Includes internal `ArkLib.*` import edges; external imports such as Mathlib are parsed but not
   emitted in the graph
 - **Warning**: This graph is very large and may be hard to read due to the number of connections
@@ -50,7 +51,7 @@ This directory contains tools and visualizations for analyzing the dependency st
 The dependency graph groups modules by the first component after `ArkLib.`. Current categories
 include:
 
-1. **AGM** - Algebraic Geometry and Mathematics
+1. **AGM** - Algebraic Group Model
 2. **CommitmentScheme** - Cryptographic commitment schemes
 3. **Data** - Core data structures and algorithms
 4. **OracleReduction** - Oracle reduction protocols

--- a/scripts/dependency_analysis/README.md
+++ b/scripts/dependency_analysis/README.md
@@ -5,12 +5,13 @@ This directory contains tools and visualizations for analyzing the dependency st
 ## Folder Structure
 
 ```
-scripts/dependency_analysis/
-├── README.md                           # This file
-├── generate_dependency_graph.py        # Main dependency graph generator
-├── generate_top_level_graph.py         # Simplified category-level graph generator
-├── explore_dependencies.py             # Interactive dependency explorer
-└── dependency_graphs/                  # Generated output files (created when running scripts)
+<repo root>/
+├── scripts/dependency_analysis/
+│   ├── README.md                       # This file
+│   ├── generate_dependency_graph.py    # Main dependency graph generator
+│   ├── generate_top_level_graph.py     # Simplified category-level graph generator
+│   └── explore_dependencies.py         # Interactive dependency explorer
+└── dependency_graphs/                  # Generated output files when using the examples below
     ├── arklib_dependencies.dot        # Full dependency graph in DOT format
     ├── arklib_dependencies.png        # Full dependency graph visualization
     ├── arklib_dependencies.json       # Machine-readable dependency data
@@ -23,20 +24,21 @@ scripts/dependency_analysis/
 
 ### 1. `arklib_dependencies.dot` / `arklib_dependencies.png`
 - **Full dependency graph** showing all modules and their import relationships
-- Contains 176 nodes and 422 edges
-- Shows both internal ArkLib dependencies and external dependencies (Mathlib, etc.)
+- Size depends on the current checkout; the generator prints the current module and edge counts
+- Includes internal `ArkLib.*` import edges; external imports such as Mathlib are parsed but not
+  emitted in the graph
 - **Warning**: This graph is very large and may be hard to read due to the number of connections
 
 ### 2. `arklib_top_level.dot` / `arklib_top_level.png`
 - **Simplified top-level graph** showing only the main categories
 - Much more readable overview of the project structure
-- Shows 7 main categories and their inter-dependencies
+- Shows the current top-level categories and their inter-dependencies
 - Recommended for understanding the high-level architecture
 
 ### 3. `arklib_dependencies.json`
 - **Machine-readable dependency data** in JSON format
 - Can be used for custom analysis or integration with other tools
-- Contains detailed information about each module and dependency relationship
+- Contains each emitted module node and internal import edge
 
 ### 4. `arklib_dependencies.txt`
 - **Human-readable summary** of dependencies
@@ -45,7 +47,8 @@ scripts/dependency_analysis/
 
 ## Main Categories
 
-The ArkLib project is organized into these main categories:
+The dependency graph groups modules by the first component after `ArkLib.`. Current categories
+include:
 
 1. **AGM** - Algebraic Geometry and Mathematics
 2. **CommitmentScheme** - Cryptographic commitment schemes
@@ -57,9 +60,9 @@ The ArkLib project is organized into these main categories:
 ## Key Insights
 
 ### Most Dependent Modules
-- `ArkLib.Data.CodingTheory.Basic` (16 dependencies)
-- `ArkLib.Data.CodingTheory.ReedSolomon` (15 dependencies)
-- `ArkLib.OracleReduction.Security.RoundByRound` (12 dependencies)
+- Run `python3 scripts/dependency_analysis/explore_dependencies.py
+  dependency_graphs/arklib_dependencies.json --top 10` after regenerating the graph to see the
+  current ranking.
 
 ### Architecture Patterns
 - **Data** category is the largest and most foundational
@@ -72,49 +75,46 @@ The ArkLib project is organized into these main categories:
 ### Generate New Graphs
 ```bash
 # From the ArkLib root directory
-cd scripts/dependency_analysis
-
 # Generate all dependency graphs
-python generate_dependency_graph.py --root ../../ --output-dir ../../dependency_graphs
+python3 scripts/dependency_analysis/generate_dependency_graph.py --root . --output-dir dependency_graphs
 
 # Generate only top-level graph
-python generate_top_level_graph.py ../../dependency_graphs/arklib_dependencies.json ../../dependency_graphs/arklib_top_level.dot
+python3 scripts/dependency_analysis/generate_top_level_graph.py dependency_graphs/arklib_dependencies.json dependency_graphs/arklib_top_level.dot
 ```
 
 ### Explore Dependencies Interactively
 ```bash
 # Interactive mode
-python explore_dependencies.py ../../dependency_graphs/arklib_dependencies.json --interactive
+python3 scripts/dependency_analysis/explore_dependencies.py dependency_graphs/arklib_dependencies.json --interactive
 
 # Quick queries
-python explore_dependencies.py ../../dependency_graphs/arklib_dependencies.json --info "Data.CodingTheory.Basic"
-python explore_dependencies.py ../../dependency_graphs/arklib_dependencies.json --category "Data"
-python explore_dependencies.py ../../dependency_graphs/arklib_dependencies.json --top 10
+python3 scripts/dependency_analysis/explore_dependencies.py dependency_graphs/arklib_dependencies.json --info "Data.CodingTheory.Basic"
+python3 scripts/dependency_analysis/explore_dependencies.py dependency_graphs/arklib_dependencies.json --category "Data"
+python3 scripts/dependency_analysis/explore_dependencies.py dependency_graphs/arklib_dependencies.json --top 10
 ```
 
 ### Visualize Graphs
 ```bash
 # Generate PNG images
-dot -Tpng arklib_dependencies.dot -o arklib_dependencies.png
-dot -Tpng arklib_top_level.dot -o arklib_top_level.png
+dot -Tpng dependency_graphs/arklib_dependencies.dot -o dependency_graphs/arklib_dependencies.png
+dot -Tpng dependency_graphs/arklib_top_level.dot -o dependency_graphs/arklib_top_level.png
 
 # Generate SVG (scalable)
-dot -Tsvg arklib_dependencies.dot -o arklib_dependencies.svg
-dot -Tsvg arklib_top_level.dot -o arklib_top_level.svg
+dot -Tsvg dependency_graphs/arklib_dependencies.dot -o dependency_graphs/arklib_dependencies.svg
+dot -Tsvg dependency_graphs/arklib_top_level.dot -o dependency_graphs/arklib_top_level.svg
 ```
 
 ## Dependencies Required
 
 - **Python 3.6+** with standard library
-- **Graphviz** for visualization (`brew install graphviz` on macOS)
-- **Virtual environment** (`.venv`) for Python dependencies
+- **Graphviz** for optional visualization (`brew install graphviz` on macOS)
 
 ## Notes
 
 - The dependency analysis is based on parsing `import` statements in `.lean` files
-- External dependencies (Mathlib, etc.) are tracked but not included in internal graphs
-- No dependency cycles were detected, indicating good architectural design
-- The analysis excludes build artifacts and temporary files
+- External dependencies (Mathlib, etc.) are ignored by the emitted internal graph
+- The generator reports dependency cycles when it detects any
+- The analysis skips `.lake`, `.git`, `.cursor`, `.claude`, and `.vscode` directories
 
 ## Customization
 
@@ -127,7 +127,7 @@ You can modify the scripts to:
 
 ## Quick Start
 
-1. **Generate graphs**: `python generate_dependency_graph.py --root ../../ --output-dir ../../dependency_graphs`
-2. **View top-level**: Open `../../dependency_graphs/arklib_top_level.png`
-3. **Explore interactively**: `python explore_dependencies.py ../../dependency_graphs/arklib_dependencies.json --interactive`
+1. **Generate graphs**: `python3 scripts/dependency_analysis/generate_dependency_graph.py --root . --output-dir dependency_graphs`
+2. **View top-level**: Open `dependency_graphs/arklib_top_level.png`
+3. **Explore interactively**: `python3 scripts/dependency_analysis/explore_dependencies.py dependency_graphs/arklib_dependencies.json --interactive`
 4. **Custom analysis**: Use the JSON output for your own tools


### PR DESCRIPTION
## Motivation

The dependency-analysis README had drifted from the current script behavior, making the documented output location and graph summary misleading for contributors using the utility from the repository root.

## Changes

- Update dependency-analysis examples to run from the ArkLib repository root.
- Document generated outputs under the root `dependency_graphs/` directory.
- Remove stale hard-coded node/edge counts and category-count wording.
- Clarify that the emitted graph contains internal `ArkLib.*` import edges.

## Previous behavior

The README previously described generated files under `scripts/dependency_analysis/dependency_graphs/` and included hard-coded graph counts that no longer matched a current run. It also referred to a stale top-level category count.

## Validation

- `python3 scripts/dependency_analysis/generate_dependency_graph.py --root . --output-dir /tmp/arklib-deps --format json`
- `python3 scripts/dependency_analysis/generate_top_level_graph.py /tmp/arklib-deps/arklib_dependencies.json /tmp/arklib-deps/arklib_top_level.dot`
- `python3 ./scripts/check-docs-integrity.py`
- `git diff --check`