### PR TITLE
feat(reed-solomon): add code_mono + code_zero simplifying lemmas

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -180,5 +180,6 @@ import ArkLib.ProofSystem.Whir.RBRSoundness
 import ArkLib.ToMathlib.BigOperators.Fin
 import ArkLib.ToMathlib.Finset.Basic
 import ArkLib.ToMathlib.List.Basic
+import ArkLib.ToMathlib.Polynomial.DegreeLT
 import ArkLib.ToMathlib.Polynomial.EvalExt
 import ArkLib.ToMathlib.Polynomial.NatDegreeOfSum

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineLines/JointAgreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineLines/JointAgreement.lean
@@ -250,12 +250,7 @@ theorem RS_jointAgreement_of_goodCoeffs_card_gt {deg : ℕ} {domain : ι ↪ F} 
   · subst hdeg_zero
     let S0 : Finset ι := Finset.univ.filter (fun i => u 0 i = 0 ∧ u 1 i = 0)
     have hcode0_zero : ∀ w ∈ (ReedSolomon.code domain 0 : Set (ι → F)), w = 0 := by
-      intro w hw
-      rcases hw with ⟨p, hpdeg, hp_eval⟩
-      have hp0 : p = 0 := by
-        simpa [Polynomial.mem_degreeLT] using hpdeg
-      ext i
-      simpa [hp0] using (congrArg (fun f => f i) hp_eval).symm
+      simp [ReedSolomon.code_zero]
     have hzero_card :
         ∀ z ∈ good,
           n - e ≤ (Finset.univ.filter (fun i : ι => u 0 i + z * u 1 i = 0)).card := by

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -1727,19 +1727,9 @@ theorem rs_listDecoding_card_lt_field {deg : ℕ} {domain : ι ↪ F} {δ : ℝ�
     -- For deg = 0: degreeLT F 0 = ⊥, so code = {0}, closeWords ⊆ {0}.
     push Not at hdeg
     interval_cases deg
-    · -- deg = 0: code = {0}, so closeWords ⊆ {0}, card ≤ 1 < |F|
-      have hcode_triv : ∀ v ∈ closeWords, v = 0 := by
-        intro v hv
-        have hvc := (hclose v hv).1
-        rw [ReedSolomon.code] at hvc
-        obtain ⟨p, hp, he⟩ := Submodule.mem_map.mp hvc
-        have hp0 : p = 0 := by
-          rw [Polynomial.mem_degreeLT] at hp
-          cases h : p.degree with
-          | bot => exact Polynomial.degree_eq_bot.mp h
-          | coe n => simp [h] at hp
-        simp [hp0, ReedSolomon.evalOnPoints] at he
-        exact he.symm
+    · -- deg = 0: code α 0 = ⊥, so closeWords ⊆ {0}, card ≤ 1 < |F|.
+      have hcode_triv : ∀ v ∈ closeWords, v = 0 := fun v hv => by
+        simpa [ReedSolomon.code_zero] using (hclose v hv).1
       have : closeWords.card ≤ 1 :=
         Finset.card_le_one_iff.mpr (fun hx hy => (hcode_triv _ hx).trans (hcode_triv _ hy).symm)
       linarith [Fintype.one_lt_card_iff_nontrivial.mpr (Field.toNontrivial : Nontrivial F)]

--- a/ArkLib/Data/CodingTheory/ReedSolomon.lean
+++ b/ArkLib/Data/CodingTheory/ReedSolomon.lean
@@ -8,6 +8,7 @@ Mirco Richter, Chung Thai Nguyen
 import ArkLib.Data.Matrix.Vandermonde
 import ArkLib.Data.MvPolynomial.LinearMvExtension
 import ArkLib.Data.Polynomial.Interface
+import ArkLib.ToMathlib.Polynomial.DegreeLT
 import CompPoly.Data.Polynomial.MonomialBasis
 import Mathlib.LinearAlgebra.Lagrange
 import Mathlib.RingTheory.Henselian
@@ -166,17 +167,31 @@ lemma mem_code_iff_exists_polynomial {n : ℕ} {α : ι ↪ F} {f : ι → F} :
              Polynomial.degree_lt_iff_coeff_zero])
 
 lemma mem_code_iff_exists_polynomial_of_ne_zero {n : ℕ} [ne : NeZero n] {α : ι ↪ F} {f : ι → F} :
