### PR TITLE
Fix MDS generator orientation

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -643,7 +643,7 @@ private lemma dist_from_code_bound_of_correlated_agreement
         exact Finset.card_le_card (by simp)
   }) h_u_deg
     aesop (add safe [mem_code_of_polynomial_of_natDegree_lt_of_eval])
-    
+
 private lemma folded_rate_div_eq_helper {d : ℕ}
   (hkn : k ≤ n) (hkd : 2 ^ k ∣ d) :
   (↑(d / 2 ^ k) : ℚ≥0) / 2 ^ (n - k) = (↑d : ℚ≥0) / 2 ^ n := by
@@ -787,9 +787,9 @@ theorem folding_preserves_distance
       SetLike.mem_coe, Matrix.of_apply] at correlated_agreement
     obtain ⟨S, h_card, v, h'⟩ := correlated_agreement
     rw [forall_and] at h'
-    rcases h' with ⟨h_rs, h'⟩ 
-    have h_rs := fun x ↦ (mem_code_iff_exists_polynomial_of_ne_zero 
-        (ne := ⟨by rw [Nat.div_ne_zero_iff]; omega⟩)).mp (h_rs x) 
+    rcases h' with ⟨h_rs, h'⟩
+    have h_rs := fun x ↦ (mem_code_iff_exists_polynomial_of_ne_zero
+        (ne := ⟨by rw [Nat.div_ne_zero_iff]; omega⟩)).mp (h_rs x)
     let u : Fin (2 ^ k - 1 + 1) → Polynomial F :=
       fun i => Classical.choose (h_rs i)
     have contradiction := dist_from_code_bound_of_correlated_agreement (domain := domain) (f := f)
@@ -813,7 +813,7 @@ theorem folding_preserves_distance
       (d := d)
       h_k_d
       h_d_n
-      (fun i ↦ 
+      (fun i ↦
         And.left <| Classical.choose_spec (h_rs (cast' i)))
     rw [Finset.card_image_of_injective _ CosetFftDomain.injective] at contradiction
     have contradiction : (Δ₀(f, code (domain : Fin (2 ^ n) ↪ F) d) : ENNReal)

--- a/ArkLib/Data/CodingTheory/ProximityGap/ProximityGenerators.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/ProximityGenerators.lean
@@ -74,14 +74,14 @@ Defined inside Definition 3.12 [BCGM25]. -/
 def M_G (G : Generator S ℓ F) : Matrix S ℓ F :=
   Matrix.of G
 
-noncomputable example [DecidableEq F] (G : Generator S ℓ F) : LinearCode S F :=
-  LinearCode.fromColGenMat (M_G G)
+noncomputable example [DecidableEq F] (G : Generator S ℓ F) : LinearCode ℓ F :=
+  LinearCode.fromRowGenMat (M_G G)
 
 /-- A generator `G` is MDS if the matrix `M_G` whose rows are the outputs of the generator
 function is a generator matrix for an MDS code.
 Definition 3.12 [BCGM25]. -/
 def IsMDSGenerator [DecidableEq F] (G : Generator S ℓ F) : Prop :=
-    LinearCode.IsMDS (LinearCode.fromColGenMat (M_G G))
+    LinearCode.IsMDS (LinearCode.fromRowGenMat (M_G G))
 
 /-- The condition for MCA generator. -/
 def IsMCA (G : Generator S ℓ F) (LC : LinearCode ι F) (x : S) (U : ℓ → (ι → F)) (γ : I) : Prop :=

--- a/ArkLib/Data/CodingTheory/ReedSolomon.lean
+++ b/ArkLib/Data/CodingTheory/ReedSolomon.lean
@@ -140,8 +140,8 @@ variable [Semiring F]
 lemma mem_code_of_polynomial_of_degree_lt_of_eval {n : ℕ} {α : ι ↪ F} {f : ι → F}
   (p : Polynomial F)
   (hdeg : p.degree < n) (heval : ∀ i, f i = p.eval (α i)) :
-  f ∈ code α n := by 
-  aesop 
+  f ∈ code α n := by
+  aesop
     (add simp [code, evalOnPoints,
                Polynomial.degreeLT,
                Polynomial.degree_lt_iff_coeff_zero])
@@ -149,7 +149,7 @@ lemma mem_code_of_polynomial_of_degree_lt_of_eval {n : ℕ} {α : ι ↪ F} {f :
 lemma mem_code_of_polynomial_of_natDegree_lt_of_eval {n : ℕ} {α : ι ↪ F} {f : ι → F}
   (p : Polynomial F)
   (hdeg : p.natDegree < n) (heval : ∀ i, f i = p.eval (α i)) :
-  f ∈ code α n := by 
+  f ∈ code α n := by
   by_cases h0 : p = 0
   · have hf : f = 0 := by aesop
     simp [hf]
@@ -157,13 +157,13 @@ lemma mem_code_of_polynomial_of_natDegree_lt_of_eval {n : ℕ} {α : ι ↪ F} {
     exact mem_code_of_polynomial_of_degree_lt_of_eval _ hdeg heval
 
 lemma mem_code_iff_exists_polynomial {n : ℕ} {α : ι ↪ F} {f : ι → F} :
-  f ∈ code α n ↔ ∃ p : Polynomial F, p.degree < n ∧ f = evalOnPoints α p := by 
-  constructor <;> 
+  f ∈ code α n ↔ ∃ p : Polynomial F, p.degree < n ∧ f = evalOnPoints α p := by
+  constructor <;>
     intro h <;>
     obtain ⟨p, h₁, h₂⟩ := h <;>
     exists p <;>
-    aesop (add simp 
-            [Polynomial.degreeLT, 
+    aesop (add simp
+            [Polynomial.degreeLT,
              Polynomial.degree_lt_iff_coeff_zero])
 
 lemma mem_code_iff_exists_polynomial_of_ne_zero {n : ℕ} [ne : NeZero n] {α : ι ↪ F} {f : ι → F} :


### PR DESCRIPTION
Posted by the assistant on behalf of Quang Dao. AI-authored by Codex (GPT-5).

## Summary
- Change `IsMDSGenerator` to build the code from the rows of `M_G`, matching the documented shape `Matrix S ℓ F` where rows are generator outputs.
- Update the local sanity example to return `LinearCode ℓ F`.
- Trim trailing whitespace reported by `git diff --check` in nearby recent changes.

## Root Cause
`M_G` was defined as a row-indexed matrix of generator outputs, but `IsMDSGenerator` used `fromColGenMat`, which typechecked while producing a code indexed by seeds `S` instead of output coordinates `ℓ`. The definition was not exercised downstream, so CI had no consumer forcing the intended index shape.

## Validation
- `git diff --check`
- `lake build ArkLib.Data.CodingTheory.ProximityGap.ProximityGenerators ArkLib.Data.CodingTheory.ProximityGap.Folding ArkLib.Data.CodingTheory.ReedSolomon`
- `./scripts/validate.sh`