### PR TITLE
Restore MDS generator code length

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/ProximityGenerators.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/ProximityGenerators.lean
@@ -74,14 +74,14 @@ Defined inside Definition 3.12 [BCGM25]. -/
 def M_G (G : Generator S ℓ F) : Matrix S ℓ F :=
   Matrix.of G
 
-noncomputable example [DecidableEq F] (G : Generator S ℓ F) : LinearCode ℓ F :=
-  LinearCode.fromRowGenMat (M_G G)
+noncomputable example [DecidableEq F] (G : Generator S ℓ F) : LinearCode S F :=
+  LinearCode.fromColGenMat (M_G G)
 
 /-- A generator `G` is MDS if the matrix `M_G` whose rows are the outputs of the generator
 function is a generator matrix for an MDS code.
 Definition 3.12 [BCGM25]. -/
 def IsMDSGenerator [DecidableEq F] (G : Generator S ℓ F) : Prop :=
-    LinearCode.IsMDS (LinearCode.fromRowGenMat (M_G G))
+    LinearCode.IsMDS (LinearCode.fromColGenMat (M_G G))
 
 /-- The condition for MCA generator. -/
 def IsMCA (G : Generator S ℓ F) (LC : LinearCode ι F) (x : S) (U : ℓ → (ι → F)) (γ : I) : Prop :=


### PR DESCRIPTION
Posted by the assistant on behalf of Quang Dao. AI-authored by Codex (GPT-5).

## Summary
- Restore `IsMDSGenerator` to use `LinearCode.fromColGenMat (M_G G)`.
- Restore the local example to return `LinearCode S F`.

## Root Cause
PR #508 incorrectly changed the MDS-generator code orientation after reading `M_G : Matrix S ℓ F` as a row-generator matrix for a length-`ℓ` code. Definition 3.12 instead defines `C_G = { M_G · vᵀ : v ∈ F^ℓ }`, so the resulting words are indexed by seeds `S` and the code length is `|S|`.

The original ArkLib encoding with `fromColGenMat` matches that paper definition: for `M_G : Matrix S ℓ F`, it produces a `LinearCode S F`.

## Validation
- `git diff --check`
- `lake build ArkLib.Data.CodingTheory.ProximityGap.ProximityGenerators`
- `./scripts/validate.sh`