### PR TITLE
ci: rename style_guide_path to additional_instructions_path

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,6 +27,6 @@ jobs:
           github_repository: ${{ github.repository }}
           pr_number: ${{ github.event.pull_request.number }}
           # Optional:
-          style_guide_path: 'CONTRIBUTING.md'
+          additional_instructions_path: 'CONTRIBUTING.md'
           validate_title: 'true'
           # upstream_path: 'ToMathlib/'


### PR DESCRIPTION
Tracks the upstream rename in alexanderlhicks/lean-summary-workflow. The input semantics are unchanged for ArkLib's deployment — the new name better reflects that the file passed in can be any deployment- supplied instructions, not just a style guide. CONTRIBUTING.md continues to be the file the agent reads.

Merge ordering: the upstream lean-summary-workflow PR renaming the input must land before this PR.