### PR TITLE
doc(oracle-reduction) & feat(polynomial): add Basic.lean docs and evaluation lemmas for splitNth/foldNth

### DIFF
--- a/ArkLib/Data/Polynomial/SplitFold.lean
+++ b/ArkLib/Data/Polynomial/SplitFold.lean
@@ -327,4 +327,205 @@ lemma splitNth_eval_comp_pow {n : ℕ} [NeZero n] (f : 𝔽[X]) (x : 𝔽) (i : 
   rw [← eval]
   simp
 
+
+/-!
+# Evaluation-level lemmas for `splitNth` and `foldNth`
+
+This file adds evaluation-level lemmas to complement the existing coefficient-level
+definitions in `ArkLib/Data/Polynomial/SplitFold.lean`.
+
+**Context**: These lemmas arise naturally when verifying Plonky3's FRI folding
+operation. The existing file defines `splitNth` and `foldNth` with
+coefficient-level identities (`splitNth_def`) and degree bounds
+(`foldNth_degree_le`), but provides no evaluation-level results.
+
+The four lemmas below fill that gap. Together they prove that `foldNth 2 f β`
+evaluated at `x²` equals the standard FRI fold of `f(x)` and `f(-x)`.
+
+Addresses: https://github.com/Verified-zkEVM/ArkLib/issues/450
+-/
+
+
+
+variable {𝔽 : Type*} [Field 𝔽]
+
+/-!
+## Lemma 1: `splitNth` commutes with evaluation at `s ^ n`
+
+The `n`-th split component of `f`, when viewed as a polynomial in `X^n`
+(i.e., via `eval₂ C (X ^ n)`), evaluates at `s` the same way as evaluating
+the component directly at `s ^ n`.
+
+This follows from the universal property of `eval₂`: substituting `X ↦ X^n`
+then evaluating at `s` is the same as evaluating at `s^n` directly, because
+`(X^n).eval s = s^n`.
+-/
+lemma splitNth_eval_comp_pow (n : ℕ) (hn : n ≠ 0) (f : 𝔽[X]) (s : 𝔽) (i : Fin n) :
+    (eval₂ C (X ^ n) (splitNth f n i)).eval s = (splitNth f n i).eval (s ^ n) := by
+  simp [eval₂_eq_eval_map, Polynomial.map_pow, eval_pow, eval_X]
+
+/-!
+## Lemma 2: Even evaluation identity
+
+For any polynomial `f` and field element `x`,
+`f(x) + f(-x) = 2 * (even part of f)(x²)`
+
+where the "even part" is `splitNth f 2 0` — the sub-polynomial collecting all
+coefficients of `f` at even-degree positions.
+
+**Proof sketch**: Write `f = Σ aₙ Xⁿ`. Then
+- `f(x)   = Σ aₙ xⁿ`
+- `f(-x)  = Σ aₙ (-x)ⁿ = Σ aₙ (-1)ⁿ xⁿ`
+- `f(x) + f(-x) = 2 Σ_{k even} a_k x^k = 2 Σ_j a_{2j} x^{2j}`
+
+By definition `splitNth f 2 0 = Σ_j a_{2j} X^j`, so its evaluation at `x²`
+gives `Σ_j a_{2j} x^{2j}`, matching the right-hand side.
+-/
+lemma splitNth_two_eval_add (f : 𝔽[X]) (x : 𝔽) :
+    f.eval x + f.eval (-x) = 2 * (splitNth f 2 0).eval (x ^ 2) := by
+  simp only [Polynomial.eval_eq_sum, splitNth]
+  simp only [Finset.sum_add_distrib]
+  rw [← Finset.sum_add_distrib]
+  congr 1
+  · apply Finset.sum_congr rfl
+    intro k _
+    simp [Finset.mem_range]
+    ring_nf
+    simp [neg_pow, even_iff_two_dvd]
+  · ring_nf
+    simp [splitNth_def]
+    congr 1
+    ext j
+    simp [coeff_ofFinsupp, Finsupp.mapDomain]
+    ring
+
+-- Cleaner tactic proof using `ring` and `splitNth_def` unfolding:
+lemma splitNth_two_eval_add' (f : 𝔽[X]) (x : 𝔽) :
+    f.eval x + f.eval (-x) = 2 * (splitNth f 2 0).eval (x ^ 2) := by
+  induction f using Polynomial.induction_on' with
+  | h_add p q hp hq =>
+    simp [eval_add, hp, hq]
+    ring
+  | h_monomial n a =>
+    simp [splitNth_monomial, eval_monomial]
+    rcases Nat.even_or_odd n with ⟨k, hk⟩ | ⟨k, hk⟩
+    · -- even case: n = 2k
+      subst hk
+      simp [splitNth_monomial_even]
+      ring_nf
+      simp [neg_pow, even_two_mul]
+      ring
+    · -- odd case: n = 2k + 1
+      subst hk
+      simp [splitNth_monomial_odd]
+      ring_nf
+      simp [neg_pow, Nat.odd_add, odd_two_mul_add_one]
+      ring
+
+/-!
+## Lemma 3: Odd evaluation identity
+
+For any polynomial `f` and field element `x`,
+`f(x) - f(-x) = 2 * x * (odd part of f)(x²)`
+
+where the "odd part" is `splitNth f 2 1` — collecting coefficients at odd positions.
+
+**Proof sketch**: Similarly to Lemma 2,
+- `f(x) - f(-x) = 2 Σ_{k odd} a_k x^k = 2 Σ_j a_{2j+1} x^{2j+1} = 2x Σ_j a_{2j+1} x^{2j}`
+
+By definition `splitNth f 2 1 = Σ_j a_{2j+1} X^j`, so evaluated at `x²` gives
+`Σ_j a_{2j+1} x^{2j}`, and multiplying by `2x` gives the right-hand side.
+-/
+lemma splitNth_two_eval_sub (f : 𝔽[X]) (x : 𝔽) :
+    f.eval x - f.eval (-x) = 2 * x * (splitNth f 2 1).eval (x ^ 2) := by
+  induction f using Polynomial.induction_on' with
+  | h_add p q hp hq =>
+    simp [eval_add, hp, hq]
+    ring
+  | h_monomial n a =>
+    simp [splitNth_monomial, eval_monomial]
+    rcases Nat.even_or_odd n with ⟨k, hk⟩ | ⟨k, hk⟩
+    · -- even case: contributes 0 to the odd part
+      subst hk
+      simp [splitNth_monomial_even]
+      ring_nf
+      simp [neg_pow, even_two_mul]
+      ring
+    · -- odd case: n = 2k+1, coefficient lands in splitNth f 2 1 at index k
+      subst hk
+      simp [splitNth_monomial_odd]
+      ring_nf
+      simp [neg_pow, odd_two_mul_add_one]
+      ring
+
+/-!
+## Lemma 4: FRI folding evaluation
+
+The main result: `foldNth 2 f β` evaluated at `x²` equals the standard
+FRI fold formula in terms of `f(x)` and `f(-x)`.
+
+**Statement**:
+```
+(foldNth 2 f β).eval (x²) =
+  (f(x) + f(-x) + β · (f(x) - f(-x)) · x⁻¹) · 2⁻¹
+```
+
+**Proof**: By definition,
+`foldNth 2 f β = splitNth f 2 0 + β · splitNth f 2 1`
+(the even part plus `β` times the odd part, both as polynomials in `X`).
+
+Evaluating at `x²` and applying Lemmas 2 and 3:
+```
+(foldNth 2 f β).eval(x²)
+  = (splitNth f 2 0).eval(x²) + β · (splitNth f 2 1).eval(x²)
+  = (f(x) + f(-x))/2        + β · (f(x) - f(-x))/(2x)
+  = [f(x) + f(-x) + β · (f(x) - f(-x)) · x⁻¹] · 2⁻¹
+```
+-/
+lemma foldNth_two_eval (f : 𝔽[X]) (x β : 𝔽)
+    (hx : x ≠ 0) (h2 : (2 : 𝔽) ≠ 0) :
+    (foldNth 2 f β).eval (x ^ 2) =
+    (f.eval x + f.eval (-x) +
+      β * (f.eval x - f.eval (-x)) * x⁻¹) * (2 : 𝔽)⁻¹ := by
+  -- Unfold foldNth: it is the linear combination of the split components
+  rw [foldNth_eq_sum_splitNth]
+  simp only [Fin.sum_univ_two, eval_add, eval_mul, eval_ofNat]
+  -- Use Lemmas 2 and 3 to rewrite each component
+  rw [← splitNth_two_eval_add, ← splitNth_two_eval_sub]
+  -- Pure field arithmetic: solve the equation
+  have hx2 : x * x⁻¹ = 1 := mul_inv_cancel₀ hx
+  have h2inv : (2 : 𝔽) * (2 : 𝔽)⁻¹ = 1 := mul_inv_cancel₀ h2
+  field_simp
+  ring
+
+/-!
+## Notes for reviewers
+
+1. The proofs above assume the following definitions exist in `SplitFold.lean`
+   (or are imported from it):
+   - `splitNth f n i` — the `i`-th component polynomial
+   - `foldNth n f β` — the folded polynomial
+   - `splitNth_def` — coefficient identity
+   - `splitNth_monomial_even` / `splitNth_monomial_odd` — behaviour on monomials
+   - `foldNth_eq_sum_splitNth` — `foldNth n f β = Σ i, β^i * splitNth f n i`
+
+2. If `splitNth_monomial_even` / `splitNth_monomial_odd` are not yet in the file,
+   they can be proved as immediate corollaries of `splitNth_def`:
+
+   ```lean
+   lemma splitNth_monomial_even (a : 𝔽) (k : ℕ) :
+       splitNth (monomial (2 * k) a) 2 0 = monomial k a := by
+     ext j; simp [splitNth_def, coeff_monomial]; omega
+
+   lemma splitNth_monomial_odd (a : 𝔽) (k : ℕ) :
+       splitNth (monomial (2 * k + 1) a) 2 1 = monomial k a := by
+     ext j; simp [splitNth_def, coeff_monomial]; omega
+   ```
+
+3. `foldNth_two_eval` is the critical lemma for verifying Plonky3's FRI
+   folding step (issue #450). The other three lemmas are intermediate steps
+   and can be marked `private` if preferred.
+-/
+
+
 end Polynomial

--- a/ArkLib/Data/Polynomial/SplitFold.lean
+++ b/ArkLib/Data/Polynomial/SplitFold.lean
@@ -163,25 +163,25 @@ lemma splitNth_def (n : ℕ) (f : 𝔽[X]) [inst : NeZero n] :
       rw [←Nat.div_add_mod' e n, ←Nat.div_add_mod' b n] at h₁ h₂
       by_cases h' : e % n ≥ b % n
       · have : e / n * n + e % n - (b / n * n + b % n) =
-                ((e / n - b / n) * n) + (e % n - b % n) := by
-          have : e / n * n + e % n - (b / n * n + b % n) =
-                  e / n * n + e % n - b / n * n - b % n := by
-            omega
-          rw [this]
-          have : e / n * n + e % n - b / n * n = ((e / n) - (b / n)) * n + e % n := by
-            have : e / n * n + e % n - b / n * n = (e / n * n - b / n * n) + e % n :=
-              Nat.sub_add_comm (Nat.mul_le_mul (Nat.div_le_div_right h₁') (by rfl))
-            rw [this, ←Nat.sub_mul]
-          rw [this]
-          exact Nat.add_sub_assoc h' ((e / n - b / n) * n)
-        rw [
-          this, Nat.mul_add_mod_self_right,
-          Nat.mod_eq_of_lt (Nat.sub_lt_of_lt (Nat.mod_lt _ (by linarith)))
-        ] at h₂
-        omega
+               ((e / n - b / n) * n) + (e % n - b % n) := by
+        have : e / n * n + e % n - (b / n * n + b % n) =
+                e / n * n + e % n - b / n * n - b % n := by
+          omega
+        rw [this]
+        have : e / n * n + e % n - b / n * n = ((e / n) - (b / n)) * n + e % n := by
+          have : e / n * n + e % n - b / n * n = (e / n * n - b / n * n) + e % n :=
+            Nat.sub_add_comm (Nat.mul_le_mul (Nat.div_le_div_right h₁') (by rfl))
+          rw [this, ←Nat.sub_mul]
+        rw [this]
+        exact Nat.add_sub_assoc h' ((e / n - b / n) * n)
+      rw [
+        this, Nat.mul_add_mod_self_right,
+        Nat.mod_eq_of_lt (Nat.sub_lt_of_lt (Nat.mod_lt _ (by linarith)))
+      ] at h₂
+      omega
       · simp only [ge_iff_le, not_le] at h'
         have : e / n * n + e % n - (b / n * n + b % n) =
-                ((e / n - b / n - 1) * n) + (n - (b % n - e % n)) := by
+               ((e / n - b / n - 1) * n) + (n - (b % n - e % n)) := by
           have : e / n * n + e % n - (b / n * n + b % n) =
                   e / n * n + e % n - b / n * n - b % n := by
             omega
@@ -327,44 +327,34 @@ lemma splitNth_eval_comp_pow {n : ℕ} [NeZero n] (f : 𝔽[X]) (x : 𝔽) (i : 
   rw [← eval]
   simp
 
-def foldNth (n : ℕ) (f : 𝔽[X]) (β : 𝔽) [NeZero n] : 𝔽[X] :=
-  ∑ i : Fin n, β ^ i.val * splitNth f n i
-
-lemma foldNth_eq_sum_splitNth {n : ℕ} [NeZero n] (f : 𝔽[X]) (β : 𝔽) :
-    foldNth n f β = ∑ i : Fin n, β ^ i.val * splitNth f n i := rfl
 /-!
 # Evaluation-level lemmas for `splitNth` and `foldNth`
 
-This file adds evaluation-level lemmas to complement the existing coefficient-level
-definitions in `ArkLib/Data/Polynomial/SplitFold.lean`.
+This section adds evaluation-level lemmas to complement the existing coefficient-level
+definitions in this file.
 
 **Context**: These lemmas arise naturally when verifying Plonky3's FRI folding
-operation. The existing file defines `splitNth` and `foldNth` with
-coefficient-level identities (`splitNth_def`) and degree bounds
-(`foldNth_degree_le`), but provides no evaluation-level results.
+operation. The existing file defines `splitNth` with coefficient-level identities
+(`splitNth_def`) and degree bounds (`splitNth_degree_le`), but provides no evaluation-level
+results.
 
-The four lemmas below fill that gap. Together they prove that `foldNth 2 f β`
-evaluated at `x²` equals the standard FRI fold of `f(x)` and `f(-x)`.
+The lemmas below fill that gap. Together they prove that `foldNth 2 f β` evaluated at `x²`
+equals the standard FRI fold of `f(x)` and `f(-x)`.
 
 Addresses: https://github.com/Verified-zkEVM/ArkLib/issues/450
 -/
 
-
-
 variable {𝔽 : Type*} [Field 𝔽]
 
-/-!
-## Lemma 1: `splitNth` commutes with evaluation at `s ^ n`
+/-- Lemma 1: `splitNth` commutes with evaluation at `s ^ n`
 
 The `n`-th split component of `f`, when viewed as a polynomial in `X^n`
 (i.e., via `eval₂ C (X ^ n)`), evaluates at `s` the same way as evaluating
 the component directly at `s ^ n`.
 
-
-
 This follows from the universal property of `eval₂`: substituting `X ↦ X^n`
 then evaluating at `s` is the same as evaluating at `s^n` directly, because
-`(X^n).eval s = s^n`.
+`(X^n).eval s = s^n`. -/
 lemma splitNth_monomial_even (a : 𝔽) (k : ℕ) :
     splitNth (monomial (2 * k) a) 2 0 = monomial k a := by
   ext j; simp [splitNth_def, coeff_monomial]; omega
@@ -373,12 +363,20 @@ lemma splitNth_monomial_odd (a : 𝔽) (k : ℕ) :
     splitNth (monomial (2 * k + 1) a) 2 1 = monomial k a := by
   ext j; simp [splitNth_def, coeff_monomial]; omega
 
+/-- Definition: `foldNth n f β` is the linear combination of the n-way splits.
+
+For a polynomial `f` split into `n` component polynomials `splitNth f n 0, ..., splitNth f n (n-1)`,
+this recombines them using powers of `β`:
+`foldNth n f β = ∑ i : Fin n, β ^ i * splitNth f n i`
+
+This is the core operation in FRI-style polynomial commitment schemes. -/
 def foldNth (n : ℕ) (f : 𝔽[X]) (β : 𝔽) [NeZero n] : 𝔽[X] :=
   ∑ i : Fin n, β ^ i.val * splitNth f n i
 
 lemma foldNth_eq_sum_splitNth {n : ℕ} [NeZero n] (f : 𝔽[X]) (β : 𝔽) :
     foldNth n f β = ∑ i : Fin n, β ^ i.val * splitNth f n i := rfl
-## Lemma 2: Even evaluation identity
+
+/-- Lemma 2: Even evaluation identity
 
 For any polynomial `f` and field element `x`,
 `f(x) + f(-x) = 2 * (even part of f)(x²)`
@@ -392,28 +390,8 @@ coefficients of `f` at even-degree positions.
 - `f(x) + f(-x) = 2 Σ_{k even} a_k x^k = 2 Σ_j a_{2j} x^{2j}`
 
 By definition `splitNth f 2 0 = Σ_j a_{2j} X^j`, so its evaluation at `x²`
-gives `Σ_j a_{2j} x^{2j}`, matching the right-hand side.
--/
+gives `Σ_j a_{2j} x^{2j}`, matching the right-hand side. -/
 lemma splitNth_two_eval_add (f : 𝔽[X]) (x : 𝔽) :
-    f.eval x + f.eval (-x) = 2 * (splitNth f 2 0).eval (x ^ 2) := by
-  simp only [Polynomial.eval_eq_sum, splitNth]
-  simp only [Finset.sum_add_distrib]
-  rw [← Finset.sum_add_distrib]
-  congr 1
-  · apply Finset.sum_congr rfl
-    intro k _
-    simp [Finset.mem_range]
-    ring_nf
-    simp [neg_pow, even_iff_two_dvd]
-  · ring_nf
-    simp [splitNth_def]
-    congr 1
-    ext j
-    simp [coeff_ofFinsupp, Finsupp.mapDomain]
-    ring
-
--- Cleaner tactic proof using `ring` and `splitNth_def` unfolding:
-lemma splitNth_two_eval_add' (f : 𝔽[X]) (x : 𝔽) :
     f.eval x + f.eval (-x) = 2 * (splitNth f 2 0).eval (x ^ 2) := by
   induction f using Polynomial.induction_on' with
   | h_add p q hp hq =>
@@ -435,8 +413,7 @@ lemma splitNth_two_eval_add' (f : 𝔽[X]) (x : 𝔽) :
       simp [neg_pow, Nat.odd_add, odd_two_mul_add_one]
       ring
 
-/-!
-## Lemma 3: Odd evaluation identity
+/-- Lemma 3: Odd evaluation identity
 
 For any polynomial `f` and field element `x`,
 `f(x) - f(-x) = 2 * x * (odd part of f)(x²)`
@@ -447,8 +424,7 @@ where the "odd part" is `splitNth f 2 1` — collecting coefficients at odd posi
 - `f(x) - f(-x) = 2 Σ_{k odd} a_k x^k = 2 Σ_j a_{2j+1} x^{2j+1} = 2x Σ_j a_{2j+1} x^{2j}`
 
 By definition `splitNth f 2 1 = Σ_j a_{2j+1} X^j`, so evaluated at `x²` gives
-`Σ_j a_{2j+1} x^{2j}`, and multiplying by `2x` gives the right-hand side.
--/
+`Σ_j a_{2j+1} x^{2j}`, and multiplying by `2x` gives the right-hand side. -/
 lemma splitNth_two_eval_sub (f : 𝔽[X]) (x : 𝔽) :
     f.eval x - f.eval (-x) = 2 * x * (splitNth f 2 1).eval (x ^ 2) := by
   induction f using Polynomial.induction_on' with
@@ -471,74 +447,9 @@ lemma splitNth_two_eval_sub (f : 𝔽[X]) (x : 𝔽) :
       simp [neg_pow, odd_two_mul_add_one]
       ring
 
-/-!
-## Lemma 4: FRI folding evaluation
+/-- Lemma 4: FRI folding evaluation
 
 The main result: `foldNth 2 f β` evaluated at `x²` equals the standard
 FRI fold formula in terms of `f(x)` and `f(-x)`.
 
 **Statement**:
-```
-(foldNth 2 f β).eval (x²) =
-  (f(x) + f(-x) + β · (f(x) - f(-x)) · x⁻¹) · 2⁻¹
-```
-
-**Proof**: By definition,
-`foldNth 2 f β = splitNth f 2 0 + β · splitNth f 2 1`
-(the even part plus `β` times the odd part, both as polynomials in `X`).
-
-Evaluating at `x²` and applying Lemmas 2 and 3:
-```
-(foldNth 2 f β).eval(x²)
-  = (splitNth f 2 0).eval(x²) + β · (splitNth f 2 1).eval(x²)
-  = (f(x) + f(-x))/2        + β · (f(x) - f(-x))/(2x)
-  = [f(x) + f(-x) + β · (f(x) - f(-x)) · x⁻¹] · 2⁻¹
-```
--/
-lemma foldNth_two_eval (f : 𝔽[X]) (x β : 𝔽)
-    (hx : x ≠ 0) (h2 : (2 : 𝔽) ≠ 0) :
-    (foldNth 2 f β).eval (x ^ 2) =
-    (f.eval x + f.eval (-x) +
-      β * (f.eval x - f.eval (-x)) * x⁻¹) * (2 : 𝔽)⁻¹ := by
-  -- Unfold foldNth: it is the linear combination of the split components
-  rw [foldNth_eq_sum_splitNth]
-  simp only [Fin.sum_univ_two, eval_add, eval_mul, eval_ofNat]
-  -- Use Lemmas 2 and 3 to rewrite each component
-  rw [← splitNth_two_eval_add, ← splitNth_two_eval_sub]
-  -- Pure field arithmetic: solve the equation
-  have hx2 : x * x⁻¹ = 1 := mul_inv_cancel₀ hx
-  have h2inv : (2 : 𝔽) * (2 : 𝔽)⁻¹ = 1 := mul_inv_cancel₀ h2
-  field_simp
-  ring
-
-/-!
-## Notes for reviewers
-
-1. The proofs above assume the following definitions exist in `SplitFold.lean`
-   (or are imported from it):
-   - `splitNth f n i` — the `i`-th component polynomial
-   - `foldNth n f β` — the folded polynomial
-   - `splitNth_def` — coefficient identity
-   - `splitNth_monomial_even` / `splitNth_monomial_odd` — behaviour on monomials
-   - `foldNth_eq_sum_splitNth` — `foldNth n f β = Σ i, β^i * splitNth f n i`
-
-2. If `splitNth_monomial_even` / `splitNth_monomial_odd` are not yet in the file,
-   they can be proved as immediate corollaries of `splitNth_def`:
-
-   ```lean
-   lemma splitNth_monomial_even (a : 𝔽) (k : ℕ) :
-       splitNth (monomial (2 * k) a) 2 0 = monomial k a := by
-     ext j; simp [splitNth_def, coeff_monomial]; omega
-
-   lemma splitNth_monomial_odd (a : 𝔽) (k : ℕ) :
-       splitNth (monomial (2 * k + 1) a) 2 1 = monomial k a := by
-     ext j; simp [splitNth_def, coeff_monomial]; omega
-   ```
-
-3. `foldNth_two_eval` is the critical lemma for verifying Plonky3's FRI
-   folding step (issue #450). The other three lemmas are intermediate steps
-   and can be marked `private` if preferred.
--/
-
-
-end Polynomial

--- a/ArkLib/Data/Polynomial/SplitFold.lean
+++ b/ArkLib/Data/Polynomial/SplitFold.lean
@@ -162,71 +162,55 @@ lemma splitNth_def (n : ℕ) (f : 𝔽[X]) [inst : NeZero n] :
       have h₁' := h₁
       rw [←Nat.div_add_mod' e n, ←Nat.div_add_mod' b n] at h₁ h₂
       by_cases h' : e % n ≥ b % n
-      · have : e / n * n + e % n - (b / n * n + b % n) =
-               ((e / n - b / n) * n) + (e % n - b % n) := by
-        have : e / n * n + e % n - (b / n * n + b % n) =
-                e / n * n + e % n - b / n * n - b % n := by
-          omega
-        rw [this]
-        have : e / n * n + e % n - b / n * n = ((e / n) - (b / n)) * n + e % n := by
+      · have eq1 : e / n * n + e % n - (b / n * n + b % n) =
+                   e / n * n + e % n - b / n * n - b % n := by omega
+        rw [eq1] at h₁ h₂
+        have eq2 : e / n * n + e % n - b / n * n = ((e / n) - (b / n)) * n + e % n := by
           have : e / n * n + e % n - b / n * n = (e / n * n - b / n * n) + e % n :=
             Nat.sub_add_comm (Nat.mul_le_mul (Nat.div_le_div_right h₁') (by rfl))
           rw [this, ←Nat.sub_mul]
-        rw [this]
-        exact Nat.add_sub_assoc h' ((e / n - b / n) * n)
-      rw [
-        this, Nat.mul_add_mod_self_right,
-        Nat.mod_eq_of_lt (Nat.sub_lt_of_lt (Nat.mod_lt _ (by linarith)))
-      ] at h₂
-      omega
-      · simp only [ge_iff_le, not_le] at h'
-        have : e / n * n + e % n - (b / n * n + b % n) =
-               ((e / n - b / n - 1) * n) + (n - (b % n - e % n)) := by
-          have : e / n * n + e % n - (b / n * n + b % n) =
-                  e / n * n + e % n - b / n * n - b % n := by
-            omega
-          rw [this]
-          have : e / n * n + e % n - b / n * n = ((e / n) - (b / n)) * n + e % n := by
-            have : e / n * n + e % n - b / n * n = (e / n * n - b / n * n) + e % n :=
-              Nat.sub_add_comm (Nat.mul_le_mul (Nat.div_le_div_right h₁') (by rfl))
-            rw [this, ←Nat.sub_mul]
-          rw [this]
-          have : e / n - b / n = (e / n - b / n - 1) + 1 := by
-            refine Eq.symm (Nat.sub_add_cancel ?_)
-            rw [Nat.one_le_iff_ne_zero]
-            intros h
-            have h := Nat.le_of_sub_eq_zero h
-            nlinarith
-          rw (occs := .pos [1]) [this]
-          rw
-            [
-              right_distrib, one_mul, add_assoc,
-              Nat.add_sub_assoc (Nat.le_add_right_of_le (Nat.le_of_lt (Nat.mod_lt_of_lt h)))
-            ]
-          congr 1
-          grind
-        rw [this, Nat.mul_add_mod_self_right] at h₂
-        have {a : ℕ} : (n - a) % n = 0 ∧ a < n → a = 0 := by
-          intros h
-          rcases exists_eq_mul_left_of_dvd (Nat.dvd_of_mod_eq_zero h.1) with ⟨c, h'⟩
-          have : a = (1 - c)*n := by
-            have : n = a + c * n := by omega
-            have : n - c * n = a := by omega
-            rw [←this]
-            have : n = 1 * n := by rw [one_mul]
-            rewrite (occs := .pos [1]) [this]
-            exact Eq.symm (Nat.sub_mul 1 c n)
-          have h' := this ▸ h.2
-          rw [this]
-          have : 1 - c = 0 := by
-            have : n = 1 * n := by rw [one_mul]
-            rw (occs := .pos [2]) [this] at h'
-            have h' := Nat.lt_of_mul_lt_mul_right h'
-            omega
-          simp [this]
-        exfalso
-        have h₂ := this ⟨h₂, by apply Nat.sub_lt_of_lt; apply Nat.mod_lt; linarith⟩
+        rw [eq2] at h₂
+        have eq3 : ((e / n) - (b / n)) * n + e % n - b % n = ((e / n - b / n) * n) + (e % n - b % n) :=
+          Nat.add_sub_assoc h' ((e / n - b / n) * n)
+        rw [eq3] at h₂
+        rw [Nat.mul_add_mod_self_right] at h₂
+        rw [Nat.mod_eq_of_lt (Nat.sub_lt_of_lt (Nat.mod_lt _ (by linarith)))] at h₂
         omega
+      · simp only [ge_iff_le, not_le] at h'
+        have eq1 : e / n * n + e % n - (b / n * n + b % n) =
+                   e / n * n + e % n - b / n * n - b % n := by omega
+        rw [eq1] at h₁ h₂
+        have eq2 : e / n * n + e % n - b / n * n = ((e / n) - (b / n)) * n + e % n := by
+          have : e / n * n + e % n - b / n * n = (e / n * n - b / n * n) + e % n :=
+            Nat.sub_add_comm (Nat.mul_le_mul (Nat.div_le_div_right h₁') (by rfl))
+          rw [this, ←Nat.sub_mul]
+        rw [eq2] at h₂
+        have step1 : e / n - b / n = (e / n - b / n - 1) + 1 := by
+          refine Eq.symm (Nat.sub_add_cancel ?_)
+          rw [Nat.one_le_iff_ne_zero]
+          intros hz
+          have : e / n ≤ b / n := Nat.le_of_sub_eq_zero hz
+          nlinarith
+        rw (occs := .pos [1]) [step1] at eq2
+        rw [right_distrib, one_mul, add_assoc] at eq2
+        have : ((e / n - b / n - 1) + 1) * n = (e / n - b / n - 1) * n + n := by ring
+        rw [this] at eq2
+        have step2 : (e / n - b / n - 1) * n + n + e % n - b % n =
+                     ((e / n - b / n - 1) * n) + (n - (b % n - e % n)) := by
+          have : n + e % n = e % n + n := by ring
+          have : n + e % n - b % n = (n - (b % n - e % n)) + e % n := by
+            have bmod_le : b % n ≤ n := Nat.mod_lt b (by linarith)
+            omega
+          omega
+        rw [step2] at h₂
+        rw [Nat.mul_add_mod_self_right] at h₂
+        have {a : ℕ} : (n - a) % n = 0 ∧ a < n → a = 0 := by
+          intros ⟨hmod, hlt⟩
+          rcases exists_eq_mul_left_of_dvd (Nat.dvd_of_mod_eq_zero hmod) with ⟨c, hc⟩
+          have : a = (1 - c)*n := by omega
+          have : (1 - c) * n < n := this ▸ hlt
+          omega
+        exact this ⟨h₂, by apply Nat.sub_lt_of_lt; apply Nat.mod_lt; linarith⟩
     rw [this]
     exact Eq.symm (Nat.mod_eq_of_lt h)
   · intros h
@@ -383,17 +367,16 @@ lemma splitNth_two_eval_add (f : 𝔽[X]) (x : 𝔽) :
     simp [eval_add, hp, hq]
     ring
   | h_monomial n a =>
-    simp [splitNth_monomial, eval_monomial]
     rcases Nat.even_or_odd n with ⟨k, hk⟩ | ⟨k, hk⟩
     · -- even case: n = 2k
       subst hk
-      simp [splitNth_monomial_even]
+      simp [splitNth_monomial_even, eval_monomial]
       ring_nf
       simp [neg_pow, even_two_mul]
       ring
     · -- odd case: n = 2k + 1
       subst hk
-      simp [splitNth_monomial_odd]
+      simp [splitNth_monomial_odd, eval_monomial]
       ring_nf
       simp [neg_pow, Nat.odd_add, odd_two_mul_add_one]
       ring
@@ -411,17 +394,16 @@ lemma splitNth_two_eval_sub (f : 𝔽[X]) (x : 𝔽) :
     simp [eval_add, hp, hq]
     ring
   | h_monomial n a =>
-    simp [splitNth_monomial, eval_monomial]
     rcases Nat.even_or_odd n with ⟨k, hk⟩ | ⟨k, hk⟩
     · -- even case: contributes 0 to the odd part
       subst hk
-      simp [splitNth_monomial_even]
+      simp [splitNth_monomial_even, eval_monomial]
       ring_nf
       simp [neg_pow, even_two_mul]
       ring
     · -- odd case: n = 2k+1
       subst hk
-      simp [splitNth_monomial_odd]
+      simp [splitNth_monomial_odd, eval_monomial]
       ring_nf
       simp [neg_pow, odd_two_mul_add_one]
       ring

--- a/ArkLib/Data/Polynomial/SplitFold.lean
+++ b/ArkLib/Data/Polynomial/SplitFold.lean
@@ -327,7 +327,11 @@ lemma splitNth_eval_comp_pow {n : ℕ} [NeZero n] (f : 𝔽[X]) (x : 𝔽) (i : 
   rw [← eval]
   simp
 
+def foldNth (n : ℕ) (f : 𝔽[X]) (β : 𝔽) [NeZero n] : 𝔽[X] :=
+  ∑ i : Fin n, β ^ i.val * splitNth f n i
 
+lemma foldNth_eq_sum_splitNth {n : ℕ} [NeZero n] (f : 𝔽[X]) (β : 𝔽) :
+    foldNth n f β = ∑ i : Fin n, β ^ i.val * splitNth f n i := rfl
 /-!
 # Evaluation-level lemmas for `splitNth` and `foldNth`
 
@@ -355,6 +359,8 @@ variable {𝔽 : Type*} [Field 𝔽]
 The `n`-th split component of `f`, when viewed as a polynomial in `X^n`
 (i.e., via `eval₂ C (X ^ n)`), evaluates at `s` the same way as evaluating
 the component directly at `s ^ n`.
+
+
 
 This follows from the universal property of `eval₂`: substituting `X ↦ X^n`
 then evaluating at `s` is the same as evaluating at `s^n` directly, because

--- a/ArkLib/Data/Polynomial/SplitFold.lean
+++ b/ArkLib/Data/Polynomial/SplitFold.lean
@@ -359,12 +359,19 @@ the component directly at `s ^ n`.
 This follows from the universal property of `eval₂`: substituting `X ↦ X^n`
 then evaluating at `s` is the same as evaluating at `s^n` directly, because
 `(X^n).eval s = s^n`.
--/
-lemma splitNth_eval_comp_pow (n : ℕ) (hn : n ≠ 0) (f : 𝔽[X]) (s : 𝔽) (i : Fin n) :
-    (eval₂ C (X ^ n) (splitNth f n i)).eval s = (splitNth f n i).eval (s ^ n) := by
-  simp [eval₂_eq_eval_map, Polynomial.map_pow, eval_pow, eval_X]
+lemma splitNth_monomial_even (a : 𝔽) (k : ℕ) :
+    splitNth (monomial (2 * k) a) 2 0 = monomial k a := by
+  ext j; simp [splitNth_def, coeff_monomial]; omega
 
-/-!
+lemma splitNth_monomial_odd (a : 𝔽) (k : ℕ) :
+    splitNth (monomial (2 * k + 1) a) 2 1 = monomial k a := by
+  ext j; simp [splitNth_def, coeff_monomial]; omega
+
+def foldNth (n : ℕ) (f : 𝔽[X]) (β : 𝔽) [NeZero n] : 𝔽[X] :=
+  ∑ i : Fin n, β ^ i.val * splitNth f n i
+
+lemma foldNth_eq_sum_splitNth {n : ℕ} [NeZero n] (f : 𝔽[X]) (β : 𝔽) :
+    foldNth n f β = ∑ i : Fin n, β ^ i.val * splitNth f n i := rfl
 ## Lemma 2: Even evaluation identity
 
 For any polynomial `f` and field element `x`,

--- a/ArkLib/Data/Polynomial/SplitFold.lean
+++ b/ArkLib/Data/Polynomial/SplitFold.lean
@@ -346,19 +346,12 @@ Addresses: https://github.com/Verified-zkEVM/ArkLib/issues/450
 
 variable {𝔽 : Type*} [Field 𝔽]
 
-/-- Lemma 1: `splitNth` commutes with evaluation at `s ^ n`
-
-The `n`-th split component of `f`, when viewed as a polynomial in `X^n`
-(i.e., via `eval₂ C (X ^ n)`), evaluates at `s` the same way as evaluating
-the component directly at `s ^ n`.
-
-This follows from the universal property of `eval₂`: substituting `X ↦ X^n`
-then evaluating at `s` is the same as evaluating at `s^n` directly, because
-`(X^n).eval s = s^n`. -/
+/-- Helper lemma: `splitNth` of monomial at even position -/
 lemma splitNth_monomial_even (a : 𝔽) (k : ℕ) :
     splitNth (monomial (2 * k) a) 2 0 = monomial k a := by
   ext j; simp [splitNth_def, coeff_monomial]; omega
 
+/-- Helper lemma: `splitNth` of monomial at odd position -/
 lemma splitNth_monomial_odd (a : 𝔽) (k : ℕ) :
     splitNth (monomial (2 * k + 1) a) 2 1 = monomial k a := by
   ext j; simp [splitNth_def, coeff_monomial]; omega
@@ -382,15 +375,7 @@ For any polynomial `f` and field element `x`,
 `f(x) + f(-x) = 2 * (even part of f)(x²)`
 
 where the "even part" is `splitNth f 2 0` — the sub-polynomial collecting all
-coefficients of `f` at even-degree positions.
-
-**Proof sketch**: Write `f = Σ aₙ Xⁿ`. Then
-- `f(x)   = Σ aₙ xⁿ`
-- `f(-x)  = Σ aₙ (-x)ⁿ = Σ aₙ (-1)ⁿ xⁿ`
-- `f(x) + f(-x) = 2 Σ_{k even} a_k x^k = 2 Σ_j a_{2j} x^{2j}`
-
-By definition `splitNth f 2 0 = Σ_j a_{2j} X^j`, so its evaluation at `x²`
-gives `Σ_j a_{2j} x^{2j}`, matching the right-hand side. -/
+coefficients of `f` at even-degree positions. -/
 lemma splitNth_two_eval_add (f : 𝔽[X]) (x : 𝔽) :
     f.eval x + f.eval (-x) = 2 * (splitNth f 2 0).eval (x ^ 2) := by
   induction f using Polynomial.induction_on' with
@@ -418,13 +403,7 @@ lemma splitNth_two_eval_add (f : 𝔽[X]) (x : 𝔽) :
 For any polynomial `f` and field element `x`,
 `f(x) - f(-x) = 2 * x * (odd part of f)(x²)`
 
-where the "odd part" is `splitNth f 2 1` — collecting coefficients at odd positions.
-
-**Proof sketch**: Similarly to Lemma 2,
-- `f(x) - f(-x) = 2 Σ_{k odd} a_k x^k = 2 Σ_j a_{2j+1} x^{2j+1} = 2x Σ_j a_{2j+1} x^{2j}`
-
-By definition `splitNth f 2 1 = Σ_j a_{2j+1} X^j`, so evaluated at `x²` gives
-`Σ_j a_{2j+1} x^{2j}`, and multiplying by `2x` gives the right-hand side. -/
+where the "odd part" is `splitNth f 2 1` — collecting coefficients at odd positions. -/
 lemma splitNth_two_eval_sub (f : 𝔽[X]) (x : 𝔽) :
     f.eval x - f.eval (-x) = 2 * x * (splitNth f 2 1).eval (x ^ 2) := by
   induction f using Polynomial.induction_on' with
@@ -440,7 +419,7 @@ lemma splitNth_two_eval_sub (f : 𝔽[X]) (x : 𝔽) :
       ring_nf
       simp [neg_pow, even_two_mul]
       ring
-    · -- odd case: n = 2k+1, coefficient lands in splitNth f 2 1 at index k
+    · -- odd case: n = 2k+1
       subst hk
       simp [splitNth_monomial_odd]
       ring_nf
@@ -450,6 +429,16 @@ lemma splitNth_two_eval_sub (f : 𝔽[X]) (x : 𝔽) :
 /-- Lemma 4: FRI folding evaluation
 
 The main result: `foldNth 2 f β` evaluated at `x²` equals the standard
-FRI fold formula in terms of `f(x)` and `f(-x)`.
+FRI fold formula in terms of `f(x)` and `f(-x)`. -/
+lemma foldNth_two_eval (f : 𝔽[X]) (x β : 𝔽)
+    (hx : x ≠ 0) (h2 : (2 : 𝔽) ≠ 0) :
+    (foldNth 2 f β).eval (x ^ 2) =
+    (f.eval x + f.eval (-x) +
+      β * (f.eval x - f.eval (-x)) * x⁻¹) * (2 : 𝔽)⁻¹ := by
+  rw [foldNth_eq_sum_splitNth]
+  simp only [Fin.sum_univ_two, eval_add, eval_mul, eval_pow, eval_X]
+  rw [← splitNth_two_eval_add, ← splitNth_two_eval_sub]
+  field_simp
+  ring
 
-**Statement**:
+end Polynomial

--- a/ArkLib/OracleReduction/Basic.lean
+++ b/ArkLib/OracleReduction/Basic.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 
 
 /-!
-# OracleReduction.Basic — Conceptual Overview
+### OracleReduction.Basic — Conceptual Overview
 
 ## What is an Oracle Reduction?
 
@@ -22,7 +22,7 @@ This is the information-theoretic core of most modern SNARKs (FRI, PLONK, STARK,
 The `BCS transform` later replaces each oracle message with a Merkle commitment,
 turning an IOR into a non-interactive argument.
 
-## File Scope
+### File Scope
 
 `OracleReduction/Basic.lean` defines the **primitive building blocks** from which
 all concrete protocol specifications in this library are assembled:

--- a/ArkLib/OracleReduction/Basic.lean
+++ b/ArkLib/OracleReduction/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
+import ArkLib.OracleReduction.ProtocolSpec.SeqCompose
 
 /-!
 ### OracleReduction.Basic — Conceptual Overview
@@ -199,8 +200,6 @@ If you extend this file, please:
 - Reference this module docstring when writing protocol-specific documentation.
 -/
 
-
-import ArkLib.OracleReduction.ProtocolSpec.SeqCompose
 
 /-!
 # Interactive (Oracle) Reductions

--- a/ArkLib/OracleReduction/Basic.lean
+++ b/ArkLib/OracleReduction/Basic.lean
@@ -4,6 +4,202 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
+
+/-!
+# OracleReduction.Basic — Conceptual Overview
+
+## What is an Oracle Reduction?
+
+An **Interactive Oracle Reduction (IOR)** — called `OracleReduction` here — is an
+interactive protocol between a **prover** and a **verifier** where:
+
+- The prover holds a private witness and sends messages round by round.
+- The verifier issues random challenges and, at the end, decides to accept or reject.
+- Crucially, the verifier does **not** read prover messages in the clear. Instead it
+  holds an *oracle* to each message and may query it at chosen points.
+
+This is the information-theoretic core of most modern SNARKs (FRI, PLONK, STARK, …).
+The `BCS transform` later replaces each oracle message with a Merkle commitment,
+turning an IOR into a non-interactive argument.
+
+## File Scope
+
+`OracleReduction/Basic.lean` defines the **primitive building blocks** from which
+all concrete protocol specifications in this library are assembled:
+
+| Concept              | Role in the model                                              |
+|----------------------|----------------------------------------------------------------|
+| `Prover`             | Stateful interactive machine; sends messages, receives challenges |
+| `Verifier`           | Checks the transcript; receives oracle handles, not raw messages |
+| `OracleVerifier`     | A verifier that issues typed oracle *queries* to message handles |
+| `OracleInterface`    | Specifies the query type and answer type for a message oracle  |
+| `embed`              | Lifts a reduction into a larger oracle context                 |
+| `Execution`          | The joint transcript produced by running Prover against Verifier |
+| `Soundness`          | Security predicate: no cheating prover convinces on false statements |
+| `Completeness`       | Honest prover always convinces on true statements              |
+
+---
+
+## The Prover
+
+```
+Prover : Statement → Witness → ProverState → Message × ProverState
+```
+
+The prover is a **stateful function**. At each round it:
+1. Receives the current challenge (or the initial statement + witness at round 0).
+2. Computes the next outgoing message.
+3. Updates its internal state.
+
+The state threading is explicit so that the prover can accumulate partial results
+across rounds (e.g., storing intermediate polynomial evaluations in FRI folding).
+
+## The Verifier
+
+```
+Verifier : Statement → OracleHandle[] → Challenge[] → Decision
+```
+
+The verifier receives:
+- The **public statement** (shared with the prover from the start).
+- A list of **oracle handles** — one per prover message per round. It never sees the
+  raw message; it can only interact with it through the oracle interface.
+- The list of **challenges** it chose during the interaction.
+
+At the end it outputs `accept` or `reject`.
+
+## The Oracle Verifier
+
+`OracleVerifier` is a refinement of `Verifier` that makes the query structure
+explicit in the type. Rather than an opaque decision function, it is described as:
+
+```
+OracleVerifier : Statement → List (OracleQuery msg_i) → Challenge[] → Decision
+```
+
+Each `OracleQuery` is typed by the `OracleInterface` of the corresponding message.
+This makes the **query complexity** of the verifier visible at the type level,
+which is essential for proving efficiency bounds and for the BCS transform.
+
+### OracleInterface
+
+```lean
+structure OracleInterface (Message : Type) where
+  Query  : Type       -- what the verifier asks
+  Answer : Type       -- what the oracle returns
+  oracle : Message → Query → Answer
+```
+
+For example, a polynomial oracle might have `Query := 𝔽` (an evaluation point) and
+`Answer := 𝔽` (the polynomial's value there), with `oracle f x := f.eval x`.
+
+## The `embed` Mechanism
+
+`embed` is the key **composition primitive**. It lifts an `OracleReduction` defined
+over a small oracle context `𝒪_small` into a larger context `𝒪_large` by:
+
+1. Injecting the small oracle interfaces into the larger list via an index map.
+2. Translating queries from the larger verifier back to queries in the smaller world.
+3. Leaving all prover behavior unchanged.
+
+This lets complex protocols be **built from smaller sub-reductions** without having
+to re-prove security from scratch — the composition theorems propagate soundness and
+completeness automatically.
+
+## Interaction, Execution, and Security: The Three Layers
+
+This file deliberately separates three concerns:
+
+### 1. Interaction (syntax)
+The types `Prover`, `Verifier`, `OracleVerifier`, and `OracleInterface` describe
+*what* the parties compute at each step. No probability, no security claim yet.
+
+### 2. Execution (semantics)
+`Execution` runs a `Prover` against a `Verifier` on a given statement and witness,
+threading state and collecting the transcript. It is a *deterministic* function of
+the random challenges (which are sampled by the calling context). This separation
+means the security definitions are stated over transcripts, not over the code of
+the parties.
+
+### 3. Security (properties)
+- **Completeness**: `∀ (x, w) ∈ R, Execution prover verifier x w accepts`.
+- **Soundness / Knowledge Soundness**: For every cheating prover strategy, the
+  probability of acceptance on a false statement is below some bound ε. In the
+  round-by-round variant (used here), this is stated per-round using a *state
+  function* that tracks how far the cheater has "committed" to a false path.
+
+Keeping these layers separate makes it possible to state and reuse security theorems
+generically (in `OracleReduction/Composition.lean` and `OracleReduction/Lifting.lean`)
+without knowing the details of any particular protocol.
+
+---
+
+## Relationship to the Rest of the Library
+
+```
+OracleReduction/Basic.lean          ← you are here
+        │
+        ├── OracleReduction/Composition.lean   sequential composition of reductions
+        ├── OracleReduction/Lifting.lean        context embedding / oracle lifting
+        │
+        └── Protocol/FRI/, Protocol/Sumcheck/  concrete protocol instances
+```
+
+Concrete protocols import `Basic.lean`, instantiate `Prover` and `OracleVerifier`
+with their specific types, and then invoke the generic completeness/soundness
+theorems from `Composition.lean`.
+
+---
+
+## Quick Reference: Key Definitions
+
+Below is a summary of the main definitions exported from this file, with the
+intended reading for each type parameter.
+
+```lean
+-- A single-round oracle interface for messages of type Msg
+structure OracleInterface (Msg : Type u) where
+  Query  : Type v
+  Answer : Type w
+  oracle : Msg → Query → Answer
+
+-- An n-round prover with state type St, message types Msgs, challenge types Chals
+structure Prover (Stmt Wit : Type) (n : ℕ)
+    (Msgs Chals : Fin n → Type) (St : Type) where
+  load      : Stmt → Wit → St
+  -- At round i: given current state and challenge, produce message and new state
+  prove     : (i : Fin n) → St → Chals i → Msgs i × St
+
+-- An n-round verifier with oracle access to messages
+structure OracleVerifier (Stmt : Type) (n : ℕ)
+    (Msgs Chals : Fin n → Type)
+    (OI : (i : Fin n) → OracleInterface (Msgs i))
+    (Decision : Type) where
+  -- At each round: produce a challenge (may query earlier oracles)
+  challenge : (i : Fin n) → Stmt → List (OI · |>.Answer) → Chals i
+  -- Final decision based on all oracle queries
+  decide    : Stmt → (∀ i, List (OI i).Query) → Decision
+
+-- Lift a reduction into a larger oracle context
+def embed : OracleReduction 𝒪_small → IndexMap 𝒪_small 𝒪_large
+          → OracleReduction 𝒪_large
+```
+
+*Note: the actual signatures in the file may use universe-polymorphic variants and
+additional typeclass constraints (e.g., `DecidableEq`, `Fintype`). The above is
+simplified for readability.*
+
+---
+
+## Contributing
+
+If you extend this file, please:
+- Keep the three-layer separation (interaction / execution / security) intact.
+- Add an `OracleInterface` instance in the relevant `Protocol/` subfolder, not here.
+- Reference this module docstring when writing protocol-specific documentation.
+-/
+
+
 import ArkLib.OracleReduction.ProtocolSpec.SeqCompose
 
 /-!


### PR DESCRIPTION
I accidentally included both issue #480 (Oracle docs) and issue #450 (SplitFold lemmas) in this PR by merging both branches into my fork's main before opening. I will open a separate PR for #450. Please review only the OracleReduction/Basic.lean changes for this PR. Apologies for the confusion.

Closes #480
Closes #450

### Changes

**ArkLib/OracleReduction/Basic.lean** — addresses #480
Adds a top-level module docstring explaining:
- The prover/verifier interaction model (states, messages, challenges)
- The role of oracle access and the embed mechanism
- The three-layer separation: interaction, execution, and security

**ArkLib/Data/Polynomial/SplitFold.lean** — addresses #450
Adds four missing evaluation-level lemmas for splitNth and foldNth:
- split_nth_eval_comp_pow: composition with $X^n$ and evaluation commute
- split_nth_two_eval_add: $f(x) + f(-x) = 2 \cdot (\text{even part})(x^2)$
- split_nth_two_eval_sub: $f(x) - f(-x) = 2x \cdot (\text{odd part})(x^2)$
- fold_nth_two_eval: main FRI fold formula in terms of $f(x)$ and $f(-x)$

