### PR TITLE
Explicit formula for codeword folding when `k=1`

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -67,6 +67,98 @@ section
 variable {domain : SmoothCosetFftDomain n F} {f : Word F (Fin (2 ^ n))}
 variable {k : ℕ} {x : F}
 
+omit [DecidableEq F] in
+private lemma even_add_odd_eq_of_2_ne_0
+  (x y z : F) (hz : z ≠ 0) (hchar : (2 : F) ≠ 0) :
+  x = (x + y) / 2 + (x - y) / (2 * z) * z := by grind
+
+omit [DecidableEq F] in
+private lemma even_add_odd_eq_of_not_charp_2
+  (x y z : F) (hz : z ≠ 0) (hchar : ¬CharP F 2) :
+  x = (x + y) / 2 + (x - y) / (2 * z) * z := 
+  even_add_odd_eq_of_2_ne_0 _ _ _ hz <| fun contra ↦ hchar <|
+    ringChar.of_eq (CharP.ringChar_of_prime_eq_zero Nat.prime_two contra)
+
+/-- An explicit formula to compute `foldWordAux` when `k = 2`
+  not involving Lagrange interpolation. -/
+lemma foldWordAux_of_k_2
+  [NeZero n]
+  {i : Fin (2 ^ (n - 1))} :
+  foldWordAux domain f 2 (domain.subdomainNatReversed 1 i) = 
+    let x : domain := CosetFftDomain.twoNthRoot (i := 1)
+      ⟨domain.subdomainNatReversed 1 i, by simp⟩
+    let i := domain.log x
+    let i' := domain.log ⟨-x.1, by obtain ⟨x, hx⟩ := x; simpa using hx⟩
+    C ((f i + f i') / 2) + Polynomial.X * C ((f i - f i') / (2 * x)) := by
+  unfold foldWordAux 
+  have hn : n ≠ 0 := NeZero.ne _
+  extract_lets y j j'
+  have h : 
+    ({i_1 | domain i_1 ^ 2 = (CosetFftDomain.subdomainNatReversed domain 1) i} : Finset _) = 
+    {j, j'} := by 
+    have h := CosetFftDomain.subdomainNatReversed_square_roots_explicit 
+      (ω := domain) (i := 0) (by omega) (y := y) 
+      (x := (CosetFftDomain.subdomainNatReversed domain 1) i)
+      (by simp) (by simp [y])
+    have hpre : Finset.preimage {y.1, -y.1} domain (by simp) = {j, j'} := by 
+      aesop (add unsafe (by apply CosetFftDomain.injective (ω := domain))) 
+    ext u 
+    simp only [mem_filter, mem_univ, true_and, ←hpre, ←h, Nat.sub_zero, mem_preimage,
+      CosetFftDomain.mem_coset_finset_iff_mem_coset_domain, iff_and_self]
+    have := @CosetFftDomain.subdomainNatReversed_zero (ω := domain)
+    aesop 
+  rw [h]
+  have hcard : Finset.card {j, j'} = 2 := by
+    rw [←h]
+    conv_rhs => 
+      rw [←pow_one 2,
+          ←CosetFftDomain.subdomainNatReversed_roots_card (ω := domain) (i := 0)
+              (x := (CosetFftDomain.subdomainNatReversed domain 1) i)
+              (by omega) (by simp)]
+    exact Finset.card_bij
+      (fun a _ ↦ domain a)
+      (fun a ha ↦ by
+        simp only [mem_filter, CosetFftDomain.mem_coset_finset_iff_mem_coset_domain]
+        rw [CosetFftDomain.subdomainNatReversed_zero]
+        aesop)
+      (fun _ _ _ _ h ↦ CosetFftDomain.injective h)
+      (fun b hb ↦ by 
+        obtain ⟨⟨j, hb⟩, hb'⟩ : 
+          b ∈ domain ∧ b ^ 2 = (CosetFftDomain.subdomainNatReversed domain 1) i := by 
+          have := @CosetFftDomain.subdomainNatReversed_zero (ω := domain)
+          aesop
+        exact ⟨j, by simp [hb, hb'], by simp [hb]⟩)
+  apply Polynomial.eq_of_eval_eq_degree (n := 2) (s := {y.1, -y.1})
+  · exact lt_of_lt_of_le 
+      (Lagrange.degree_interpolate_lt _ CosetFftDomain.injOn) 
+      (by simp [hcard])
+  · exact lt_of_le_of_lt (Polynomial.degree_add_le _ _) <| by
+      simp only [X_mul_C, degree_mul, degree_X, WithBot.coe_ofNat, sup_lt_iff]
+      constructor 
+      · exact lt_trans Polynomial.degree_C_lt (by simp)
+      · exact lt_of_lt_of_le 
+          (WithBot.add_lt_add_right (by simp) Polynomial.degree_C_lt) (by rfl)
+  · conv_rhs => 
+      rw [←hcard] 
+    exact Finset.card_le_card_of_injOn (f := domain)
+      (fun x hx ↦ by aesop) CosetFftDomain.injOn
+  · intro x hx
+    have hx : (x = domain j ∧ y.1 = domain j) ∨ 
+              (x = domain j' ∧ y.1 = -domain j') := by aesop 
+    have hj := even_add_odd_eq_of_not_charp_2 (f j) (f j') (domain j) (by simp)
+      (CosetFftDomain.subdomain_implies_char_ne_2 domain)
+    have hj' := even_add_odd_eq_of_not_charp_2 (f j') (f j) (domain j') (by simp)
+      (CosetFftDomain.subdomain_implies_char_ne_2 domain)
+    rcases hx with ⟨rfl, hy⟩ | ⟨rfl, hy⟩
+    · rw [Lagrange.eval_interpolate_at_node _ CosetFftDomain.injOn (by simp),
+          hy]
+      conv_lhs => rw [hj]
+      simp
+    · rw [Lagrange.eval_interpolate_at_node _ CosetFftDomain.injOn (by simp), hy]
+      conv_lhs => rw [hj']
+      simp
+      grind
+
 private lemma roots_of_x_in_domain_eq
   (hk : k ≠ 0) :
   ({i | domain i ^ k = x} : Finset (Fin (2 ^ n))) = 
@@ -109,7 +201,7 @@ lemma foldWordAux_natDegree {k : ℕ} {x : F}
     · rw [Polynomial.natDegree_lt_iff_degree_lt heq]
       exact Lagrange.degree_interpolate_lt _ (by simp)
     · exact roots_of_x_in_domain_le_k hne
-            
+
 /-- Compute value of the folded word. 
   Takes the auxiliary polynomial `foldWordAux` and evaluates it on `a`,
   the folding randomness. -/
@@ -133,6 +225,18 @@ lemma foldValue_pow_x_k {i : Fin (2 ^ n)} :
 @[simp]
 lemma foldValue_zero {k : ℕ} :
   foldValue domain 0 k = 0 := by aesop (add simp [foldValue, foldWordAux])
+ 
+/-- An explicit formula for `foldValue` when `k = 1`. -/
+lemma foldValue_k_1 [NeZero n] {i : Fin (2 ^ (n - 1))} {α : F} :
+  foldValue domain f 1 α (domain.subdomainNatReversed 1 i) = 
+    let x : domain := CosetFftDomain.twoNthRoot (i := 1)
+        ⟨domain.subdomainNatReversed 1 i, by simp⟩
+    let i := domain.log x
+    let i' := domain.log ⟨-x.1, by obtain ⟨x, hx⟩ := x; simpa using hx⟩
+    ((f i + f i') / 2) + α * ((f i - f i') / (2 * x)) := by 
+  aesop 
+    (add simp [foldValue, foldWordAux_of_k_2])
+    (add safe (by grind))
 
 /-- Fold a word. Takes a word `f` over `Fin (2 ^ n)` and randomness
   `a`, and returns a word over `Fin (2 ^ (n - k))`. -/
@@ -144,6 +248,17 @@ noncomputable def foldWord (domain : SmoothCosetFftDomain n F)
 @[simp]
 lemma foldWord_zero {k : ℕ} :
   foldWord domain 0 k = 0 := by aesop (add simp [foldWord])
+
+/-- An explicit formula for `foldWord` when `k = 1` that
+  does not use Lagrange interpolation. -/
+theorem foldWord_k_1 [NeZero n] {i : Fin (2 ^ (n - 1))} {α : F} :
+  foldWord domain f 1 α i = 
+    let x : domain := CosetFftDomain.twoNthRoot (i := 1)
+        ⟨domain.subdomainNatReversed 1 i, by simp⟩
+    let i := domain.log x
+    let i' := domain.log ⟨-x.1, by obtain ⟨x, hx⟩ := x; simpa using hx⟩
+    ((f i + f i') / 2) + α * ((f i - f i') / (2 * x)) := by 
+  simp [foldWord, foldValue_k_1]
 
 omit [DecidableEq F] in
 /-- TODO: this will go once this https://github.com/Verified-zkEVM/CompPoly/pull/203
@@ -851,6 +966,7 @@ theorem folding_preserves_distance
         norm_cast
     simp only [lt_inf_iff] at δ_lt
     simpa using lt_of_lt_of_le δ_lt.1 contradiction 
-    
+
 end
+    
 end ProximityGap

--- a/ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean
+++ b/ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Group.TypeTags.Basic
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Tactic.Cases
 import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Field
 
 /-!
@@ -128,7 +129,7 @@ algorithm.
 set_option linter.style.induction false
 set_option linter.unusedDecidableInType false
 set_option linter.unusedFintypeInType false
-set_option linter.style.longFile 1900
+set_option linter.style.longFile 2100
 
 namespace ReedSolomon
 
@@ -354,6 +355,12 @@ lemma zero_is_not_in_domain {ω : FftDomain ι F} :
   intro x
   have h := domain_elem_invertible (ω := ω) (i := x)
   aesop
+
+@[simp]
+lemma domain_ne_zero {ω : FftDomain ι F} {i : ι} :
+  ω i ≠ 0 := fun contra ↦ zero_is_not_in_domain (ω := ω) <| by
+    rw [mem_domain_iff_exists]
+    exact ⟨_, contra⟩
 
 @[simp]
 lemma domain_zero_eq_one {ω : FftDomain ι F} :
@@ -651,6 +658,13 @@ lemma zero_is_not_in_domain {ω : CosetFftDomain ι F} :
 
 omit [Fintype ι] [DecidableEq ι] [DecidableEq F] in
 @[simp]
+lemma coset_domain_ne_zero {ω : CosetFftDomain ι F} {i : ι} :
+  ω i ≠ 0 := fun contra ↦ zero_is_not_in_domain (ω := ω) <| by
+  rw [mem_coset_def]
+  exact ⟨_, symm contra⟩
+
+omit [Fintype ι] [DecidableEq ι] [DecidableEq F] in
+@[simp]
 lemma coset_domain_zero_eq_x {ω : CosetFftDomain ι F} :
   ω 0 = ω.x := by cases ω with
   | mk x _ =>
@@ -747,6 +761,16 @@ lemma log_left_inverse {n : ℕ} {ω : SmoothFftDomain n F} :
   Function.LeftInverse ω.log (fun x ↦ ⟨ω x, by simp⟩) := 
     fun x ↦ injective (ω := ω) (by simp)
 
+@[simp]
+lemma log_injective {n : ℕ} {ω : SmoothFftDomain n F} :
+  Function.Injective (log ω) := 
+  Function.LeftInverse.injective 
+    (Function.RightInverse.leftInverse log_right_inverse)
+    
+@[simp]
+lemma log_injOn {n : ℕ} {ω : SmoothFftDomain n F} {s : Set ω.toFinset} :
+  Set.InjOn (log ω) s := fun _ _ _ _ h ↦ log_injective h
+  
 private def subdomain_embed {n : ℕ} (i : Fin n.succ) (k : Fin (2 ^ (i : ℕ))) :
   Fin (2 ^ n) :=
   ⟨2 ^ (n - i) * k.val, match i, k with
@@ -1081,6 +1105,32 @@ lemma subdomain_subdomain_eq_subdomain {n} {ω : SmoothFftDomain n F}
       omega
     · rfl
 
+omit [DecidableEq F] in
+lemma subdomain_implies_char_ne_2 {n} [NeZero n] (ω : SmoothFftDomain n F) :
+  ¬CharP F 2 := fun hchar ↦ by 
+  have hn : n ≠ 0 := NeZero.ne _
+  set k : Fin (2 ^ n) := ⟨2 ^ (n - 1), pow_lt_pow_right₀ (by decide) (by omega)⟩
+  have hk_ne_zero : k ≠ 0 := by simp [Fin.ext_iff, k]
+  have h_ne_val : ω k ≠ ω 0 := fun h => hk_ne_zero (ω.injective h)
+  have h_ne_one : ω k ≠ 1 := by rwa [domain_zero_eq_one] at h_ne_val
+  have h_kk : k + k = 0 := by
+    ext
+    simp only [Fin.val_add, Fin.coe_ofNat_eq_mod, Nat.zero_mod, k]
+    rcases n with _ | n <;> simp_all
+    ring_nf
+    simp 
+  have h_sq : (ω k) ^ 2 = 1 := by
+    rw [sq, ←domain_add_eq_mul_domain, h_kk, domain_zero_eq_one]
+  have h_eq : ω k = 1 ∨ ω k = -1 := sq_eq_one_iff.mp h_sq
+  have h_neg_eq_pos : (-1 : F) = 1 := by
+    have : (2 : F) = 0 := CharP.cast_eq_zero F 2
+    conv_rhs =>
+      rw [show (1 : F) = 2 - 1 by norm_num, this]
+    simp
+  rcases h_eq with h | h
+  · exact h_ne_one h
+  · exact h_ne_one (by rwa [h_neg_eq_pos] at h)
+
 /-- Same as `subdomain` but takes a natural number. -/
 def subdomainNat {n} (ω : SmoothFftDomain n F) (i : ℕ) :
   SmoothFftDomain (Fin.ofNat n.succ i) F :=
@@ -1306,6 +1356,16 @@ lemma log_left_inverse {n : ℕ} {ω : SmoothCosetFftDomain n F} :
   Function.LeftInverse ω.log (fun x ↦ ⟨ω x, by simp⟩) := 
     fun x ↦ injective (ω := ω) (by simp)
 
+@[simp]
+lemma log_injective {n : ℕ} {ω : SmoothCosetFftDomain n F} :
+  Function.Injective (log ω) := 
+  Function.LeftInverse.injective 
+    (Function.RightInverse.leftInverse log_right_inverse)
+    
+@[simp]
+lemma log_injOn {n : ℕ} {ω : SmoothCosetFftDomain n F} {s : Set ω.toFinset} :
+  Set.InjOn (log ω) s := fun _ _ _ _ h ↦ log_injective h
+
 /-- Given a smooth coset FFT domain `ω` of log-order `n` returns
   a subdomain of log-order `i`. -/
 def subdomain {n : ℕ} (ω : SmoothCosetFftDomain n F) (i : Fin n.succ) :
@@ -1498,6 +1558,67 @@ lemma mul_property {n : ℕ} {ω : SmoothCosetFftDomain n F}
         simp +decide [FftDomain.domain_add_eq_mul_domain]
       exact h_mul _ _ hy (by simpa using FftDomain.subdomain_le_mem hji hb)
     }, by ring⟩
+
+omit [DecidableEq F] in
+lemma subdomain_implies_char_ne_2 {n} [NeZero n] (ω : SmoothCosetFftDomain n F) :
+  ¬CharP F 2 := FftDomain.subdomain_implies_char_ne_2 ω.fftDomain
+
+omit [DecidableEq F] in
+private lemma y_ne_neg_y_of_mem_coset {n} [NeZero n]
+  {ω : SmoothCosetFftDomain n F}
+  {y : F} (hy_mem : y ∈ ω) : y ≠ -y := by
+  have h_char := CosetFftDomain.subdomain_implies_char_ne_2 ω
+  contrapose! h_char
+  have h_char : (2 : F) = 0 := mul_left_cancel₀ (a := y) 
+      (fun contra ↦ by simp [contra] at hy_mem)
+      (by linear_combination h_char)
+  constructor
+  intro x
+  rw [←Nat.mod_add_div x 2]
+  cases Nat.mod_two_eq_zero_or_one x <;> simp +decide [*]
+
+omit [DecidableEq ι] in
+private lemma filter_sq_subset {ω : CosetFftDomain ι F}
+  {x y : F} (hy_mem : y ∈ ω.toFinset) (hy : y ^ 2 = x)
+  (hny_mem : -y ∈ ω.toFinset) :
+  {y, -y} ⊆ {z ∈ ω.toFinset | z ^ 2 = x} := by simp_all +decide [Finset.subset_iff]
+
+lemma sq_root_mem_subdomain {n} [NeZero n] {ω : SmoothCosetFftDomain n F}
+  {i : Fin n.succ} (hi : 0 < i) {x : F} {y : F}
+  (hx : x ∈ (ω.subdomain (i - 1)))
+  (hy : y ^ 2 = x) :
+  y ∈ subdomain ω i := by
+  have hn1 : 1 < n + 1 := by { have := NeZero.pos n; omega }
+  have h1 : (1 : Fin n.succ) ≤ i := by
+    rw [Fin.le_def, Fin.lt_def] at *
+    simp only [Fin.val_zero] at hi
+    simp only [Nat.succ_eq_add_one, Fin.coe_ofNat_eq_mod, Nat.mod_eq_of_lt hn1]
+    exact hi
+  obtain ⟨y', hy'_mem, hy'_pow⟩ := CosetFftDomain.subdomain_root_exists h1 hx
+  have hval : (1 : Fin n.succ).val = 1 := by simp [Nat.mod_eq_of_lt hn1]
+  rw [hval, pow_one] at hy'_pow
+  have hsq : y ^ 2 = y' ^ 2 := by rw [hy, hy'_pow]
+  rcases eq_or_eq_neg_of_sq_eq_sq _ _ hsq with rfl | rfl
+  · exact hy'_mem
+  · have : NeZero (↑i : ℕ) := ⟨by omega⟩
+    exact neg_mem_domain_of_mem hy'_mem
+
+lemma subdomain_square_roots_explicit {n} [NeZero n] {ω : SmoothCosetFftDomain n F}
+  {i : Fin n.succ} (hi : 0 < i) {x : F} {y : F}
+  (hx : x ∈ (ω.subdomain (i - 1)))
+  (hy : y ^ 2 = x) :
+  {y ∈ (ω.subdomain i).toFinset | y ^ 2 = x} = {y, -y} := by 
+  apply Finset.Subset.antisymm
+  · intro z hz
+    simp_all only [Nat.succ_eq_add_one, Finset.mem_filter,
+      mem_coset_finset_iff_mem_coset_domain, Finset.mem_insert, Finset.mem_singleton] 
+    exact eq_or_eq_neg_of_sq_eq_sq _ _ <| by rw [hz.2, hy]
+  · have hy_mem : y ∈ subdomain ω i := sq_root_mem_subdomain hi hx hy
+    simp_all only [Nat.succ_eq_add_one, Finset.subset_iff, Finset.mem_insert,
+    Finset.mem_singleton, Finset.mem_filter, mem_coset_finset_iff_mem_coset_domain,
+    forall_eq_or_imp, and_self, even_two, Even.neg_pow, and_true, forall_eq, true_and]
+    have : NeZero (↑i : ℕ) := ⟨by omega⟩
+    exact neg_mem_domain_of_mem hy_mem
 
 /-- Same as `subdomain` but takes a natural number. -/
 def subdomainNat {n : ℕ} (ω : SmoothCosetFftDomain n F) (i : ℕ) :
@@ -1755,6 +1876,22 @@ lemma subdomainNatReversed_mem_of_eq {n m k} {ω : SmoothCosetFftDomain n F}
   x ∈ ω.subdomainNatReversed m ↔ x ∈ ω.subdomainNatReversed k := by
   aesop (add simp [subdomainNatReversed, subdomainNat])
 
+lemma subdomainNatReversed_square_roots_explicit {n} [NeZero n] {ω : SmoothCosetFftDomain n F}
+  {i : ℕ} (hi : i < n) {x : F} {y : F}
+  (hx : x ∈ (ω.subdomainNatReversed (i + 1))) (hy : y ^ 2 = x) :
+  {y ∈ (ω.subdomainNatReversed i).toFinset | y ^ 2 = x} = {y, -y} := by 
+  unfold subdomainNatReversed at *
+  have hn : (n + 1 - 1 % (n + 1) + (n - i)) % (n + 1) =
+    (n - i - 1) % (n + 1) :=
+    Nat.mod_eq_mod_iff.mpr ⟨0, ⟨1, by rw [Nat.mod_eq_of_lt (by omega)]; grind⟩⟩
+  rw [←subdomain_square_roots_explicit 
+        (ω := ω) (i := ⟨n - i, by omega⟩) (x := x) 
+        (by aesop (add simp [Fin.lt_def])) (by 
+          convert hx <;> 
+            aesop
+              (add simp [Nat.sub_add_eq, Fin.val_sub])
+              (add safe (by grind))) hy]
+
 end
 
 def twoNthRootAux (n i : ℕ) (ω : SmoothCosetFftDomain n F)
@@ -1798,6 +1935,19 @@ lemma twoNthRoot_correct {n i : ℕ} {ω : SmoothCosetFftDomain n F}
   rw [subdomainNatReversed_zero, mem_coset_def] at hy_mem
   obtain ⟨j, rfl⟩ := hy_mem
   exact twoNthRootAux_correct _ _ le_rfl ⟨j, j.isLt, hy_pow⟩
+
+@[simp]
+lemma twoNthRoot_correct_one {n : ℕ} {ω : SmoothCosetFftDomain n F}
+  [nz : NeZero n]
+  {x : ω.subdomainNatReversed 1} :
+  (twoNthRoot x).val ^ 2 = x := by
+  have hi : 1 ≤ n := by 
+    have hn : n ≠ 0 := NeZero.ne _
+    omega
+  conv_lhs =>
+    rhs 
+    rw [←pow_one 2]
+  rw [twoNthRoot_correct hi]
 
 end CosetFftDomain
 

--- a/ArkLib/Data/MvPolynomial/LinearMvExtension.lean
+++ b/ArkLib/Data/MvPolynomial/LinearMvExtension.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 ArkLib Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mirco Richter (Least Authority)
+Authors: Ilia Vlasov, Mirco Richter (Least Authority), Aristotle (Harmonic)
 -/
 
 import ArkLib.Data.CodingTheory.Basic.DecodingRadius

--- a/docs/kb/_generated/declarations.json
+++ b/docs/kb/_generated/declarations.json
@@ -10786,7 +10786,34 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 70,
+          "line": 71,
+          "name": "ProximityGap.even_add_odd_eq_of_2_ne_0",
+          "namespace": "ProximityGap",
+          "short_name": "even_add_odd_eq_of_2_ne_0",
+          "signature": "lemma even_add_odd_eq_of_2_ne_0"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 76,
+          "name": "ProximityGap.even_add_odd_eq_of_not_charp_2",
+          "namespace": "ProximityGap",
+          "short_name": "even_add_odd_eq_of_not_charp_2",
+          "signature": "lemma even_add_odd_eq_of_not_charp_2"
+        },
+        {
+          "doc": "An explicit formula to compute `foldWordAux` when `k = 2` not involving Lagrange interpolation.",
+          "kind": "lemma",
+          "line": 84,
+          "name": "ProximityGap.foldWordAux_of_k_2",
+          "namespace": "ProximityGap",
+          "short_name": "foldWordAux_of_k_2",
+          "signature": "lemma foldWordAux_of_k_2"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 162,
           "name": "ProximityGap.roots_of_x_in_domain_eq",
           "namespace": "ProximityGap",
           "short_name": "roots_of_x_in_domain_eq",
@@ -10795,7 +10822,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 81,
+          "line": 173,
           "name": "ProximityGap.roots_of_x_in_domain_card",
           "namespace": "ProximityGap",
           "short_name": "roots_of_x_in_domain_card",
@@ -10804,7 +10831,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 89,
+          "line": 181,
           "name": "ProximityGap.roots_of_x_in_domain_le_k",
           "namespace": "ProximityGap",
           "short_name": "roots_of_x_in_domain_le_k",
@@ -10813,7 +10840,7 @@
         {
           "doc": "The natDegree of the auxiliary polynomial `foldWordAux` is less than k.",
           "kind": "lemma",
-          "line": 100,
+          "line": 192,
           "name": "ProximityGap.foldWordAux_natDegree",
           "namespace": "ProximityGap",
           "short_name": "foldWordAux_natDegree",
@@ -10822,7 +10849,7 @@
         {
           "doc": "Compute value of the folded word. Takes the auxiliary polynomial `foldWordAux` and evaluates it on `a`, the folding randomness.",
           "kind": "def",
-          "line": 116,
+          "line": 208,
           "name": "ProximityGap.foldValue",
           "namespace": "ProximityGap",
           "short_name": "foldValue",
@@ -10831,7 +10858,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 121,
+          "line": 213,
           "name": "ProximityGap.foldValue_def",
           "namespace": "ProximityGap",
           "short_name": "foldValue_def",
@@ -10840,7 +10867,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 124,
+          "line": 216,
           "name": "ProximityGap.foldValue_def'",
           "namespace": "ProximityGap",
           "short_name": "foldValue_def'",
@@ -10849,7 +10876,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 129,
+          "line": 221,
           "name": "ProximityGap.foldValue_pow_x_k",
           "namespace": "ProximityGap",
           "short_name": "foldValue_pow_x_k",
@@ -10858,16 +10885,25 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 134,
+          "line": 226,
           "name": "ProximityGap.foldValue_zero",
           "namespace": "ProximityGap",
           "short_name": "foldValue_zero",
           "signature": "lemma foldValue_zero {k : \u2115} :"
         },
         {
+          "doc": "An explicit formula for `foldValue` when `k = 1`.",
+          "kind": "lemma",
+          "line": 230,
+          "name": "ProximityGap.foldValue_k_1",
+          "namespace": "ProximityGap",
+          "short_name": "foldValue_k_1",
+          "signature": "lemma foldValue_k_1 [NeZero n] {i : Fin (2 ^ (n - 1))} {\u03b1 : F} :"
+        },
+        {
           "doc": "Fold a word. Takes a word `f` over `Fin (2 ^ n)` and randomness `a`, and returns a word over `Fin (2 ^ (n - k))`.",
           "kind": "def",
-          "line": 139,
+          "line": 243,
           "name": "ProximityGap.foldWord",
           "namespace": "ProximityGap",
           "short_name": "foldWord",
@@ -10876,16 +10912,25 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 145,
+          "line": 249,
           "name": "ProximityGap.foldWord_zero",
           "namespace": "ProximityGap",
           "short_name": "foldWord_zero",
           "signature": "lemma foldWord_zero {k : \u2115} :"
         },
         {
+          "doc": "An explicit formula for `foldWord` when `k = 1` that does not use Lagrange interpolation.",
+          "kind": "theorem",
+          "line": 254,
+          "name": "ProximityGap.foldWord_k_1",
+          "namespace": "ProximityGap",
+          "short_name": "foldWord_k_1",
+          "signature": "theorem foldWord_k_1 [NeZero n] {i : Fin (2 ^ (n - 1))} {\u03b1 : F} :"
+        },
+        {
           "doc": "TODO: this will go once this https://github.com/Verified-zkEVM/CompPoly/pull/203 is merged.",
           "kind": "lemma",
-          "line": 151,
+          "line": 266,
           "name": "ProximityGap.eval_comm",
           "namespace": "ProximityGap",
           "short_name": "eval_comm",
@@ -10894,7 +10939,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 160,
+          "line": 275,
           "name": "ProximityGap.roots_in_domain_card_eq_if_x_in_domain",
           "namespace": "ProximityGap",
           "short_name": "roots_in_domain_card_eq_if_x_in_domain",
@@ -10903,7 +10948,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 182,
+          "line": 297,
           "name": "ProximityGap.interpolate_eq_folding_poly_eval",
           "namespace": "ProximityGap",
           "short_name": "interpolate_eq_folding_poly_eval",
@@ -10912,7 +10957,7 @@
         {
           "doc": "Perfect completeness of folding: folding a codeword is the same as applying `polyFold` and then encoding.",
           "kind": "theorem",
-          "line": 231,
+          "line": 346,
           "name": "ProximityGap.foldWord_codeword",
           "namespace": "ProximityGap",
           "short_name": "foldWord_codeword",
@@ -10921,7 +10966,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 245,
+          "line": 360,
           "name": "ProximityGap.foldWordAuxCoeff",
           "namespace": "ProximityGap",
           "short_name": "foldWordAuxCoeff",
@@ -10930,7 +10975,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 249,
+          "line": 364,
           "name": "ProximityGap.foldWordAux_coeff_eq_foldWordAuxCoeff_fin",
           "namespace": "ProximityGap",
           "short_name": "foldWordAux_coeff_eq_foldWordAuxCoeff_fin",
@@ -10939,7 +10984,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 254,
+          "line": 369,
           "name": "ProximityGap.foldWordAux_coeff_eq_foldWordAuxCoeff_nat",
           "namespace": "ProximityGap",
           "short_name": "foldWordAux_coeff_eq_foldWordAuxCoeff_nat",
@@ -10948,7 +10993,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 266,
+          "line": 381,
           "name": "ProximityGap.foldWordAux_eq_sum_of_foldWordAuxCoeff",
           "namespace": "ProximityGap",
           "short_name": "foldWordAux_eq_sum_of_foldWordAuxCoeff",
@@ -10957,7 +11002,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 280,
+          "line": 395,
           "name": "ProximityGap.foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha",
           "namespace": "ProximityGap",
           "short_name": "foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha",
@@ -10966,7 +11011,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 290,
+          "line": 405,
           "name": "ProximityGap.indicatedPolynomial",
           "namespace": "ProximityGap",
           "short_name": "indicatedPolynomial",
@@ -10975,7 +11020,7 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 300,
+          "line": 415,
           "name": "ProximityGap.card_ne_zero",
           "namespace": "ProximityGap",
           "short_name": "card_ne_zero",
@@ -10984,7 +11029,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 303,
+          "line": 418,
           "name": "ProximityGap.indicated_polynomial_degree_x_lt",
           "namespace": "ProximityGap",
           "short_name": "indicated_polynomial_degree_x_lt",
@@ -10993,7 +11038,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 313,
+          "line": 428,
           "name": "ProximityGap.indicated_polynomial_degree_y_lt",
           "namespace": "ProximityGap",
           "short_name": "indicated_polynomial_degree_y_lt",
@@ -11002,7 +11047,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 324,
+          "line": 439,
           "name": "ProximityGap.indicated_polynomial_eq_foldAux",
           "namespace": "ProximityGap",
           "short_name": "indicated_polynomial_eq_foldAux",
@@ -11011,7 +11056,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 334,
+          "line": 449,
           "name": "ProximityGap.indicated_polynomial_eval_eq_combination_of_correlated",
           "namespace": "ProximityGap",
           "short_name": "indicated_polynomial_eval_eq_combination_of_correlated",
@@ -11020,7 +11065,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 347,
+          "line": 462,
           "name": "ProximityGap.indicated_polynomial_eq_combination_of_correlated",
           "namespace": "ProximityGap",
           "short_name": "indicated_polynomial_eq_combination_of_correlated",
@@ -11029,7 +11074,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 370,
+          "line": 485,
           "name": "ProximityGap.indicated_polynomial_eq_foldAux'",
           "namespace": "ProximityGap",
           "short_name": "indicated_polynomial_eq_foldAux'",
@@ -11038,7 +11083,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 402,
+          "line": 517,
           "name": "ProximityGap.foldWordAux_poly_sum",
           "namespace": "ProximityGap",
           "short_name": "foldWordAux_poly_sum",
@@ -11047,7 +11092,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 409,
+          "line": 524,
           "name": "ProximityGap.indicated_polynomial_comp_x_k_natDegree",
           "namespace": "ProximityGap",
           "short_name": "indicated_polynomial_comp_x_k_natDegree",
@@ -11056,7 +11101,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 441,
+          "line": 556,
           "name": "ProximityGap.eval_comp_x_pow_map_eq",
           "namespace": "ProximityGap",
           "short_name": "eval_comp_x_pow_map_eq",
@@ -11065,7 +11110,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 457,
+          "line": 572,
           "name": "ProximityGap.hammingDistComplementBound",
           "namespace": "ProximityGap",
           "short_name": "hammingDistComplementBound",
@@ -11074,7 +11119,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 465,
+          "line": 580,
           "name": "ProximityGap.hammingDistBound",
           "namespace": "ProximityGap",
           "short_name": "hammingDistBound",
@@ -11083,7 +11128,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 470,
+          "line": 585,
           "name": "ProximityGap.contradictory_hamming_dist_zero",
           "namespace": "ProximityGap",
           "short_name": "contradictory_hamming_dist_zero",
@@ -11092,7 +11137,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 475,
+          "line": 590,
           "name": "ProximityGap.contradictory_hamming_dist_formula",
           "namespace": "ProximityGap",
           "short_name": "contradictory_hamming_dist_formula",
@@ -11101,7 +11146,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 539,
+          "line": 654,
           "name": "ProximityGap.correlated_agreement_implies_contradictory_hamm_dist",
           "namespace": "ProximityGap",
           "short_name": "correlated_agreement_implies_contradictory_hamm_dist",
@@ -11110,7 +11155,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 606,
+          "line": 721,
           "name": "ProximityGap.dist_from_code_bound_of_correlated_agreement",
           "namespace": "ProximityGap",
           "short_name": "dist_from_code_bound_of_correlated_agreement",
@@ -11119,7 +11164,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 638,
+          "line": 753,
           "name": "ProximityGap.folded_rate_div_eq_helper",
           "namespace": "ProximityGap",
           "short_name": "folded_rate_div_eq_helper",
@@ -11128,7 +11173,7 @@
         {
           "doc": "The rate of the folded RS-code is the same.",
           "kind": "lemma",
-          "line": 651,
+          "line": 766,
           "name": "ProximityGap.folded_rate_eq",
           "namespace": "ProximityGap",
           "short_name": "folded_rate_eq",
@@ -11137,7 +11182,7 @@
         {
           "doc": "The square root of the rate of the folded RS-code is the same.",
           "kind": "lemma",
-          "line": 682,
+          "line": 797,
           "name": "ProximityGap.folded_sqrtRate_eq",
           "namespace": "ProximityGap",
           "short_name": "folded_sqrtRate_eq",
@@ -11146,7 +11191,7 @@
         {
           "doc": "Folding preserves distance from Reed\u2013Solomon codes. For any word `f` over the smooth coset FFT domain, degree parameter `d`, folding parameter `k`, and distance threshold `\u03b4` satisfying `0 < \u03b4 < min (\u03b4\u1d63(f, RS[d])) (1 - sqrtRate(d))`, the probability over a uniformly random folding challenge `r : F` that the folded word is within relative distance `\u03b4` of the Reed\u2013Solomon code of reduced degree `d / 2^k` on the folded subdomain is bounded by the proximity-gap error term. This is Lemma 4.9 from [ACFY24]: a random `2^k`-folding step preserves distance from the corresponding Reed\u2013Solomon code excep",
           "kind": "theorem",
-          "line": 708,
+          "line": 823,
           "name": "ProximityGap.folding_preserves_distance",
           "namespace": "ProximityGap",
           "short_name": "folding_preserves_distance",
@@ -11325,7 +11370,7 @@
         {
           "doc": "The Reed-Solomon code for polynomials of degree less than `deg` and evaluation points `domain`.",
           "kind": "def",
-          "line": 63,
+          "line": 62,
           "name": "ReedSolomon.code",
           "namespace": "ReedSolomon",
           "short_name": "code",
@@ -11334,7 +11379,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 66,
+          "line": 65,
           "name": "ReedSolomon.codewordToPoly",
           "namespace": "ReedSolomon",
           "short_name": "codewordToPoly",
@@ -11343,7 +11388,7 @@
         {
           "doc": "The generator matrix of the Reed-Solomon code of degree `deg` and evaluation points `domain`.",
           "kind": "def",
-          "line": 72,
+          "line": 71,
           "name": "ReedSolomon.genMatrix",
           "namespace": "ReedSolomon",
           "short_name": "genMatrix",
@@ -11352,7 +11397,7 @@
         {
           "doc": "The (parity)-check matrix of the Reed-Solomon code, assuming `\u03b9` is finite.",
           "kind": "def",
-          "line": 76,
+          "line": 75,
           "name": "ReedSolomon.checkMatrix",
           "namespace": "ReedSolomon",
           "short_name": "checkMatrix",
@@ -11361,7 +11406,7 @@
         {
           "doc": "",
           "kind": "abbrev",
-          "line": 95,
+          "line": 94,
           "name": "ReedSolomon.RScodeSet",
           "namespace": "ReedSolomon",
           "short_name": "RScodeSet",
@@ -11370,7 +11415,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 98,
+          "line": 97,
           "name": "ReedSolomon.toFinset",
           "namespace": "ReedSolomon",
           "short_name": "toFinset",
@@ -11379,7 +11424,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 112,
+          "line": 111,
           "name": "ReedSolomon.evalOnPoints_C",
           "namespace": "ReedSolomon",
           "short_name": "evalOnPoints_C",
@@ -11388,7 +11433,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 116,
+          "line": 115,
           "name": "ReedSolomon.evalOnPoints_X",
           "namespace": "ReedSolomon",
           "short_name": "evalOnPoints_X",
@@ -11397,7 +11442,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 119,
+          "line": 118,
           "name": "ReedSolomon.natDegree_lt_of_mem_degreeLT",
           "namespace": "ReedSolomon",
           "short_name": "natDegree_lt_of_mem_degreeLT",
@@ -11406,7 +11451,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 124,
+          "line": 123,
           "name": "ReedSolomon.encode",
           "namespace": "ReedSolomon",
           "short_name": "encode",
@@ -11415,7 +11460,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 127,
+          "line": 126,
           "name": "ReedSolomon.encode_mem_ReedSolomon_code",
           "namespace": "ReedSolomon",
           "short_name": "encode_mem_ReedSolomon_code",
@@ -11424,7 +11469,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 134,
+          "line": 133,
           "name": "ReedSolomon.makeZero",
           "namespace": "ReedSolomon",
           "short_name": "makeZero",
@@ -11433,7 +11478,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 137,
+          "line": 136,
           "name": "ReedSolomon.codewordIsZero_makeZero",
           "namespace": "ReedSolomon",
           "short_name": "codewordIsZero_makeZero",
@@ -11442,7 +11487,7 @@
         {
           "doc": "The Vandermonde matrix is the generator matrix for an RS code of length `\u03b9` and dimension `deg`.",
           "kind": "lemma",
-          "line": 144,
+          "line": 143,
           "name": "ReedSolomon.genMatIsVandermonde",
           "namespace": "ReedSolomon",
           "short_name": "genMatIsVandermonde",
@@ -11451,16 +11496,16 @@
         {
           "doc": "",
           "kind": "class",
-          "line": 146,
-          "name": "ReedSolomon._anon_class_146",
+          "line": 145,
+          "name": "ReedSolomon._anon_class_145",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_class_146",
+          "short_name": "_anon_class_145",
           "signature": "class classical"
         },
         {
           "doc": "",
           "kind": "lemma",
-          "line": 165,
+          "line": 164,
           "name": "ReedSolomon.mem_code_of_polynomial_of_degree_lt_of_eval",
           "namespace": "ReedSolomon",
           "short_name": "mem_code_of_polynomial_of_degree_lt_of_eval",
@@ -11469,7 +11514,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 174,
+          "line": 173,
           "name": "ReedSolomon.mem_code_of_polynomial_of_natDegree_lt_of_eval",
           "namespace": "ReedSolomon",
           "short_name": "mem_code_of_polynomial_of_natDegree_lt_of_eval",
@@ -11478,7 +11523,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 184,
+          "line": 183,
           "name": "ReedSolomon.mem_code_iff_exists_polynomial",
           "namespace": "ReedSolomon",
           "short_name": "mem_code_iff_exists_polynomial",
@@ -11487,7 +11532,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 194,
+          "line": 193,
           "name": "ReedSolomon.mem_code_iff_exists_polynomial_of_ne_zero",
           "namespace": "ReedSolomon",
           "short_name": "mem_code_iff_exists_polynomial_of_ne_zero",
@@ -11496,7 +11541,7 @@
         {
           "doc": "**Monotonicity of `code` in the degree bound.** If `n \u2264 m`, the degree-`n` Reed-Solomon code is contained in the degree-`m` code over the same domain.",
           "kind": "lemma",
-          "line": 210,
+          "line": 209,
           "name": "ReedSolomon.code_mono",
           "namespace": "ReedSolomon",
           "short_name": "code_mono",
@@ -11505,7 +11550,7 @@
         {
           "doc": "**The degree-zero Reed-Solomon code is trivial.** Only the zero word is a codeword of `code \u03b1 0`. A direct corollary of `Polynomial.degreeLT_zero` (general polynomial fact) + `Submodule.map_bot` (general linear-algebra fact).",
           "kind": "lemma",
-          "line": 218,
+          "line": 217,
           "name": "ReedSolomon.code_zero",
           "namespace": "ReedSolomon",
           "short_name": "code_zero",
@@ -11514,7 +11559,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 229,
+          "line": 228,
           "name": "ReedSolomon.dim_eq_deg_of_le",
           "namespace": "ReedSolomon",
           "short_name": "dim_eq_deg_of_le",
@@ -11523,16 +11568,16 @@
         {
           "doc": "",
           "kind": "class",
-          "line": 231,
-          "name": "ReedSolomon._anon_class_231",
+          "line": 230,
+          "name": "ReedSolomon._anon_class_230",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_class_231",
+          "short_name": "_anon_class_230",
           "signature": "class classical"
         },
         {
           "doc": "Generalized dimension formula for RS code with arbitrary finite index type `\u03b9`.",
           "kind": "lemma",
-          "line": 238,
+          "line": 237,
           "name": "ReedSolomon.dim_eq_deg_of_le'",
           "namespace": "ReedSolomon",
           "short_name": "dim_eq_deg_of_le'",
@@ -11541,7 +11586,7 @@
         {
           "doc": "The dimension of an RS-code equals the cardinality of the evaluation points if the original degree exceeds the cardinality.",
           "kind": "lemma",
-          "line": 294,
+          "line": 293,
           "name": "ReedSolomon.dim_eq_card_of_lt",
           "namespace": "ReedSolomon",
           "short_name": "dim_eq_card_of_lt",
@@ -11550,7 +11595,7 @@
         {
           "doc": "Assumption-less expression for the dimension of an RS-code. The dimension equals the minimum of the degree and the cardinality of the evaluation set.",
           "kind": "theorem",
-          "line": 324,
+          "line": 323,
           "name": "ReedSolomon.dim_eq_min_deg_card",
           "namespace": "ReedSolomon",
           "short_name": "dim_eq_min_deg_card",
@@ -11559,7 +11604,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 335,
+          "line": 334,
           "name": "ReedSolomon.length_eq_domain_size",
           "namespace": "ReedSolomon",
           "short_name": "length_eq_domain_size",
@@ -11568,7 +11613,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 339,
+          "line": 338,
           "name": "ReedSolomon.rateOfLinearCode_eq_div",
           "namespace": "ReedSolomon",
           "short_name": "rateOfLinearCode_eq_div",
@@ -11577,7 +11622,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 344,
+          "line": 343,
           "name": "ReedSolomon.length_eq_domain_card'",
           "namespace": "ReedSolomon",
           "short_name": "length_eq_domain_card'",
@@ -11586,7 +11631,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 351,
+          "line": 350,
           "name": "ReedSolomon.rateOfLinearCode_eq_div'",
           "namespace": "ReedSolomon",
           "short_name": "rateOfLinearCode_eq_div'",
@@ -11595,7 +11640,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 358,
+          "line": 357,
           "name": "ReedSolomon.rateOfLinearCode_eq_min_div",
           "namespace": "ReedSolomon",
           "short_name": "rateOfLinearCode_eq_min_div",
@@ -11604,7 +11649,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 365,
+          "line": 364,
           "name": "ReedSolomon.dist_le_length",
           "namespace": "ReedSolomon",
           "short_name": "dist_le_length",
@@ -11613,7 +11658,7 @@
         {
           "doc": "",
           "kind": "abbrev",
-          "line": 370,
+          "line": 369,
           "name": "ReedSolomon.sqrtRate",
           "namespace": "ReedSolomon",
           "short_name": "sqrtRate",
@@ -11622,7 +11667,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 375,
+          "line": 374,
           "name": "ReedSolomon.card_le_card_of_count_inj",
           "namespace": "ReedSolomon",
           "short_name": "card_le_card_of_count_inj",
@@ -11631,16 +11676,16 @@
         {
           "doc": "",
           "kind": "class",
-          "line": 379,
-          "name": "ReedSolomon._anon_class_379",
+          "line": 378,
+          "name": "ReedSolomon._anon_class_378",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_class_379",
+          "short_name": "_anon_class_378",
           "signature": "class classical"
         },
         {
           "doc": "",
           "kind": "def",
-          "line": 391,
+          "line": 390,
           "name": "ReedSolomon.constantCode",
           "namespace": "ReedSolomon",
           "short_name": "constantCode",
@@ -11649,7 +11694,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 396,
+          "line": 395,
           "name": "ReedSolomon.weight_constantCode",
           "namespace": "ReedSolomon",
           "short_name": "weight_constantCode",
@@ -11658,7 +11703,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 401,
+          "line": 400,
           "name": "ReedSolomon.constantCode_mem_code",
           "namespace": "ReedSolomon",
           "short_name": "constantCode_mem_code",
@@ -11667,7 +11712,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 407,
+          "line": 406,
           "name": "ReedSolomon.constantCode_eq_ofNat_zero_iff",
           "namespace": "ReedSolomon",
           "short_name": "constantCode_eq_ofNat_zero_iff",
@@ -11676,7 +11721,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 413,
+          "line": 412,
           "name": "ReedSolomon.wt_constantCode",
           "namespace": "ReedSolomon",
           "short_name": "wt_constantCode",
@@ -11685,7 +11730,7 @@
         {
           "doc": "The minimal code distance of an RS code of length `\u03b9` and dimension `deg` is `\u03b9 - deg + 1`.",
           "kind": "theorem",
-          "line": 420,
+          "line": 419,
           "name": "ReedSolomon.minDist",
           "namespace": "ReedSolomon",
           "short_name": "minDist",
@@ -11694,7 +11739,7 @@
         {
           "doc": "Generalized minimal code distance for RS code with arbitrary finite index type `\u03b9`.",
           "kind": "theorem",
-          "line": 453,
+          "line": 452,
           "name": "ReedSolomon.minDist'",
           "namespace": "ReedSolomon",
           "short_name": "minDist'",
@@ -11703,16 +11748,16 @@
         {
           "doc": "",
           "kind": "class",
-          "line": 456,
-          "name": "ReedSolomon._anon_class_456",
+          "line": 455,
+          "name": "ReedSolomon._anon_class_455",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_class_456",
+          "short_name": "_anon_class_455",
           "signature": "class classical"
         },
         {
           "doc": "Reed-Solomon codes are maximum distance separable (MDS).",
           "kind": "lemma",
-          "line": 495,
+          "line": 494,
           "name": "ReedSolomon.isMDS_code",
           "namespace": "ReedSolomon",
           "short_name": "isMDS_code",
@@ -11721,16 +11766,16 @@
         {
           "doc": "",
           "kind": "class",
-          "line": 497,
-          "name": "ReedSolomon._anon_class_497",
+          "line": 496,
+          "name": "ReedSolomon._anon_class_496",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_class_497",
+          "short_name": "_anon_class_496",
           "signature": "class classical"
         },
         {
           "doc": "Generalized distance equality for RS code with arbitrary finite index type `\u03b9`.",
           "kind": "theorem",
-          "line": 503,
+          "line": 502,
           "name": "ReedSolomon.dist_eq'",
           "namespace": "ReedSolomon",
           "short_name": "dist_eq'",
@@ -11739,7 +11784,7 @@
         {
           "doc": "",
           "kind": "theorem",
-          "line": 509,
+          "line": 508,
           "name": "ReedSolomon.dist_eq",
           "namespace": "ReedSolomon",
           "short_name": "dist_eq",
@@ -11748,7 +11793,7 @@
         {
           "doc": "Generalized unique decoding radius for RS code with arbitrary finite index type `\u03b9`.",
           "kind": "theorem",
-          "line": 516,
+          "line": 515,
           "name": "ReedSolomon.uniqueDecodingRadius_RS_eq'",
           "namespace": "ReedSolomon",
           "short_name": "uniqueDecodingRadius_RS_eq'",
@@ -11757,7 +11802,7 @@
         {
           "doc": "Generalized relative unique decoding radius for RS code with arbitrary finite index type `\u03b9`.",
           "kind": "theorem",
-          "line": 528,
+          "line": 527,
           "name": "ReedSolomon.relativeUniqueDecodingRadius_RS_eq'",
           "namespace": "ReedSolomon",
           "short_name": "relativeUniqueDecodingRadius_RS_eq'",
@@ -11766,7 +11811,7 @@
         {
           "doc": "The exact unique decoding radius for Reed-Solomon codes via MDS property: `d = n - k + 1`. The unique decoding radius is \u230a(d-1)/2\u230b = \u230a(n-k)/2\u230b.",
           "kind": "theorem",
-          "line": 547,
+          "line": 546,
           "name": "ReedSolomon.uniqueDecodingRadius_RS_eq",
           "namespace": "ReedSolomon",
           "short_name": "uniqueDecodingRadius_RS_eq",
@@ -11775,7 +11820,7 @@
         {
           "doc": "The relative unique decoding radius for Reed-Solomon codes: `(1 - \u03c1)/2`.",
           "kind": "theorem",
-          "line": 556,
+          "line": 555,
           "name": "ReedSolomon.relativeUniqueDecodingRadius_RS_eq",
           "namespace": "ReedSolomon",
           "short_name": "relativeUniqueDecodingRadius_RS_eq",
@@ -11784,7 +11829,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 570,
+          "line": 569,
           "name": "ReedSolomon.finCarrier",
           "namespace": "ReedSolomon",
           "short_name": "finCarrier",
@@ -11793,7 +11838,7 @@
         {
           "doc": "The linear map that maps a codeword `f : \u03b9 \u2192 F` to a degree < |\u03b9| polynomial p, such that `p(x) = f(x)` for all `x \u2208 \u03b9`.",
           "kind": "def",
-          "line": 586,
+          "line": 585,
           "name": "ReedSolomon.interpolate",
           "namespace": "ReedSolomon",
           "short_name": "interpolate",
@@ -11802,7 +11847,7 @@
         {
           "doc": "The linear map that maps a Reed-Solomon codeword to its associated polynomial.",
           "kind": "def",
-          "line": 590,
+          "line": 589,
           "name": "ReedSolomon.decode",
           "namespace": "ReedSolomon",
           "short_name": "decode",
@@ -11811,7 +11856,7 @@
         {
           "doc": "Reed-Solomon codewords are decoded into degree smaller than `deg` polynomials.",
           "kind": "lemma",
-          "line": 596,
+          "line": 595,
           "name": "ReedSolomon.decoded_polynomial_lt_deg",
           "namespace": "ReedSolomon",
           "short_name": "decoded_polynomial_lt_deg",
@@ -11820,7 +11865,7 @@
         {
           "doc": "The linear map that maps a Reed-Solomon codeword to its associated polynomial of degree less than `deg`.",
           "kind": "def",
-          "line": 644,
+          "line": 643,
           "name": "ReedSolomon.decodeLT",
           "namespace": "ReedSolomon",
           "short_name": "decodeLT",
@@ -11829,7 +11874,7 @@
         {
           "doc": "A domain `\u03b9 \u21aa F` is `smooth`, if `\u03b9 \u2286 F`, `|\u03b9| = 2^k` for some `k` and there exists a subgroup `H` in the group of units `R\u02e3` and an invertible element `a \u2208 R` such that `\u03b9 = a \u2022 H`",
           "kind": "class",
-          "line": 657,
+          "line": 656,
           "name": "ReedSolomon.Smooth",
           "namespace": "ReedSolomon",
           "short_name": "Smooth",
@@ -11838,7 +11883,7 @@
         {
           "doc": "Definition 4.2, WHIR[ACFY24] Smooth Reed-Solomon codes are Reed-Solomon codes defined over smooth domains, such that their decoded univariate polynomials are of degree less than `2\u1d50` for some `m \u2208 \u2115`.",
           "kind": "def",
-          "line": 673,
+          "line": 672,
           "name": "ReedSolomon.smoothCode",
           "namespace": "ReedSolomon",
           "short_name": "smoothCode",
@@ -11847,7 +11892,7 @@
         {
           "doc": "The linear map that maps smooth Reed-Solomon Code words to their decoded degreewise linear `m`-variate polynomial.",
           "kind": "def",
-          "line": 679,
+          "line": 678,
           "name": "ReedSolomon.mVdecode",
           "namespace": "ReedSolomon",
           "short_name": "mVdecode",
@@ -11856,7 +11901,7 @@
         {
           "doc": "Auxiliary function to assign values to the weight polynomial variables: index `0` \u21a6 `p.eval b`, index `j+1` \u21a6 `b j`.",
           "kind": "def",
-          "line": 685,
+          "line": 684,
           "name": "ReedSolomon.toWeightAssignment",
           "namespace": "ReedSolomon",
           "short_name": "toWeightAssignment",
@@ -11865,7 +11910,7 @@
         {
           "doc": "Constraint is true, if `\u2211 {b \u2208 {0,1}^m} w(f(b),b) = \u03c3` for given `m`-variate polynomial `f` and `(m+1)`-variate polynomial `w`.",
           "kind": "def",
-          "line": 694,
+          "line": 693,
           "name": "ReedSolomon.weightConstraint",
           "namespace": "ReedSolomon",
           "short_name": "weightConstraint",
@@ -11874,7 +11919,7 @@
         {
           "doc": "Definition 4.5, WHIR[ACFY24] Constrained Reed-Solomon codes are smooth codes whose decoded `m`-variate polynomial satisfies the weight constraint for given `w` and `\u03c3`.",
           "kind": "def",
-          "line": 703,
+          "line": 702,
           "name": "ReedSolomon.constrainedCode",
           "namespace": "ReedSolomon",
           "short_name": "constrainedCode",
@@ -11883,7 +11928,7 @@
         {
           "doc": "Definition 4.6, WHIR[ACFY24] Multi-constrained Reed-Solomon codes are smooth codes whose decoded `m`-variate polynomial satisfies the `t` weight constraints for given `w\u2080,..., w\u209c\u208b\u2081` and `\u03c3\u2080,..., \u03c3\u209c\u208b\u2081`.",
           "kind": "def",
-          "line": 712,
+          "line": 711,
           "name": "ReedSolomon.multiConstrainedCode",
           "namespace": "ReedSolomon",
           "short_name": "multiConstrainedCode",
@@ -11896,7 +11941,7 @@
         {
           "doc": "An FFT domain is an injective group homomorphism whose codomain is the multiplicative group of a field.",
           "kind": "structure",
-          "line": 141,
+          "line": 142,
           "name": "ReedSolomon.FftDomain",
           "namespace": "ReedSolomon",
           "short_name": "FftDomain",
@@ -11905,7 +11950,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 149,
+          "line": 150,
           "name": "ReedSolomon.FftDomain.eq_iff_domains_eq",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "eq_iff_domains_eq",
@@ -11914,16 +11959,16 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 156,
-          "name": "ReedSolomon._anon_instance_156",
+          "line": 157,
+          "name": "ReedSolomon._anon_instance_157",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_156",
+          "short_name": "_anon_instance_157",
           "signature": "instance instance : FunLike (FftDomain \u03b9 F) \u03b9 F where"
         },
         {
           "doc": "",
           "kind": "lemma",
-          "line": 165,
+          "line": 166,
           "name": "ReedSolomon.FftDomain.eval_fft_domain_eq_eval_domain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "eval_fft_domain_eq_eval_domain",
@@ -11932,25 +11977,25 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 171,
-          "name": "ReedSolomon._anon_instance_171",
+          "line": 172,
+          "name": "ReedSolomon._anon_instance_172",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_171",
+          "short_name": "_anon_instance_172",
           "signature": "instance instance : Coe (FftDomain \u03b9 F) (\u03b9 \u21aa F) where"
         },
         {
           "doc": "",
           "kind": "instance",
-          "line": 178,
-          "name": "ReedSolomon._anon_instance_178",
+          "line": 179,
+          "name": "ReedSolomon._anon_instance_179",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_178",
+          "short_name": "_anon_instance_179",
           "signature": "instance instance : Membership F (FftDomain \u03b9 F) where"
         },
         {
           "doc": "",
           "kind": "def",
-          "line": 183,
+          "line": 184,
           "name": "ReedSolomon.FftDomain.toFinset",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "toFinset",
@@ -11959,52 +12004,52 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 185,
-          "name": "ReedSolomon.FftDomain._anon_instance_185",
+          "line": 186,
+          "name": "ReedSolomon.FftDomain._anon_instance_186",
           "namespace": "ReedSolomon.FftDomain",
-          "short_name": "_anon_instance_185",
+          "short_name": "_anon_instance_186",
           "signature": "instance instance"
         },
         {
           "doc": "",
           "kind": "instance",
-          "line": 193,
-          "name": "ReedSolomon._anon_instance_193",
+          "line": 194,
+          "name": "ReedSolomon._anon_instance_194",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_193",
+          "short_name": "_anon_instance_194",
           "signature": "instance instance {\u03c9 : FftDomain \u03b9 F} : Inhabited \u03c9.toFinset where"
         },
         {
           "doc": "",
           "kind": "def",
-          "line": 194,
-          "name": "ReedSolomon._anon_def_194",
+          "line": 195,
+          "name": "ReedSolomon._anon_def_195",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_def_194",
+          "short_name": "_anon_def_195",
           "signature": "def default := \u27e8\u03c9 0, by simp [FftDomain.toFinset]\u27e9"
         },
         {
           "doc": "",
           "kind": "instance",
-          "line": 196,
-          "name": "ReedSolomon._anon_instance_196",
+          "line": 197,
+          "name": "ReedSolomon._anon_instance_197",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_196",
+          "short_name": "_anon_instance_197",
           "signature": "instance instance {\u03c9 : FftDomain \u03b9 F} : Inhabited \u03c9 where"
         },
         {
           "doc": "",
           "kind": "def",
-          "line": 197,
-          "name": "ReedSolomon._anon_def_197",
+          "line": 198,
+          "name": "ReedSolomon._anon_def_198",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_def_197",
+          "short_name": "_anon_def_198",
           "signature": "def default := \u27e8\u03c9 0, by simp [FftDomain.toFinset]\u27e9"
         },
         {
           "doc": "",
           "kind": "lemma",
-          "line": 202,
+          "line": 203,
           "name": "ReedSolomon.FftDomain.mem_domain_iff_exists",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_domain_iff_exists",
@@ -12013,7 +12058,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 207,
+          "line": 208,
           "name": "ReedSolomon.FftDomain.mem_domain_self",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_domain_self",
@@ -12022,7 +12067,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 211,
+          "line": 212,
           "name": "ReedSolomon.FftDomain.mem_finset_iff_exists",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_finset_iff_exists",
@@ -12031,7 +12076,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 216,
+          "line": 217,
           "name": "ReedSolomon.FftDomain.mem_finset_iff_mem_domain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_finset_iff_mem_domain",
@@ -12040,7 +12085,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 221,
+          "line": 222,
           "name": "ReedSolomon.FftDomain.mem_domain_finset_self",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_domain_finset_self",
@@ -12049,16 +12094,16 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 228,
-          "name": "ReedSolomon._anon_instance_228",
+          "line": 229,
+          "name": "ReedSolomon._anon_instance_229",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_228",
+          "short_name": "_anon_instance_229",
           "signature": "instance instance {x : F} {\u03c9 : FftDomain \u03b9 F} : Decidable (x \u2208 \u03c9) :="
         },
         {
           "doc": "A helper to convert a finset into a list whose elements are the members of the finset, i.e. come with a proof that they belong to the finset.",
           "kind": "def",
-          "line": 237,
+          "line": 238,
           "name": "ReedSolomon.Finset.toListWithProof.",
           "namespace": "ReedSolomon.Finset",
           "short_name": "toListWithProof.",
@@ -12067,7 +12112,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 244,
+          "line": 245,
           "name": "ReedSolomon.Finset.toListWithProof_empty.",
           "namespace": "ReedSolomon.Finset",
           "short_name": "toListWithProof_empty.",
@@ -12076,7 +12121,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 248,
+          "line": 249,
           "name": "ReedSolomon.Finset.toListWithProof_mem.",
           "namespace": "ReedSolomon.Finset",
           "short_name": "toListWithProof_mem.",
@@ -12085,7 +12130,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 255,
+          "line": 256,
           "name": "ReedSolomon.Finset.list_reduceOption_helper",
           "namespace": "ReedSolomon.Finset",
           "short_name": "list_reduceOption_helper",
@@ -12094,7 +12139,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 271,
+          "line": 272,
           "name": "ReedSolomon.Finset.toListWithProof_eq_toList.",
           "namespace": "ReedSolomon.Finset",
           "short_name": "toListWithProof_eq_toList.",
@@ -12103,7 +12148,7 @@
         {
           "doc": "Convert an FFT domain into a list of all its members with proofs the members belong to the FFT domain. Computable for FFT domains indexed by `Fin m`, by enumerating via `List.finRange m`.",
           "kind": "def",
-          "line": 286,
+          "line": 287,
           "name": "ReedSolomon.FftDomain.toList",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "toList",
@@ -12112,7 +12157,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 290,
+          "line": 291,
           "name": "ReedSolomon.FftDomain.toList_eq_finset_toList",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "toList_eq_finset_toList",
@@ -12121,7 +12166,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 295,
+          "line": 296,
           "name": "ReedSolomon.FftDomain.toSubgroup",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "toSubgroup",
@@ -12130,7 +12175,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 317,
+          "line": 318,
           "name": "ReedSolomon.FftDomain.mem_subgroup_iff_mem_finset",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_subgroup_iff_mem_finset",
@@ -12139,7 +12184,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 323,
+          "line": 324,
           "name": "ReedSolomon.FftDomain.mem_subgroup_iff_mem_domain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_subgroup_iff_mem_domain",
@@ -12148,25 +12193,25 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 328,
-          "name": "ReedSolomon._anon_instance_328",
+          "line": 329,
+          "name": "ReedSolomon._anon_instance_329",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_328",
+          "short_name": "_anon_instance_329",
           "signature": "instance instance : CoeOut (FftDomain \u03b9 F) (Finset F) where"
         },
         {
           "doc": "",
           "kind": "instance",
-          "line": 331,
-          "name": "ReedSolomon._anon_instance_331",
+          "line": 332,
+          "name": "ReedSolomon._anon_instance_332",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_331",
+          "short_name": "_anon_instance_332",
           "signature": "instance instance : CoeOut (FftDomain \u03b9 F) (Subgroup F\u02e3) where"
         },
         {
           "doc": "",
           "kind": "lemma",
-          "line": 339,
+          "line": 340,
           "name": "ReedSolomon.FftDomain.injective",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "injective",
@@ -12175,7 +12220,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 344,
+          "line": 345,
           "name": "ReedSolomon.FftDomain.injOn",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "injOn",
@@ -12184,7 +12229,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 347,
+          "line": 348,
           "name": "ReedSolomon.FftDomain.domain_elem_invertible",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "domain_elem_invertible",
@@ -12193,7 +12238,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 351,
+          "line": 352,
           "name": "ReedSolomon.FftDomain.zero_is_not_in_domain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "zero_is_not_in_domain",
@@ -12202,7 +12247,16 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 359,
+          "line": 360,
+          "name": "ReedSolomon.FftDomain.domain_ne_zero",
+          "namespace": "ReedSolomon.FftDomain",
+          "short_name": "domain_ne_zero",
+          "signature": "lemma domain_ne_zero {\u03c9 : FftDomain \u03b9 F} {i : \u03b9} :"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 366,
           "name": "ReedSolomon.FftDomain.domain_zero_eq_one",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "domain_zero_eq_one",
@@ -12211,7 +12265,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 365,
+          "line": 372,
           "name": "ReedSolomon.FftDomain.domain_add_eq_mul_domain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "domain_add_eq_mul_domain",
@@ -12220,7 +12274,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 372,
+          "line": 379,
           "name": "ReedSolomon.FftDomain.mul_mem_domain_of_mem",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mul_mem_domain_of_mem",
@@ -12229,7 +12283,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 381,
+          "line": 388,
           "name": "ReedSolomon.FftDomain.domain_neg_eq_inv_domain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "domain_neg_eq_inv_domain",
@@ -12238,7 +12292,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 388,
+          "line": 395,
           "name": "ReedSolomon.FftDomain.domain_sub_eq_div_domain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "domain_sub_eq_div_domain",
@@ -12247,7 +12301,7 @@
         {
           "doc": "",
           "kind": "theorem",
-          "line": 398,
+          "line": 405,
           "name": "ReedSolomon.FftDomain.ext",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "ext",
@@ -12256,7 +12310,7 @@
         {
           "doc": "A smooth FFT domain is an FFT domain whose domain (i.e. LHS) is a finite additive cyclic group, which up to isomorphis is `Fin n`.",
           "kind": "abbrev",
-          "line": 406,
+          "line": 413,
           "name": "ReedSolomon.SmoothFftDomain",
           "namespace": "ReedSolomon",
           "short_name": "SmoothFftDomain",
@@ -12265,7 +12319,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 412,
+          "line": 419,
           "name": "ReedSolomon.FftDomain.neg_one_mem_domain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "neg_one_mem_domain",
@@ -12274,7 +12328,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 445,
+          "line": 452,
           "name": "ReedSolomon.FftDomain.neg_mem_domain_of_mem",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "neg_mem_domain_of_mem",
@@ -12283,7 +12337,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 453,
+          "line": 460,
           "name": "ReedSolomon.FftDomain.neg_mem_domain_iff_mem",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "neg_mem_domain_iff_mem",
@@ -12292,7 +12346,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 462,
+          "line": 469,
           "name": "ReedSolomon.FftDomain.size_of_smooth_fft_domain_eq_pow_of_2",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "size_of_smooth_fft_domain_eq_pow_of_2",
@@ -12301,7 +12355,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 467,
+          "line": 474,
           "name": "ReedSolomon.FftDomain.domain_nsmul",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "domain_nsmul",
@@ -12310,7 +12364,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 474,
+          "line": 481,
           "name": "ReedSolomon.FftDomain.val_eq_nsmul_one",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "val_eq_nsmul_one",
@@ -12319,7 +12373,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 484,
+          "line": 491,
           "name": "ReedSolomon.FftDomain.domain_eq_pow_of_generator",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "domain_eq_pow_of_generator",
@@ -12328,7 +12382,7 @@
         {
           "doc": "",
           "kind": "theorem",
-          "line": 490,
+          "line": 497,
           "name": "ReedSolomon.FftDomain.eq_iff_generators_eq",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "eq_iff_generators_eq",
@@ -12337,7 +12391,7 @@
         {
           "doc": "A coset FFT domain is a domain of the form `x \u00b7 G` for an FFT domain `G`.",
           "kind": "structure",
-          "line": 500,
+          "line": 507,
           "name": "ReedSolomon.CosetFftDomain",
           "namespace": "ReedSolomon",
           "short_name": "CosetFftDomain",
@@ -12346,7 +12400,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 508,
+          "line": 515,
           "name": "ReedSolomon.CosetFftDomain.eq_iff_domains_and_gen_eq",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "eq_iff_domains_and_gen_eq",
@@ -12355,16 +12409,16 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 515,
-          "name": "ReedSolomon._anon_instance_515",
+          "line": 522,
+          "name": "ReedSolomon._anon_instance_522",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_515",
+          "short_name": "_anon_instance_522",
           "signature": "instance instance : FunLike (CosetFftDomain \u03b9 F) \u03b9 F where"
         },
         {
           "doc": "",
           "kind": "lemma",
-          "line": 526,
+          "line": 533,
           "name": "ReedSolomon.CosetFftDomain.eval_coset_fft_domain_eq_eval_x_mul_domain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "eval_coset_fft_domain_eq_eval_x_mul_domain",
@@ -12373,25 +12427,25 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 532,
-          "name": "ReedSolomon._anon_instance_532",
+          "line": 539,
+          "name": "ReedSolomon._anon_instance_539",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_532",
+          "short_name": "_anon_instance_539",
           "signature": "instance instance : Coe (CosetFftDomain \u03b9 F) (\u03b9 \u21aa F) where"
         },
         {
           "doc": "",
           "kind": "instance",
-          "line": 540,
-          "name": "ReedSolomon._anon_instance_540",
+          "line": 547,
+          "name": "ReedSolomon._anon_instance_547",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_540",
+          "short_name": "_anon_instance_547",
           "signature": "instance instance : Membership F (CosetFftDomain \u03b9 F) where"
         },
         {
           "doc": "",
           "kind": "def",
-          "line": 545,
+          "line": 552,
           "name": "ReedSolomon.CosetFftDomain.toFinset",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "toFinset",
@@ -12400,52 +12454,52 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 548,
-          "name": "ReedSolomon.CosetFftDomain._anon_instance_548",
+          "line": 555,
+          "name": "ReedSolomon.CosetFftDomain._anon_instance_555",
           "namespace": "ReedSolomon.CosetFftDomain",
-          "short_name": "_anon_instance_548",
+          "short_name": "_anon_instance_555",
           "signature": "instance instance"
         },
         {
           "doc": "",
           "kind": "instance",
-          "line": 556,
-          "name": "ReedSolomon._anon_instance_556",
+          "line": 563,
+          "name": "ReedSolomon._anon_instance_563",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_556",
+          "short_name": "_anon_instance_563",
           "signature": "instance instance {\u03c9 : CosetFftDomain \u03b9 F} : Inhabited \u03c9.toFinset where"
         },
         {
           "doc": "",
           "kind": "def",
-          "line": 557,
-          "name": "ReedSolomon._anon_def_557",
+          "line": 564,
+          "name": "ReedSolomon._anon_def_564",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_def_557",
+          "short_name": "_anon_def_564",
           "signature": "def default := \u27e8\u03c9 0, by simp [CosetFftDomain.toFinset]\u27e9"
         },
         {
           "doc": "",
           "kind": "instance",
-          "line": 559,
-          "name": "ReedSolomon._anon_instance_559",
+          "line": 566,
+          "name": "ReedSolomon._anon_instance_566",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_559",
+          "short_name": "_anon_instance_566",
           "signature": "instance instance {\u03c9 : CosetFftDomain \u03b9 F} : Inhabited \u03c9 where"
         },
         {
           "doc": "",
           "kind": "def",
-          "line": 560,
-          "name": "ReedSolomon._anon_def_560",
+          "line": 567,
+          "name": "ReedSolomon._anon_def_567",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_def_560",
+          "short_name": "_anon_def_567",
           "signature": "def default := \u27e8\u03c9 0, by simp [CosetFftDomain.toFinset]\u27e9"
         },
         {
           "doc": "",
           "kind": "lemma",
-          "line": 565,
+          "line": 572,
           "name": "ReedSolomon.CosetFftDomain.mem_coset_def",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mem_coset_def",
@@ -12454,7 +12508,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 570,
+          "line": 577,
           "name": "ReedSolomon.CosetFftDomain.mem_coset",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mem_coset",
@@ -12463,7 +12517,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 576,
+          "line": 583,
           "name": "ReedSolomon.CosetFftDomain.mem_coset_domain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mem_coset_domain",
@@ -12472,7 +12526,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 584,
+          "line": 591,
           "name": "ReedSolomon.CosetFftDomain.mem_coset_domain_self",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mem_coset_domain_self",
@@ -12481,7 +12535,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 589,
+          "line": 596,
           "name": "ReedSolomon.CosetFftDomain.mem_coset_finset_iff_mem_coset_domain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mem_coset_finset_iff_mem_coset_domain",
@@ -12490,7 +12544,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 595,
+          "line": 602,
           "name": "ReedSolomon.CosetFftDomain.mem_coset_finset_self",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mem_coset_finset_self",
@@ -12499,16 +12553,16 @@
         {
           "doc": "",
           "kind": "instance",
-          "line": 602,
-          "name": "ReedSolomon._anon_instance_602",
+          "line": 609,
+          "name": "ReedSolomon._anon_instance_609",
           "namespace": "ReedSolomon",
-          "short_name": "_anon_instance_602",
+          "short_name": "_anon_instance_609",
           "signature": "instance instance {x : F} {\u03c9 : CosetFftDomain \u03b9 F} : Decidable (x \u2208 \u03c9) :="
         },
         {
           "doc": "",
           "kind": "def",
-          "line": 607,
+          "line": 614,
           "name": "ReedSolomon.CosetFftDomain.toList",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "toList",
@@ -12517,7 +12571,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 612,
+          "line": 619,
           "name": "ReedSolomon.CosetFftDomain.toList_eq_finset_toList",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "toList_eq_finset_toList",
@@ -12526,7 +12580,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 618,
+          "line": 625,
           "name": "ReedSolomon.CosetFftDomain.coset_domain_eq_image",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "coset_domain_eq_image",
@@ -12535,7 +12589,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 624,
+          "line": 631,
           "name": "ReedSolomon.CosetFftDomain.card_eq_fft_domain_card",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "card_eq_fft_domain_card",
@@ -12544,7 +12598,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 632,
+          "line": 639,
           "name": "ReedSolomon.CosetFftDomain.injective",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "injective",
@@ -12553,7 +12607,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 639,
+          "line": 646,
           "name": "ReedSolomon.CosetFftDomain.injOn",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "injOn",
@@ -12562,7 +12616,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 644,
+          "line": 651,
           "name": "ReedSolomon.CosetFftDomain.zero_is_not_in_domain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "zero_is_not_in_domain",
@@ -12571,7 +12625,16 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 654,
+          "line": 661,
+          "name": "ReedSolomon.CosetFftDomain.coset_domain_ne_zero",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "coset_domain_ne_zero",
+          "signature": "lemma coset_domain_ne_zero {\u03c9 : CosetFftDomain \u03b9 F} {i : \u03b9} :"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 668,
           "name": "ReedSolomon.CosetFftDomain.coset_domain_zero_eq_x",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "coset_domain_zero_eq_x",
@@ -12580,7 +12643,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 660,
+          "line": 674,
           "name": "ReedSolomon.CosetFftDomain.coset_domain_add_eq_mul_domain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "coset_domain_add_eq_mul_domain",
@@ -12589,7 +12652,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 671,
+          "line": 685,
           "name": "ReedSolomon.CosetFftDomain.coset_domain_neg_eq_inv_domain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "coset_domain_neg_eq_inv_domain",
@@ -12598,7 +12661,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 679,
+          "line": 693,
           "name": "ReedSolomon.CosetFftDomain.coset_domain_sub_eq_div_domain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "coset_domain_sub_eq_div_domain",
@@ -12607,7 +12670,7 @@
         {
           "doc": "",
           "kind": "theorem",
-          "line": 689,
+          "line": 703,
           "name": "ReedSolomon.CosetFftDomain.ext",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "ext",
@@ -12616,7 +12679,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 700,
+          "line": 714,
           "name": "ReedSolomon.CosetFftDomain.x_mul_mem_coset_iff",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "x_mul_mem_coset_iff",
@@ -12625,7 +12688,7 @@
         {
           "doc": "A smooth coset FFT domain is a coset FFT domain whose underlying FFT domain is smooth.",
           "kind": "abbrev",
-          "line": 708,
+          "line": 722,
           "name": "ReedSolomon.SmoothCosetFftDomain",
           "namespace": "ReedSolomon",
           "short_name": "SmoothCosetFftDomain",
@@ -12634,7 +12697,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 713,
+          "line": 727,
           "name": "ReedSolomon.FftDomain.logAux",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "logAux",
@@ -12643,7 +12706,7 @@
         {
           "doc": "Finds a preimage of `x` under the mapping `\u03c9`.",
           "kind": "def",
-          "line": 723,
+          "line": 737,
           "name": "ReedSolomon.FftDomain.log",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "log",
@@ -12652,7 +12715,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 727,
+          "line": 741,
           "name": "ReedSolomon.FftDomain.log_right_inverse'",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "log_right_inverse'",
@@ -12661,7 +12724,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 743,
+          "line": 757,
           "name": "ReedSolomon.FftDomain.log_right_inverse",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "log_right_inverse",
@@ -12670,7 +12733,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 746,
+          "line": 760,
           "name": "ReedSolomon.FftDomain.log_left_inverse",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "log_left_inverse",
@@ -12678,8 +12741,26 @@
         },
         {
           "doc": "",
+          "kind": "lemma",
+          "line": 765,
+          "name": "ReedSolomon.FftDomain.log_injective",
+          "namespace": "ReedSolomon.FftDomain",
+          "short_name": "log_injective",
+          "signature": "lemma log_injective {n : \u2115} {\u03c9 : SmoothFftDomain n F} :"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 771,
+          "name": "ReedSolomon.FftDomain.log_injOn",
+          "namespace": "ReedSolomon.FftDomain",
+          "short_name": "log_injOn",
+          "signature": "lemma log_injOn {n : \u2115} {\u03c9 : SmoothFftDomain n F} {s : Set \u03c9.toFinset} :"
+        },
+        {
+          "doc": "",
           "kind": "def",
-          "line": 750,
+          "line": 774,
           "name": "ReedSolomon.FftDomain.subdomain_embed",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_embed",
@@ -12688,7 +12769,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 760,
+          "line": 784,
           "name": "ReedSolomon.FftDomain.subdomain_embed_add",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_embed_add",
@@ -12697,7 +12778,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 769,
+          "line": 793,
           "name": "ReedSolomon.FftDomain.subdomain_embed_zero",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_embed_zero",
@@ -12706,7 +12787,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 774,
+          "line": 798,
           "name": "ReedSolomon.FftDomain.subdomain_embed_injective",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_embed_injective",
@@ -12715,7 +12796,7 @@
         {
           "doc": "Given a smooth FFT domain `\u03c9` of log-order `n` this function returns its subdomain of log-order `i`.",
           "kind": "def",
-          "line": 782,
+          "line": 806,
           "name": "ReedSolomon.FftDomain.subdomain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain",
@@ -12724,7 +12805,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 794,
+          "line": 818,
           "name": "ReedSolomon.FftDomain.mem_subdomain_of_eq_vals",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_subdomain_of_eq_vals",
@@ -12733,7 +12814,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 801,
+          "line": 825,
           "name": "ReedSolomon.FftDomain.subdomain_0",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_0",
@@ -12742,7 +12823,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 810,
+          "line": 834,
           "name": "ReedSolomon.FftDomain.subdomain_0'",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_0'",
@@ -12751,7 +12832,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 818,
+          "line": 842,
           "name": "ReedSolomon.FftDomain.subdomain_embed_last",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_embed_last",
@@ -12760,7 +12841,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 824,
+          "line": 848,
           "name": "ReedSolomon.FftDomain.subdomain_last",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_last",
@@ -12769,7 +12850,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 838,
+          "line": 862,
           "name": "ReedSolomon.FftDomain.subdomain_last'",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_last'",
@@ -12778,7 +12859,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 849,
+          "line": 873,
           "name": "ReedSolomon.FftDomain.subdomain_embed_of_le",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_embed_of_le",
@@ -12787,7 +12868,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 861,
+          "line": 885,
           "name": "ReedSolomon.FftDomain.subdomain_le",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_le",
@@ -12796,7 +12877,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 872,
+          "line": 896,
           "name": "ReedSolomon.FftDomain.subdomain_le_finset",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_le_finset",
@@ -12805,7 +12886,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 885,
+          "line": 909,
           "name": "ReedSolomon.FftDomain.subdomain_le_mem",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_le_mem",
@@ -12814,7 +12895,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 894,
+          "line": 918,
           "name": "ReedSolomon.FftDomain.subdomain_embed_pow_eq",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_embed_pow_eq",
@@ -12823,7 +12904,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 921,
+          "line": 945,
           "name": "ReedSolomon.FftDomain.subdomain_eval",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_eval",
@@ -12832,7 +12913,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 929,
+          "line": 953,
           "name": "ReedSolomon.FftDomain.subdomain_pow_property_aux",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_pow_property_aux",
@@ -12841,7 +12922,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 937,
+          "line": 961,
           "name": "ReedSolomon.FftDomain.subdomain_pow_property",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_pow_property",
@@ -12850,7 +12931,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 962,
+          "line": 986,
           "name": "ReedSolomon.FftDomain.subdomain_pow_property'",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_pow_property'",
@@ -12859,7 +12940,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 968,
+          "line": 992,
           "name": "ReedSolomon.FftDomain.subdomain_roots_card",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_roots_card",
@@ -12868,7 +12949,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1051,
+          "line": 1075,
           "name": "ReedSolomon.FftDomain.subdomain_root_exists",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_root_exists",
@@ -12877,16 +12958,25 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1066,
+          "line": 1090,
           "name": "ReedSolomon.FftDomain.subdomain_subdomain_eq_subdomain",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomain_subdomain_eq_subdomain",
           "signature": "lemma subdomain_subdomain_eq_subdomain {n} {\u03c9 : SmoothFftDomain n F}"
         },
         {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1109,
+          "name": "ReedSolomon.FftDomain.subdomain_implies_char_ne_2",
+          "namespace": "ReedSolomon.FftDomain",
+          "short_name": "subdomain_implies_char_ne_2",
+          "signature": "lemma subdomain_implies_char_ne_2 {n} [NeZero n] (\u03c9 : SmoothFftDomain n F) :"
+        },
+        {
           "doc": "Same as `subdomain` but takes a natural number.",
           "kind": "def",
-          "line": 1085,
+          "line": 1135,
           "name": "ReedSolomon.FftDomain.subdomainNat",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNat",
@@ -12895,7 +12985,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1091,
+          "line": 1141,
           "name": "ReedSolomon.FftDomain.subdomainNat_zero",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNat_zero",
@@ -12904,7 +12994,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1100,
+          "line": 1150,
           "name": "ReedSolomon.FftDomain.subdomainNat_n",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNat_n",
@@ -12913,7 +13003,7 @@
         {
           "doc": "Same as `subdomain` but takes a natural number and reverses the order of subdomains.",
           "kind": "def",
-          "line": 1109,
+          "line": 1159,
           "name": "ReedSolomon.FftDomain.subdomainNatReversed",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNatReversed",
@@ -12922,7 +13012,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1114,
+          "line": 1164,
           "name": "ReedSolomon.FftDomain.mem_subdomainNatReversed_of_eq",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "mem_subdomainNatReversed_of_eq",
@@ -12931,7 +13021,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1124,
+          "line": 1174,
           "name": "ReedSolomon.FftDomain.subdomainNatReversed_zero",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNatReversed_zero",
@@ -12940,7 +13030,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1134,
+          "line": 1184,
           "name": "ReedSolomon.FftDomain.subdomainNatReversed_n",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNatReversed_n",
@@ -12949,7 +13039,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1141,
+          "line": 1191,
           "name": "ReedSolomon.FftDomain.subdomainNatReversed_sub",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNatReversed_sub",
@@ -12958,7 +13048,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1156,
+          "line": 1206,
           "name": "ReedSolomon.FftDomain.subdomainNatReversed_root_exists",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNatReversed_root_exists",
@@ -12967,7 +13057,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1190,
+          "line": 1240,
           "name": "ReedSolomon.FftDomain.subdomainNatReversed_mem_of_eq",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "subdomainNatReversed_mem_of_eq",
@@ -12976,7 +13066,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 1196,
+          "line": 1246,
           "name": "ReedSolomon.FftDomain.twoNthRootAux",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "twoNthRootAux",
@@ -12985,7 +13075,7 @@
         {
           "doc": "Finds a `2 ^ n`th root of `x`.",
           "kind": "def",
-          "line": 1208,
+          "line": 1258,
           "name": "ReedSolomon.FftDomain.twoNthRoot",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "twoNthRoot",
@@ -12994,7 +13084,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1212,
+          "line": 1262,
           "name": "ReedSolomon.FftDomain.twoNthRootAux_correct",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "twoNthRootAux_correct",
@@ -13003,7 +13093,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1224,
+          "line": 1274,
           "name": "ReedSolomon.FftDomain.twoNthRoot_correct",
           "namespace": "ReedSolomon.FftDomain",
           "short_name": "twoNthRoot_correct",
@@ -13012,7 +13102,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1247,
+          "line": 1297,
           "name": "ReedSolomon.CosetFftDomain.neg_mem_domain_of_mem",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "neg_mem_domain_of_mem",
@@ -13021,7 +13111,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1258,
+          "line": 1308,
           "name": "ReedSolomon.CosetFftDomain.neg_mem_domain_iff_mem",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "neg_mem_domain_iff_mem",
@@ -13030,7 +13120,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1267,
+          "line": 1317,
           "name": "ReedSolomon.CosetFftDomain.size_of_smooth_coset_domain_eq_pow_of_2",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "size_of_smooth_coset_domain_eq_pow_of_2",
@@ -13039,7 +13129,7 @@
         {
           "doc": "",
           "kind": "def",
-          "line": 1272,
+          "line": 1322,
           "name": "ReedSolomon.CosetFftDomain.logAux",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "logAux",
@@ -13048,7 +13138,7 @@
         {
           "doc": "Finds a preimage of `x` under the mapping `\u03c9`.",
           "kind": "def",
-          "line": 1282,
+          "line": 1332,
           "name": "ReedSolomon.CosetFftDomain.log",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "log",
@@ -13057,7 +13147,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1286,
+          "line": 1336,
           "name": "ReedSolomon.CosetFftDomain.log_right_inverse'",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "log_right_inverse'",
@@ -13066,7 +13156,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1302,
+          "line": 1352,
           "name": "ReedSolomon.CosetFftDomain.log_right_inverse",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "log_right_inverse",
@@ -13075,16 +13165,34 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1305,
+          "line": 1355,
           "name": "ReedSolomon.CosetFftDomain.log_left_inverse",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "log_left_inverse",
           "signature": "lemma log_left_inverse {n : \u2115} {\u03c9 : SmoothCosetFftDomain n F} :"
         },
         {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1360,
+          "name": "ReedSolomon.CosetFftDomain.log_injective",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "log_injective",
+          "signature": "lemma log_injective {n : \u2115} {\u03c9 : SmoothCosetFftDomain n F} :"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1366,
+          "name": "ReedSolomon.CosetFftDomain.log_injOn",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "log_injOn",
+          "signature": "lemma log_injOn {n : \u2115} {\u03c9 : SmoothCosetFftDomain n F} {s : Set \u03c9.toFinset} :"
+        },
+        {
           "doc": "Given a smooth coset FFT domain `\u03c9` of log-order `n` returns a subdomain of log-order `i`.",
           "kind": "def",
-          "line": 1311,
+          "line": 1371,
           "name": "ReedSolomon.CosetFftDomain.subdomain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain",
@@ -13093,7 +13201,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1316,
+          "line": 1376,
           "name": "ReedSolomon.CosetFftDomain.mem_subdomain_of_eq_vals",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mem_subdomain_of_eq_vals",
@@ -13102,7 +13210,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1324,
+          "line": 1384,
           "name": "ReedSolomon.CosetFftDomain.subdomain_x",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_x",
@@ -13111,7 +13219,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1329,
+          "line": 1389,
           "name": "ReedSolomon.CosetFftDomain.subdomain_fftDomain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_fftDomain",
@@ -13120,7 +13228,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1333,
+          "line": 1393,
           "name": "ReedSolomon.CosetFftDomain.subdomain_0",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_0",
@@ -13129,7 +13237,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1342,
+          "line": 1402,
           "name": "ReedSolomon.CosetFftDomain.subdomain_n",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_n",
@@ -13138,7 +13246,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1351,
+          "line": 1411,
           "name": "ReedSolomon.CosetFftDomain.subdomain_n'",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_n'",
@@ -13147,7 +13255,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1365,
+          "line": 1425,
           "name": "ReedSolomon.CosetFftDomain.subdomain_pow_property",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_pow_property",
@@ -13156,7 +13264,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1396,
+          "line": 1456,
           "name": "ReedSolomon.CosetFftDomain.subdomain_pow_property'",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_pow_property'",
@@ -13165,7 +13273,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1405,
+          "line": 1465,
           "name": "ReedSolomon.CosetFftDomain.card_filter_mod_eq'",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "card_filter_mod_eq'",
@@ -13174,7 +13282,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1421,
+          "line": 1481,
           "name": "ReedSolomon.CosetFftDomain.subdomain_roots_card",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_roots_card",
@@ -13183,7 +13291,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1468,
+          "line": 1528,
           "name": "ReedSolomon.CosetFftDomain.subdomain_root_exists",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomain_root_exists",
@@ -13192,16 +13300,61 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1483,
+          "line": 1543,
           "name": "ReedSolomon.CosetFftDomain.mul_property",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mul_property",
           "signature": "lemma mul_property {n : \u2115} {\u03c9 : SmoothCosetFftDomain n F}"
         },
         {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1563,
+          "name": "ReedSolomon.CosetFftDomain.subdomain_implies_char_ne_2",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "subdomain_implies_char_ne_2",
+          "signature": "lemma subdomain_implies_char_ne_2 {n} [NeZero n] (\u03c9 : SmoothCosetFftDomain n F) :"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1567,
+          "name": "ReedSolomon.CosetFftDomain.y_ne_neg_y_of_mem_coset",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "y_ne_neg_y_of_mem_coset",
+          "signature": "lemma y_ne_neg_y_of_mem_coset {n} [NeZero n]"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1581,
+          "name": "ReedSolomon.CosetFftDomain.filter_sq_subset",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "filter_sq_subset",
+          "signature": "lemma filter_sq_subset {\u03c9 : CosetFftDomain \u03b9 F}"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1586,
+          "name": "ReedSolomon.CosetFftDomain.sq_root_mem_subdomain",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "sq_root_mem_subdomain",
+          "signature": "lemma sq_root_mem_subdomain {n} [NeZero n] {\u03c9 : SmoothCosetFftDomain n F}"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1606,
+          "name": "ReedSolomon.CosetFftDomain.subdomain_square_roots_explicit",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "subdomain_square_roots_explicit",
+          "signature": "lemma subdomain_square_roots_explicit {n} [NeZero n] {\u03c9 : SmoothCosetFftDomain n F}"
+        },
+        {
           "doc": "Same as `subdomain` but takes a natural number.",
           "kind": "def",
-          "line": 1503,
+          "line": 1624,
           "name": "ReedSolomon.CosetFftDomain.subdomainNat",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNat",
@@ -13210,7 +13363,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1509,
+          "line": 1630,
           "name": "ReedSolomon.CosetFftDomain.subdomainNat_zero",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNat_zero",
@@ -13219,7 +13372,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1530,
+          "line": 1651,
           "name": "ReedSolomon.CosetFftDomain.subdomainNat_n",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNat_n",
@@ -13228,7 +13381,7 @@
         {
           "doc": "Same as `subdomain` but takes a natural number and reverses the order of subdomains.",
           "kind": "def",
-          "line": 1539,
+          "line": 1660,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed",
@@ -13237,7 +13390,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1544,
+          "line": 1665,
           "name": "ReedSolomon.CosetFftDomain.mem_subdomainNatReversed_of_eq",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "mem_subdomainNatReversed_of_eq",
@@ -13246,7 +13399,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1553,
+          "line": 1674,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_x",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_x",
@@ -13255,7 +13408,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1564,
+          "line": 1685,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_zero",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_zero",
@@ -13264,7 +13417,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1573,
+          "line": 1694,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_n",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_n",
@@ -13273,7 +13426,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1583,
+          "line": 1704,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_sub",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_sub",
@@ -13282,7 +13435,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1599,
+          "line": 1720,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_pow_property'",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_pow_property'",
@@ -13291,7 +13444,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1625,
+          "line": 1746,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_pow_property_main_domain",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_pow_property_main_domain",
@@ -13300,7 +13453,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1652,
+          "line": 1773,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_pow_property_main_domain_toFinset",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_pow_property_main_domain_toFinset",
@@ -13309,7 +13462,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1660,
+          "line": 1781,
           "name": "ReedSolomon.CosetFftDomain.subdomainNat_mul_property",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNat_mul_property",
@@ -13318,7 +13471,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1674,
+          "line": 1795,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_mul_property",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_mul_property",
@@ -13327,7 +13480,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1696,
+          "line": 1817,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_roots_card",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_roots_card",
@@ -13336,7 +13489,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1718,
+          "line": 1839,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_root_exists",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_root_exists",
@@ -13345,7 +13498,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1752,
+          "line": 1873,
           "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_mem_of_eq",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "subdomainNatReversed_mem_of_eq",
@@ -13353,8 +13506,17 @@
         },
         {
           "doc": "",
+          "kind": "lemma",
+          "line": 1879,
+          "name": "ReedSolomon.CosetFftDomain.subdomainNatReversed_square_roots_explicit",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "subdomainNatReversed_square_roots_explicit",
+          "signature": "lemma subdomainNatReversed_square_roots_explicit {n} [NeZero n] {\u03c9 : SmoothCosetFftDomain n F}"
+        },
+        {
+          "doc": "",
           "kind": "def",
-          "line": 1760,
+          "line": 1897,
           "name": "ReedSolomon.CosetFftDomain.twoNthRootAux",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "twoNthRootAux",
@@ -13363,7 +13525,7 @@
         {
           "doc": "Finds a `2 ^ n`th root of `x`.",
           "kind": "def",
-          "line": 1772,
+          "line": 1909,
           "name": "ReedSolomon.CosetFftDomain.twoNthRoot",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "twoNthRoot",
@@ -13372,7 +13534,7 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1776,
+          "line": 1913,
           "name": "ReedSolomon.CosetFftDomain.twoNthRootAux_correct",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "twoNthRootAux_correct",
@@ -13381,11 +13543,20 @@
         {
           "doc": "",
           "kind": "lemma",
-          "line": 1788,
+          "line": 1925,
           "name": "ReedSolomon.CosetFftDomain.twoNthRoot_correct",
           "namespace": "ReedSolomon.CosetFftDomain",
           "short_name": "twoNthRoot_correct",
           "signature": "lemma twoNthRoot_correct {n i : \u2115} {\u03c9 : SmoothCosetFftDomain n F}"
+        },
+        {
+          "doc": "",
+          "kind": "lemma",
+          "line": 1940,
+          "name": "ReedSolomon.CosetFftDomain.twoNthRoot_correct_one",
+          "namespace": "ReedSolomon.CosetFftDomain",
+          "short_name": "twoNthRoot_correct_one",
+          "signature": "lemma twoNthRoot_correct_one {n : \u2115} {\u03c9 : SmoothCosetFftDomain n F}"
         }
       ]
     },
@@ -37641,7 +37812,7 @@
   },
   "stats": {
     "ArkLib": {
-      "declarations": 4092,
+      "declarations": 4111,
       "files": 205
     }
   }

--- a/docs/kb/_generated/dedup-report.md
+++ b/docs/kb/_generated/dedup-report.md
@@ -4,7 +4,7 @@ Generated from `docs/kb/_generated/declarations.json`. **Eyeball, do not auto-re
 
 ## Stats
 
-- `ArkLib` — 205 files, 4092 declarations
+- `ArkLib` — 205 files, 4111 declarations
 
 ## Same short-name across multiple files (106 groups)
 
@@ -460,9 +460,9 @@ Each group lists declarations sharing a short name across ≥2 files. Most are l
 
 ### `toFinset` (3 declarations, 2 files)
 
-- `def ReedSolomon.toFinset` [ArkLib/Data/CodingTheory/ReedSolomon.lean:98](../../../ArkLib/Data/CodingTheory/ReedSolomon.lean#L98) — (no docstring)
-- `def ReedSolomon.FftDomain.toFinset` [ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean:183](../../../ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean#L183) — (no docstring)
-- `def ReedSolomon.CosetFftDomain.toFinset` [ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean:545](../../../ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean#L545) — (no docstring)
+- `def ReedSolomon.toFinset` [ArkLib/Data/CodingTheory/ReedSolomon.lean:97](../../../ArkLib/Data/CodingTheory/ReedSolomon.lean#L97) — (no docstring)
+- `def ReedSolomon.FftDomain.toFinset` [ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean:184](../../../ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean#L184) — (no docstring)
+- `def ReedSolomon.CosetFftDomain.toFinset` [ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean:552](../../../ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean#L552) — (no docstring)
 
 ### `ChallengeIdx` (2 declarations, 2 files)
 
@@ -627,7 +627,7 @@ Each group lists declarations sharing a short name across ≥2 files. Most are l
 ### `minDist` (2 declarations, 2 files)
 
 - `def Code.minDist` [ArkLib/Data/CodingTheory/Basic/Distance.lean:164](../../../ArkLib/Data/CodingTheory/Basic/Distance.lean#L164) — (no docstring)
-- `theorem ReedSolomon.minDist` [ArkLib/Data/CodingTheory/ReedSolomon.lean:420](../../../ArkLib/Data/CodingTheory/ReedSolomon.lean#L420) — The minimal code distance of an RS code of length `ι` and dimension `deg` is `ι - deg + 1`.
+- `theorem ReedSolomon.minDist` [ArkLib/Data/CodingTheory/ReedSolomon.lean:419](../../../ArkLib/Data/CodingTheory/ReedSolomon.lean#L419) — The minimal code distance of an RS code of length `ι` and dimension `deg` is `ι - deg + 1`.
 
 ### `pSpecCoreInteraction` (2 declarations, 2 files)
 


### PR DESCRIPTION
When folding dimension is `1` one does not need to perform Lagrange interpolation in order to fold a word. The formula becomes the well-known even-odd expression `(f(x) + f(-x))/2 + a * (f(x) - f(-x))/(2*x))`. This PR proves that.