-  f ∈ code α n ↔ ∃ p : Polynomial F, p.natDegree < n ∧ f = evalOnPoints α p := by 
-  rw [mem_code_iff_exists_polynomial] 
+  f ∈ code α n ↔ ∃ p : Polynomial F, p.natDegree < n ∧ f = evalOnPoints α p := by
+  rw [mem_code_iff_exists_polynomial]
   have hne := ne.out
-  constructor <;> 
+  constructor <;>
   intro h <;>
   obtain ⟨p, h₁, h₂⟩ := h <;>
   exists p <;>
-  by_cases hy : p = 0 <;> 
-  aesop 
+  by_cases hy : p = 0 <;>
+  aesop
     (add simp [Polynomial.natDegree_lt_iff_degree_lt])
     (add safe (by omega))
+
+/-- **Monotonicity of `code` in the degree bound.** If `n ≤ m`, the degree-`n` Reed-Solomon code
+is contained in the degree-`m` code over the same domain. -/
+@[mono]
+lemma code_mono {n m : ℕ} (h : n ≤ m) (α : ι ↪ F) :
+    code α n ≤ code α m :=
+  Submodule.map_mono (Polynomial.degreeLT_mono h)
+
+/-- **The degree-zero Reed-Solomon code is trivial.** Only the zero word is a codeword of
+`code α 0`. A direct corollary of `Polynomial.degreeLT_zero` (general polynomial fact) +
+`Submodule.map_bot` (general linear-algebra fact). -/
+@[simp]
+lemma code_zero (α : ι ↪ F) : code α 0 = ⊥ := by
+  rw [code, Polynomial.degreeLT_zero, Submodule.map_bot]
 
 end
 
@@ -267,19 +282,8 @@ lemma dim_eq_card_of_lt {ι : Type*} [Fintype ι] {F : Type*} [Field F]
   · apply le_trans
     · apply Submodule.finrank_le
     · simp
-  · have h_sub : ReedSolomon.code α (Fintype.card ι) ≤
-      ReedSolomon.code α n := by
-      intro x hx
-      simp only [code, Submodule.mem_map] at hx
-      rcases hx with ⟨y, hy⟩
-      simp only [code, Submodule.mem_map]
-      exists y
-      constructor
-      · simp only [LinearMap.range_domRestrict, degreeLT, ge_iff_le, Submodule.mem_iInf,
-        LinearMap.mem_ker, lcoeff_apply] at *
-        intro i hi
-        exact (hy.1 i (by omega))
-      · tauto
+  · have h_sub : ReedSolomon.code α (Fintype.card ι) ≤ ReedSolomon.code α n :=
+      code_mono (le_of_lt h) α
     have h_sub := Submodule.finrank_mono h_sub
     have dim_eq := dim_eq_deg_of_le'
       (n := Fintype.card ι)

--- a/ArkLib/ToMathlib/Polynomial/DegreeLT.lean
+++ b/ArkLib/ToMathlib/Polynomial/DegreeLT.lean
@@ -1,0 +1,29 @@
+import Mathlib.RingTheory.Polynomial.Basic
+
+/-!
+# `Polynomial.degreeLT` boundary facts
+
+Lemmas about `Polynomial.degreeLT R n` (the submodule of polynomials of degree `< n`) at
+the boundary `n = 0`, where it collapses to the zero submodule.
+
+These are reusable for any construction that maps `degreeLT` through a linear map — e.g.
+Reed-Solomon codes (`ReedSolomon.code α n = (degreeLT F n).map (evalOnPoints α)`), folded
+RS codes, and similar code families. Candidate for upstream PR to Mathlib.
+-/
+
+namespace Polynomial
+
+variable {R : Type*} [Semiring R]
+
+/-- `Polynomial.degreeLT R 0 = ⊥`: the only polynomial with degree strictly less than `0`
+(in `WithBot ℕ`) is the zero polynomial.
+
+Not `@[simp]` to avoid disrupting existing simp-based proofs that unfold `degreeLT` directly. -/
+theorem degreeLT_zero : degreeLT R 0 = ⊥ := by
+  rw [eq_bot_iff]
+  intro p hp
+  rw [Polynomial.mem_degreeLT, Nat.cast_zero, Nat.WithBot.lt_zero_iff,
+      Polynomial.degree_eq_bot] at hp
+  exact hp ▸ Submodule.zero_mem _
+
+end Polynomial


### PR DESCRIPTION
motivated by https://github.com/Verified-zkEVM/ArkLib/pull/504, two (ok three technically) simple lemmas that simplify some proofs. Probably more places where these can be used.