### PR TITLE
chore: fix warnings

### DIFF
--- a/ArkLib/CommitmentScheme/Fold.lean
+++ b/ArkLib/CommitmentScheme/Fold.lean
@@ -75,8 +75,8 @@ open scoped Polynomial MvPolynomial NNReal
 --   prover_first' := by simp [pSpec]
 --   verifier_last' := by simp [pSpec, Neg.neg]
 
--- /-- Recognize that the (only) message from the prover to the verifier has type `Vector R (2 ^ n)`,
---   and hence can be turned into an oracle for evaluating the polynomial -/
+-- /-- Recognize that the (only) message from the prover to the verifier has type
+--   `Vector R (2 ^ n)`, and hence can be turned into an oracle for evaluating the polynomial -/
 -- instance instOracleInterfaceMessagePSpec : OracleInterface ((pSpec R n).Message default) := by
 --   simp [pSpec, default, Message, getType]
 --   exact instOracleInterfaceVector

--- a/ArkLib/OracleReduction/Composition/Sequential/Append.lean
+++ b/ArkLib/OracleReduction/Composition/Sequential/Append.lean
@@ -58,7 +58,9 @@ def Prover.append (P₁ : Prover oSpec Stmt₁ Wit₁ Stmt₂ Wit₂ pSpec₁)
 
   /- The combined prover's input function is the first prover's input function, except for when the
   first protocol is empty, in which case it is the second prover's input function -/
-  input := fun ctxIn => by simp; exact P₁.input ctxIn
+  input := fun ctxIn => by
+    simp only [Function.comp_apply, Fin.cast_zero]
+    exact P₁.input ctxIn
 
   /- The combined prover sends messages according to the round index `i` as follows:
   - if `i < m`, then it sends the message & updates the state as the first prover
@@ -92,8 +94,8 @@ def Prover.append (P₁ : Prover oSpec Stmt₁ Wit₁ Stmt₂ Wit₂ pSpec₁)
       Fin.cast, Fin.castLT, Fin.succ, Fin.castSucc] at hDir state ⊢
     by_cases hi : i < m
     · haveI : i < m + 1 := by omega
-      simp [hi, Fin.vappend_left_of_lt] at hDir ⊢
-      simp [this] at state
+      simp only [hi, Fin.vappend_left_of_lt, dif_pos (show ↑i + 1 < m + 1 by omega)] at hDir ⊢
+      simp only [this, dif_pos] at state
       exact P₁.receiveChallenge ⟨⟨i, hi⟩, hDir⟩ state
     · by_cases hi' : i = m
       · simp [hi', Fin.vappend_right_of_not_lt] at hDir state ⊢
@@ -114,13 +116,14 @@ def Prover.append (P₁ : Prover oSpec Stmt₁ Wit₁ Stmt₂ Wit₂ pSpec₁)
   output := fun state => by
     dsimp [Fin.append, Fin.addCases, Fin.tail, Fin.cast, Fin.last, Fin.subNat] at state
     by_cases hn : n = 0
-    · simp [hn] at state
+    · simp only [hn, Nat.add_zero, dif_pos (show m < m + 1 from lt_add_one m)] at state
       exact (do
         let ctxIn₂ ← P₁.output state
         letI state₂ := P₂.input ctxIn₂
         P₂.output (dcast (by simp [hn]) state₂))
     · haveI : m + n - (m + 1) + 1 = n := by omega
-      simp [hn] at state
+      simp only [Order.lt_add_one_iff, add_le_iff_nonpos_right, nonpos_iff_eq_zero, hn, ↓reduceDIte,
+        eq_rec_constant] at state
       exact P₂.output (dcast (by simp [this, Fin.last]) state)
 
 /-- Composition of verifiers. Return the conjunction of the decisions of the two verifiers. -/
@@ -246,7 +249,7 @@ def RoundByRound.append
       Extractor.RoundByRound oSpec Stmt₁ Wit₁ Wit₃ (pSpec₁ ++ₚ pSpec₂)
         (Fin.append (m := m + 1) WitMid₁ (Fin.tail WitMid₂) ∘ Fin.cast (by omega)) where
   eqIn := by
-    simp [Fin.append, Fin.addCases, Fin.castLT]
+    simp only [Function.comp_apply, Fin.cast_zero]
     exact E₁.eqIn
   extractMid := fun idx stmt₁ tr h => by
     dsimp [Fin.append, Fin.addCases, Fin.tail, Fin.castLT, Fin.cast] at h ⊢

--- a/ArkLib/OracleReduction/Composition/Sequential/General.lean
+++ b/ArkLib/OracleReduction/Composition/Sequential/General.lean
@@ -230,7 +230,10 @@ lemma seqCompose_toVerifier {m : ℕ}
     (seqCompose Stmt OStmt V).toVerifier =
       Verifier.seqCompose (fun i => Stmt i × (∀ j, OStmt i j)) (fun i => (V i).toVerifier) := by
   induction m with
-  | zero => simp; exact OracleVerifier.id_toVerifier
+  | zero =>
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero, Nat.reduceAdd,
+      Verifier.seqCompose_zero]
+    exact OracleVerifier.id_toVerifier
   | succ m ih =>
     simp only [seqCompose_succ, Verifier.seqCompose_succ]
     have h1 := OracleVerifier.append_toVerifier (V 0) (seqCompose (Stmt ∘ Fin.succ)
@@ -304,7 +307,10 @@ lemma seqCompose_toReduction {m : ℕ}
       Reduction.seqCompose (fun i => Stmt i × (∀ j, OStmt i j)) Wit
         (fun i => (R i).toReduction) := by
   induction m with
-  | zero => simp; exact OracleReduction.id_toReduction
+  | zero =>
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero, Nat.reduceAdd,
+      Reduction.seqCompose_zero]
+    exact OracleReduction.id_toReduction
   | succ m ih =>
     simp only [seqCompose_succ, Reduction.seqCompose_succ]
     have h1 := OracleReduction.append_toReduction (R 0) (seqCompose (Stmt ∘ Fin.succ)
@@ -357,10 +363,10 @@ theorem seqCompose_completeness
   induction m with
   | zero => simp only [seqCompose_zero]; exact id_perfectCompleteness init impl
   | succ m ih =>
-    simp
+    simp only [seqCompose_succ]
     have := ih (fun i => rel i.succ) (fun i => R i.succ)
       (fun i => completenessError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last] at this
     rw [Fin.sum_univ_succ]
     exact append_completeness
       (R 0)
@@ -394,12 +400,15 @@ theorem seqCompose_soundness
       (Verifier.seqCompose Stmt V).soundness init impl (lang 0) (lang (Fin.last m))
         (∑ i, soundnessError i) := by
   induction m with
-  | zero => simp; exact Verifier.id_soundness init impl
+  | zero =>
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero, Finset.univ_eq_empty,
+      Finset.sum_empty]
+    exact Verifier.id_soundness init impl
   | succ m ih =>
-    simp
+    simp only [seqCompose_succ]
     have := ih (fun i => lang i.succ) (fun i => V i.succ)
       (fun i => soundnessError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last] at this
     rw [Fin.sum_univ_succ]
     exact append_soundness (V 0) (seqCompose (Stmt ∘ Fin.succ) (fun i => V i.succ))
       (h 0) this
@@ -415,12 +424,15 @@ theorem seqCompose_knowledgeSoundness
       (Verifier.seqCompose Stmt V).knowledgeSoundness init impl (rel 0) (rel (Fin.last m))
         (∑ i, knowledgeError i) := by
   induction m with
-  | zero => simp; exact Verifier.id_knowledgeSoundness init impl
+  | zero =>
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero, Finset.univ_eq_empty,
+      Finset.sum_empty]
+    exact Verifier.id_knowledgeSoundness init impl
   | succ m ih =>
-    simp
+    simp only [seqCompose_succ]
     have := ih (fun i => rel i.succ) (fun i => V i.succ)
       (fun i => knowledgeError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last] at this
     rw [Fin.sum_univ_succ]
     exact append_knowledgeSoundness (V 0) (seqCompose (Stmt ∘ Fin.succ) (fun i => V i.succ))
       (h 0) this
@@ -438,15 +450,15 @@ theorem seqCompose_rbrSoundness
           rbrSoundnessError ij.1 ij.2) := by
   induction m with
   | zero =>
-    simp
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero, ChallengeIdx]
     convert Verifier.id_rbrSoundness init impl using 1
     funext ⟨i, _⟩
     exact Fin.elim0 i
   | succ m ih =>
-    simp
+    simp only [seqCompose_succ]
     have := ih (fun i => lang i.succ) (fun i => V i.succ)
       (fun i => rbrSoundnessError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last] at this
     convert append_rbrSoundness (V 0) (seqCompose (Stmt ∘ Fin.succ) (fun i => V i.succ))
       (h 0) this <;>
     sorry
@@ -466,15 +478,15 @@ theorem seqCompose_rbrKnowledgeSoundness
           rbrKnowledgeError ij.1 ij.2) := by
   induction m with
   | zero =>
-    simp
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero, ChallengeIdx]
     convert Verifier.id_rbrKnowledgeSoundness init impl using 1
     funext ⟨i, _⟩
     exact Fin.elim0 i
   | succ m ih =>
-    simp
+    simp only [seqCompose_succ]
     have := ih (fun i => rel i.succ) (fun i => V i.succ)
       (fun i => rbrKnowledgeError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last] at this
     convert append_rbrKnowledgeSoundness (V 0) (seqCompose (Stmt ∘ Fin.succ) (fun i => V i.succ))
       (h 0) this <;>
     sorry

--- a/ArkLib/OracleReduction/Equiv.lean
+++ b/ArkLib/OracleReduction/Equiv.lean
@@ -97,7 +97,8 @@ def symm (eqv : Equiv pSpec pSpec') : Equiv pSpec' pSpec where
   dir_eq := fun i => by simp [eqv.dir_eq]
   typeEquiv := fun i => (eqv.typeEquiv (Fin.cast (eqv.round_eq.symm) i)).symm
 
-/-- Compose protocol specification equivalences (spelled `equivTrans` because `trans` is reserved). -/
+/-- Compose protocol specification equivalences
+    (spelled `equivTrans` because `trans` is reserved). -/
 def equivTrans (eqv : Equiv pSpec pSpec') (eqv' : Equiv pSpec' pSpec'') : Equiv pSpec pSpec'' where
   round_eq := eqv.round_eq.trans eqv'.round_eq
   dir_eq := fun i => by simp [eqv.dir_eq, eqv'.dir_eq]

--- a/ArkLib/OracleReduction/FiatShamir/DuplexSponge/State.lean
+++ b/ArkLib/OracleReduction/FiatShamir/DuplexSponge/State.lean
@@ -226,7 +226,6 @@ pub fn hint_bytes(&mut self) -> Result<&'a [u8], DomainSeparatorMismatch>
 def hintBytes (state : FSVerifierState U H) :
     Except DomainSeparatorMismatch (FSVerifierState U H × ByteArray) := do
   let newHashState ← state.hashState.hint
-
     -- Ensure at least 4 bytes are available for the length prefix
   if state.nargString.size < 4 then
     .error { message := "Insufficient transcript remaining for hint" }
@@ -238,7 +237,6 @@ def hintBytes (state : FSVerifierState U H) :
     let byte3 := state.nargString[3]!.toNat
     let length := byte0 + (byte1 <<< 8) + (byte2 <<< 16) + (byte3 <<< 24)
     let rest := state.nargString.extract 4 state.nargString.size
-
     -- Ensure the rest of the slice has `length` bytes
     if rest.size < length then
       .error { message := s!"Insufficient transcript remaining, got {rest.size}, need {length}" }

--- a/ArkLib/OracleReduction/LiftContext/Lens.lean
+++ b/ArkLib/OracleReduction/LiftContext/Lens.lean
@@ -428,14 +428,16 @@ instance [Inhabited OuterWitOut]
       innerRelIn.language innerRelOut.language
       compatStmt where
   proj_sound := fun outerStmtIn hCompat => by
-    simp [Set.language] at hCompat ⊢
+    simp only [Set.language, Set.mem_image, Prod.exists, exists_and_right, exists_eq_right,
+      not_exists] at hCompat ⊢
     intro innerWitIn hRelIn
     contrapose! hCompat
     let outerWitIn := lens.wit.lift (outerStmtIn, default) innerWitIn
     have hOuterWitIn := instKS.lift_knowledgeSound outerStmtIn default innerWitIn (by simp) hRelIn
     exact ⟨outerWitIn, hOuterWitIn⟩
   lift_sound := fun outerStmtIn innerStmtOut hCompat hInnerRelOut => by
-    simp [Set.language] at hCompat hInnerRelOut ⊢
+    simp only [Set.language, Set.mem_image, Prod.exists, exists_and_right, exists_eq_right,
+      not_exists] at hCompat hInnerRelOut ⊢
     intro outerWitOut hOuterRelOut
     contrapose! hInnerRelOut
     let innerWitOut := lens.wit.proj (outerStmtIn, outerWitOut)

--- a/ArkLib/OracleReduction/LiftContext/Reduction.lean
+++ b/ArkLib/OracleReduction/LiftContext/Reduction.lean
@@ -224,8 +224,7 @@ theorem liftContext_processRound
   simp only [bind_pure_comp]
   congr 1; funext ⟨tr, ps, outerStmtIn', outerWitIn'⟩
   simp only [pure_bind]
-  split <;> simp [Functor.map_map, Function.comp, liftM_map, map_bind,
-    bind_assoc, pure_bind, bind_map_left, bind_pure_comp]
+  split <;> simp [Functor.map_map, liftM_map, map_bind]
 
 
 theorem liftContext_runToRound
@@ -310,7 +309,7 @@ theorem liftContext_run
   unfold run
   simp [liftContext, Prover.liftContext_run, Verifier.liftContext, Verifier.run, Function.uncurry]
   congr 1; funext ⟨_, _⟩; congr 1; funext a_1
-  simp [Functor.map_map, Function.comp]
+  simp
   cases a_1 <;> simp [Option.getM, map_pure]
 
 theorem liftContext_runWithLog
@@ -407,7 +406,10 @@ theorem liftContext_soundness [Inhabited InnerStmtOut]
   unfold soundness Reduction.run at h ⊢
   -- Note: there is no distinction between `Outer` and `Inner` here
   intro WitIn WitOut outerWitIn outerP outerStmtIn hOuterStmtIn
-  simp at h ⊢
+  simp only [ChallengeIdx, Challenge, QueryImpl.addLift_def, QueryImpl.liftTarget_self,
+    bind_pure_comp, OptionT.run_bind, OptionT.run_monadLift, monadLift_self, OptionT.run_map,
+    Option.elimM_map, Option.elim_some, simulateQ_bind, simulateQ_option_elimM, simulateQ_pure,
+    simulateQ_map, StateT.run'_eq, StateT.run_bind, map_bind, OptionT.mk_bind] at h ⊢
   have innerP : Prover oSpec InnerStmtIn WitIn InnerStmtOut WitOut pSpec := {
     PrvState := outerP.PrvState
     input := fun _ => outerP.input (outerStmtIn, outerWitIn)
@@ -499,7 +501,10 @@ theorem liftContext_rbr_soundness [Inhabited InnerStmtOut]
       (V.liftContext lens).rbrSoundness init impl outerLangIn outerLangOut rbrSoundnessError := by
   unfold rbrSoundness at h ⊢
   obtain ⟨stF, h⟩ := h
-  simp at h ⊢
+  simp only [ChallengeIdx, Challenge, QueryImpl.addLift_def, QueryImpl.liftTarget_self,
+    HasQuery.instOfMonadLift_query, liftComp_eq_liftM, bind_pure_comp, simulateQ_bind,
+    simulateQ_map, StateT.run'_eq, StateT.run_bind, StateT.run_map, map_bind, Functor.map_map,
+    Subtype.forall] at h ⊢
   refine ⟨stF.liftContext lens (lensSound := lensSound), ?_⟩
   intro outerStmtIn hOuterStmtIn WitIn WitOut witIn outerP roundIdx hDir
   have innerP : Prover oSpec InnerStmtIn WitIn InnerStmtOut WitOut pSpec := {

--- a/ArkLib/OracleReduction/ProtocolSpec/Basic.lean
+++ b/ArkLib/OracleReduction/ProtocolSpec/Basic.lean
@@ -271,7 +271,8 @@ section Instances
 /-- There is only one protocol specification with 0 messages (the empty one) -/
 instance : Unique (ProtocolSpec 0) where
   default := empty
-  uniq := fun ⟨_, _⟩ => by simp; constructor <;> (funext i; exact Fin.elim0 i)
+  uniq := fun ⟨_, _⟩ => by
+    simp only [mk.injEq]; constructor <;> (funext i; exact Fin.elim0 i)
 
 -- Note these strange instance syntheses. This is necessary to avoid diamonds later on when
 -- going to sequential composition.
@@ -655,6 +656,7 @@ instance challengeOracleInterface {pSpec : ProtocolSpec n} :
     toOC.impl := fun _ => do read }
 
 -- dtumad: Longer term I think you want this, but need to change `[_]ₒ` stuff for that
+@[reducible]
 def challengeOracleInterface' {pSpec : ProtocolSpec n} :
     OracleInterface (∀ i, pSpec.Challenge i) where
   Query := pSpec.ChallengeIdx
@@ -709,7 +711,8 @@ the input statement (i.e. we can always transform a given reduction into one whe
 random salt). -/
 @[inline, reducible]
 def srChallengeOracle (Statement : Type) {n : ℕ} (pSpec : ProtocolSpec n) :
-    OracleSpec (((i : pSpec.ChallengeIdx) × (challengeOracleInterfaceSR Statement pSpec i).Query)) :=
+    OracleSpec
+      (((i : pSpec.ChallengeIdx) × (challengeOracleInterfaceSR Statement pSpec i).Query)) :=
   [pSpec.Challenge]ₒ'(challengeOracleInterfaceSR Statement pSpec)
 
 alias fsChallengeOracle := srChallengeOracle

--- a/ArkLib/OracleReduction/ProtocolSpec/Basic.lean
+++ b/ArkLib/OracleReduction/ProtocolSpec/Basic.lean
@@ -656,7 +656,6 @@ instance challengeOracleInterface {pSpec : ProtocolSpec n} :
     toOC.impl := fun _ => do read }
 
 -- dtumad: Longer term I think you want this, but need to change `[_]ₒ` stuff for that
-@[reducible]
 def challengeOracleInterface' {pSpec : ProtocolSpec n} :
     OracleInterface (∀ i, pSpec.Challenge i) where
   Query := pSpec.ChallengeIdx

--- a/ArkLib/OracleReduction/ProtocolSpec/Cast.lean
+++ b/ArkLib/OracleReduction/ProtocolSpec/Cast.lean
@@ -81,7 +81,7 @@ theorem cast_id : MessageIdx.cast (Eq.refl n₁) rfl = (id : pSpec₁.MessageIdx
 
 theorem cast_injective : Function.Injective (MessageIdx.cast hn hSpec) := by
   intro i j h'
-  simp [MessageIdx.cast] at h'
+  simp only [MessageIdx, MessageIdx.cast, Subtype.mk.injEq, Fin.cast_inj] at h'
   ext : 1
   exact h'
 
@@ -89,7 +89,7 @@ instance instDCast₂ : DCast₂ Nat ProtocolSpec (fun _ pSpec => MessageIdx pSp
   dcast₂ h := MessageIdx.cast h
   dcast₂_id := cast_id
 
-theorem cast_eq_dcast₂ {hn} {hSpec : pSpec₁.cast hn = pSpec₂} {i : MessageIdx pSpec₁}:
+theorem cast_eq_dcast₂ {hn} {hSpec : pSpec₁.cast hn = pSpec₂} {i : MessageIdx pSpec₁} :
     i.cast hn hSpec = dcast₂ hn hSpec i := rfl
 
 end MessageIdx
@@ -125,7 +125,7 @@ theorem cast_id : ChallengeIdx.cast (Eq.refl n₁) rfl = (id : pSpec₁.Challeng
 
 theorem cast_injective : Function.Injective (ChallengeIdx.cast hn hSpec) := by
   intro i j h'
-  simp [ChallengeIdx.cast] at h'
+  simp only [ChallengeIdx, ChallengeIdx.cast, Subtype.mk.injEq, Fin.cast_inj] at h'
   ext : 1
   exact h'
 
@@ -133,7 +133,7 @@ instance instDCast₂ : DCast₂ Nat ProtocolSpec (fun _ pSpec => ChallengeIdx p
   dcast₂ h := ChallengeIdx.cast h
   dcast₂_id := cast_id
 
-theorem cast_eq_dcast₂ {hn} {hSpec : pSpec₁.cast hn = pSpec₂} {i : ChallengeIdx pSpec₁}:
+theorem cast_eq_dcast₂ {hn} {hSpec : pSpec₁.cast hn = pSpec₂} {i : ChallengeIdx pSpec₁} :
     i.cast hn hSpec = dcast₂ hn hSpec i := rfl
 
 end ChallengeIdx
@@ -173,7 +173,7 @@ instance instDCast₃ : DCast₃ Nat (fun n => Fin (n + 1)) (fun n _ => Protocol
     (fun _ k pSpec => pSpec.Transcript k) where
   dcast₃ h h' h'' T := Transcript.cast h
     (by simp only [dcast] at h'; rw [← h']; subst h; rfl)
-    (by simp [ProtocolSpec.cast_eq_dcast, dcast_eq_root_cast]; exact h'')
+    (by simp only [ProtocolSpec.cast_eq_dcast, dcast_eq_root_cast]; exact h'')
     T
   dcast₃_id := cast_id
 

--- a/ArkLib/OracleReduction/ProtocolSpec/SeqCompose.lean
+++ b/ArkLib/OracleReduction/ProtocolSpec/SeqCompose.lean
@@ -56,7 +56,7 @@ theorem append_left_injective {pSpec : ProtocolSpec n} :
     Function.Injective (@ProtocolSpec.append m n · pSpec) := by
   simp only [append, Fin.vappend_eq_append]
   intro x y h
-  simp at h
+  simp only [mk.injEq] at h
   obtain ⟨hDir, hType⟩ := h
   ext i
   · simp [Fin.append_left_injective pSpec.dir hDir]
@@ -67,7 +67,7 @@ theorem append_right_injective {pSpec : ProtocolSpec m} :
   unfold ProtocolSpec.append
   simp only [Fin.vappend_eq_append]
   intro x y h
-  simp at h
+  simp only [mk.injEq] at h
   obtain ⟨hDir, hType⟩ := h
   ext i
   · simp [Fin.append_right_injective pSpec.dir hDir]
@@ -172,8 +172,8 @@ theorem take_append_left (T : FullTranscript pSpec₁) (T' : FullTranscript pSpe
     (T ++ₜ T').take m (Nat.le_add_right m n) =
       T.cast rfl (by simp [ProtocolSpec.append]) := by
   ext i
-  simp [take, append, ProtocolSpec.append, Fin.castLE,
-    FullTranscript.cast, Transcript.cast]
+  simp only [ProtocolSpec.append, take, append, Fin.take_apply, Fin.castLE,
+    FullTranscript.cast, Transcript.cast, Fin.val_last, Fin.cast_eq_self, take_Type]
   have : ⟨i.val, by omega⟩ = Fin.castAdd n i := by ext; simp
   rw! (castMode := .all) [this, Fin.happend_left]
   rfl
@@ -183,7 +183,8 @@ theorem rtake_append_right (T : FullTranscript pSpec₁) (T' : FullTranscript pS
     (T ++ₜ T').rtake n (Nat.le_add_left n m) =
       T'.cast rfl (by simp [ProtocolSpec.append]) := by
   ext i
-  simp [rtake, Fin.rtake, append, Fin.cast, FullTranscript.cast, Transcript.cast]
+  simp only [rtake, Fin.rtake, append, Fin.cast, Fin.val_natAdd,
+    FullTranscript.cast, Transcript.cast, Fin.val_last, Fin.cast_eq_self, take_Type]
   have : ⟨m + n - n + i.val, by omega⟩ = Fin.natAdd m i := by ext; simp
   rw! (castMode := .all) [this, Fin.happend_right]
   sorry
@@ -226,9 +227,10 @@ def MessageIdx.sumEquiv :
   toFun := Sum.elim (MessageIdx.inl) (MessageIdx.inr)
   invFun := fun ⟨i, h⟩ => by
     by_cases hi : i < m
-    · simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi] at h
+    · simp only [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi, ↓reduceDIte] at h
       exact Sum.inl ⟨⟨i, hi⟩, h⟩
-    · simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi] at h
+    · simp only [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi, ↓reduceDIte,
+        eq_rec_constant] at h
       exact Sum.inr ⟨⟨i - m, by omega⟩, h⟩
   left_inv := fun i => by
     rcases i with ⟨⟨i, isLt⟩, h⟩ | ⟨⟨i, isLt⟩, h⟩ <;>
@@ -250,9 +252,10 @@ def ChallengeIdx.sumEquiv :
   toFun := Sum.elim (ChallengeIdx.inl) (ChallengeIdx.inr)
   invFun := fun ⟨i, h⟩ => by
     by_cases hi : i < m
-    · simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi] at h
+    · simp only [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi, ↓reduceDIte] at h
       exact Sum.inl ⟨⟨i, hi⟩, h⟩
-    · simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi] at h
+    · simp only [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi, ↓reduceDIte,
+        eq_rec_constant] at h
       exact Sum.inr ⟨⟨i - m, by omega⟩, h⟩
   left_inv := fun i => by
     rcases i with ⟨⟨i, isLt⟩, h⟩ | ⟨⟨i, isLt⟩, h⟩ <;>
@@ -439,10 +442,12 @@ variable [∀ i, SampleableType (pSpec₁.Challenge i)] [∀ i, SampleableType (
 --       simpa using query (spec := [(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ) j.inr ()
 
 -- instance : SubSpec [pSpec₁.Challenge]ₒ ([(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ) where
---   monadLift | query i t => instSubSpecOfProtocolSpecAppendChallenge.monadLift (query (Sum.inl i) t)
+--   monadLift | query i t =>
+--     instSubSpecOfProtocolSpecAppendChallenge.monadLift (query (Sum.inl i) t)
 
 -- instance : SubSpec [pSpec₂.Challenge]ₒ ([(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ) where
---   monadLift | query i t => instSubSpecOfProtocolSpecAppendChallenge.monadLift (query (Sum.inr i) t)
+--   monadLift | query i t =>
+--     instSubSpecOfProtocolSpecAppendChallenge.monadLift (query (Sum.inr i) t)
 
 end Append
 
@@ -456,9 +461,11 @@ def seqComposeChallengeIdxToSigma {m : ℕ} {n : Fin m → ℕ} {pSpec : ∀ i, 
     (k : (seqCompose pSpec).ChallengeIdx) : (i : Fin m) × (pSpec i).ChallengeIdx :=
   let ij := Fin.splitSum k.1
   ⟨ij.1, ⟨ij.2, by
-    simp [ij]; have := k.property; simp at this
+    simp only [ij]
+    have := k.property
+    simp only [seqCompose_dir] at this
     have hk : k.1 = Fin.embedSum ij.1 ij.2 := by simp [ij]
-    simp [hk] at this
+    simp only [hk, Fin.vflatten_embedSum] at this
     exact this⟩⟩
 
 /-- The equivalence between the challenge indices of the individual protocols and the challenge
@@ -481,9 +488,11 @@ def seqComposeMessageIdxToSigma {m : ℕ} {n : Fin m → ℕ} {pSpec : ∀ i, Pr
     (k : (seqCompose pSpec).MessageIdx) : (i : Fin m) × (pSpec i).MessageIdx :=
   let ij := Fin.splitSum k.1
   ⟨ij.1, ⟨ij.2, by
-    simp [ij]; have := k.property; simp at this
+    simp only [ij]
+    have := k.property
+    simp only [seqCompose_dir] at this
     have hk : k.1 = Fin.embedSum ij.1 ij.2 := by simp [ij]
-    simp [hk] at this
+    simp only [hk, Fin.vflatten_embedSum] at this
     exact this⟩⟩
 
 /-- The equivalence between the message indices of the individual protocols and the message

--- a/ArkLib/OracleReduction/Security/StateRestoration.lean
+++ b/ArkLib/OracleReduction/Security/StateRestoration.lean
@@ -144,7 +144,9 @@ def knowledgeSoundness
     (srKnowledgeSoundnessError : ENNReal) : Prop :=
   ∃ srExtractor : Extractor.StateRestoration oSpec StmtIn WitIn WitOut pSpec,
   ∀ srProver : Prover.StateRestoration.KnowledgeSoundness oSpec StmtIn WitOut pSpec,
-    Pr[ fun | ⟨stmtIn, witIn, some stmtOut, witOut⟩ => (stmtOut, witOut) ∈ relOut ∧ (stmtIn, witIn) ∉ relIn | _ => False
+    Pr[ fun | ⟨stmtIn, witIn, some stmtOut, witOut⟩ =>
+              (stmtOut, witOut) ∈ relOut ∧ (stmtIn, witIn) ∉ relIn
+            | _ => False
     | do
       (simulateQ (impl.addLift srChallengeQueryImpl' : QueryImpl _ (StateT _ ProbComp))
           <| (do

--- a/ArkLib/ProofSystem/BatchedFri/Security.lean
+++ b/ArkLib/ProofSystem/BatchedFri/Security.lean
@@ -356,8 +356,7 @@ noncomputable def εC
 
 private abbrev fullChallengeProtocol (t l : ℕ) (ω : SmoothCosetFftDomain n 𝔽) :=
   (BatchedFri.Spec.BatchingRound.batchSpec 𝔽 t) ++ₚ
-    (Spec.pSpecFold k (ω := ω) s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ
-      Spec.QueryRound.pSpec l (ω := ω))
+    (Spec.pSpecFold k (ω := ω) s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ Spec.QueryRound.pSpec l (ω := ω))
 
 noncomputable instance {t l : ℕ} {ω : SmoothCosetFftDomain n 𝔽} :
     ∀ j,
@@ -619,8 +618,7 @@ noncomputable instance {t l : ℕ} {ω : SmoothCosetFftDomain n 𝔽} :
 --         (OracleComp
 --           ([]ₒ +
 --             [(BatchedFri.Spec.BatchingRound.batchSpec 𝔽 t ++ₚ
---                   (Spec.pSpecFold k s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ
---                     Spec.QueryRound.pSpec l)).Challenge]ₒ)))
+--                   (Spec.pSpecFold k s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ Spec.QueryRound.pSpec l)).Challenge]ₒ)))
 --
 noncomputable instance {t l : ℕ} {ω : SmoothCosetFftDomain n 𝔽} :
     HasEvalSPMF

--- a/ArkLib/ProofSystem/BatchedFri/Security.lean
+++ b/ArkLib/ProofSystem/BatchedFri/Security.lean
@@ -67,7 +67,7 @@ def cosetEnum (s₀ : evalDomainSigma s ω i) (k_le_n : ∑ j', (s j').1 ≤ n)
             apply (swap <| Nat.le_trans) k_le_n
             omega
           rcases j with ⟨j, h⟩
-          simp only [Nat.succ_eq_add_one, Fin.ofNat_eq_cast, Fin.val_natCast]
+          simp only []
           have : n - (n - (s i).1) = (s i).1 := by
             apply Nat.sub_sub_self
             exact Nat.le_of_lt_succ s_i_lim
@@ -133,22 +133,20 @@ noncomputable def fin_equiv_coset (s₀ : evalDomainSigma s ω ↑i)
   unfold Function.Bijective
   apply And.intro
   · intros a b h
-    simp only [Nat.succ_eq_add_one, finRangeTo.eq_1, Fin.ofNat_eq_cast, Fin.val_natCast,
-      Set.mem_setOf_eq, FftDomain.subdomainNatReversed, FftDomain.subdomainNat, Subtype.mk.injEq,
+    simp only [finRangeTo.eq_1, FftDomain.subdomainNatReversed, Subtype.mk.injEq,
       mul_eq_mul_left_iff] at h
     rcases h with h | h
     · have h := FftDomain.injective h
       aesop
     · rcases s₀ with ⟨s₀, hs₀⟩
       subst h
-      simp only [Nat.succ_eq_add_one, finRangeTo.eq_1, Fin.ofNat_eq_cast, Fin.val_natCast,
-        evalDomainSigma, CosetFftDomain.subdomainNatReversed, CosetFftDomain.subdomainNat] at hs₀
-      rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at hs₀ 
+      simp only [finRangeTo.eq_1,
+        evalDomainSigma, CosetFftDomain.subdomainNatReversed] at hs₀
+      rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at hs₀
       have hs₀ := CosetFftDomain.zero_is_not_in_domain hs₀
       simp at hs₀
   · rintro ⟨⟨y, h'⟩, h⟩
     simp only [FftDomain.subdomainNatReversed,
-      FftDomain.subdomainNat,
       finRangeTo.eq_1, Subtype.mk.injEq]
     simp only [cosetG, k_le_n, ↓reduceDIte] at h
     obtain ⟨a, -, ha⟩ := Finset.mem_image.mp h
@@ -176,18 +174,18 @@ def invertibleDomain (s₀ : evalDomainSigma s ω ↑i) : Invertible (VDM n s s�
       intros contra
       apply this
       rw [sub_eq_zero, cosetEnum, cosetEnum] at contra
-      simp only [Nat.succ_eq_add_one, finRangeTo, Fin.ofNat_eq_cast, Fin.val_natCast,
-        Set.mem_setOf_eq, mul_eq_mul_left_iff] at contra
+      simp only [finRangeTo,
+        mul_eq_mul_left_iff] at contra
       rcases contra with contra | contra
-      · simp only [FftDomain.subdomainNatReversed, FftDomain.subdomainNat] at contra
+      · simp only [FftDomain.subdomainNatReversed] at contra
         have h := FftDomain.injective contra
         simp only [Fin.mk.injEq] at h
         ext
         exact (symm h)
       · rcases s₀ with ⟨s₀, hs₀⟩
         subst contra
-        simp only [Nat.succ_eq_add_one, finRangeTo.eq_1, Fin.ofNat_eq_cast, Fin.val_natCast,
-          evalDomainSigma, CosetFftDomain.subdomainNatReversed, CosetFftDomain.subdomainNat] at hs₀
+        simp only [finRangeTo.eq_1,
+          evalDomainSigma, CosetFftDomain.subdomainNatReversed] at hs₀
         rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at hs₀
         have hs₀ := CosetFftDomain.zero_is_not_in_domain hs₀
         simp at hs₀
@@ -223,8 +221,8 @@ noncomputable def f_succ'
     ∃ s₀ : (ω.subdomainNatReversed (∑ j' ∈ finRangeTo _ (i.1), (s j').1)).toFinset,
       s₀.1 ^ (2 ^ (s i).1) = s₀'.1 := by
     rcases s₀' with ⟨s₀', hs₀'⟩
-    simp only [Fin.val_natCast]
-    simp only [evalDomainSigma] at hs₀' 
+    simp only []
+    simp only [evalDomainSigma] at hs₀'
     rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at hs₀'
     rw [CosetFftDomain.subdomainNatReversed_mem_of_eq 
       (ω := ω)
@@ -358,7 +356,8 @@ noncomputable def εC
 
 private abbrev fullChallengeProtocol (t l : ℕ) (ω : SmoothCosetFftDomain n 𝔽) :=
   (BatchedFri.Spec.BatchingRound.batchSpec 𝔽 t) ++ₚ
-    (Spec.pSpecFold k (ω := ω) s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ Spec.QueryRound.pSpec l (ω := ω))
+    (Spec.pSpecFold k (ω := ω) s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ
+      Spec.QueryRound.pSpec l (ω := ω))
 
 noncomputable instance {t l : ℕ} {ω : SmoothCosetFftDomain n 𝔽} :
     ∀ j,
@@ -620,7 +619,8 @@ noncomputable instance {t l : ℕ} {ω : SmoothCosetFftDomain n 𝔽} :
 --         (OracleComp
 --           ([]ₒ +
 --             [(BatchedFri.Spec.BatchingRound.batchSpec 𝔽 t ++ₚ
---                   (Spec.pSpecFold k s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ Spec.QueryRound.pSpec l)).Challenge]ₒ)))
+--                   (Spec.pSpecFold k s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ
+--                     Spec.QueryRound.pSpec l)).Challenge]ₒ)))
 --
 noncomputable instance {t l : ℕ} {ω : SmoothCosetFftDomain n 𝔽} :
     HasEvalSPMF
@@ -774,7 +774,8 @@ lemma fri_soundness
           OracleReduction.run () f ()
             ⟨
               prov,
-              (BatchedFri.Spec.batchedFRIreduction (ω := ω) (n := n) k s d domain_size_cond l t).verifier
+              (BatchedFri.Spec.batchedFRIreduction (ω := ω) (n := n) k s d domain_size_cond l t)
+                .verifier
             ⟩
         ] > εC 𝔽 n s m ρ_sqrt + α ^ l) →
       Code.jointAgreement

--- a/ArkLib/ProofSystem/BatchedFri/Spec/General.lean
+++ b/ArkLib/ProofSystem/BatchedFri/Spec/General.lean
@@ -66,14 +66,13 @@ def liftingLens :
             rw [ReedSolomon.CosetFftDomain.mem_coset_finset_iff_mem_coset_domain]
             rcases j with ⟨j, h⟩
             have : j = 0 := by simpa using h
-            simp only [Nat.succ_eq_add_one, Fin.coe_ofNat_eq_mod, Nat.zero_mod, Nat.reduceAdd,
-              Fin.ofNat_eq_cast, Fin.val_natCast] at v
+            simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, Nat.reduceAdd] at v
             rcases v with ⟨v, h'⟩
             simp only
             subst this
             simp only [finRangeTo.eq_1, List.take_zero, List.toFinset_nil, Finset.sum_empty,
               Nat.sub_zero, ReedSolomon.CosetFftDomain.subdomainNatReversed,
-              ReedSolomon.CosetFftDomain.subdomainNat, Nat.succ_eq_add_one, Fin.ofNat_eq_cast] at h'
+              Nat.succ_eq_add_one] at h'
             rw [ReedSolomon.CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at h'
             rw [←ReedSolomon.CosetFftDomain.subdomain_n']
             exact (ReedSolomon.CosetFftDomain.mem_subdomain_of_eq_vals (by simp)).1 h'

--- a/ArkLib/ProofSystem/Component/CheckClaim.lean
+++ b/ArkLib/ProofSystem/Component/CheckClaim.lean
@@ -111,7 +111,7 @@ theorem reduction_completeness [Nonempty σ] [DecidableEq Statement] :
       (Prod.fst <$> (pure (some ((default, stmt, ()), stmt)) :
         StateT σ ProbComp _).run s) at hx
     rw [StateT.run_pure] at hx
-    simp [map_pure, support_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff, Option.some.injEq] at hx
     cases hx
     simp [relOut]
 

--- a/ArkLib/ProofSystem/Component/NoInteraction.lean
+++ b/ArkLib/ProofSystem/Component/NoInteraction.lean
@@ -69,11 +69,17 @@ variable {σ : Type} {init : ProbComp σ} {impl : QueryImpl oSpec (StateT σ Pro
 theorem reduction_completeness {ε : ℝ≥0} [DecidablePred (· ∈ relOut)]
     [DecidableEq StmtOut]
     (hRel : ∀ stmtIn witIn, (stmtIn, witIn) ∈ relIn →
-      Pr[fun ⟨stmtOut, witOut⟩ => (stmtOut, witOut) ∈ relOut | do
+      Pr[ fun ⟨stmtOut, witOut⟩ => (stmtOut, witOut) ∈ relOut | do
         (simulateQ impl <| combineMap mapStmt mapWit ⟨stmtIn, witIn⟩).run' (← init)] ≥ 1 - ε) :
     Reduction.completeness init impl relIn relOut (reduction mapStmt mapWit) ε := by
-  simp [Reduction.completeness, Reduction.run, Verifier.run, prover, Prover.run,
-    - tsub_le_iff_right]
+  simp only [Reduction.completeness, ChallengeIdx, Challenge, QueryImpl.addLift_def,
+    QueryImpl.liftTarget_self, Reduction.run, Prover.run, Fin.reduceLast, prover, Nat.reduceAdd,
+    Fin.isValue, MessageIdx, Message, Prover.runToRound_zero_of_prover_first, id_eq, liftM_bind,
+    bind_pure_comp, liftM_map, map_bind, Functor.map_map, pure_bind, monadLift_liftM_OptionT,
+    Verifier.run, OptionT.run_monadLift, monadLift_self, bind_map_left, Option.getM_some, map_pure,
+    bind_assoc, OptionT.run_bind, OracleSpec.ProgrammingPolicy.empty_apply, OptionT.run_map,
+    simulateQ_option_elimM, simulateQ_pure, simulateQ_map, StateT.run'_eq, OptionT.mk_bind,
+    ge_iff_le]
   intro stmtIn witIn hStmtIn
   refine ge_trans ?_ (hRel stmtIn witIn hStmtIn)
   sorry

--- a/ArkLib/ProofSystem/Component/RandomQuery.lean
+++ b/ArkLib/ProofSystem/Component/RandomQuery.lean
@@ -200,8 +200,9 @@ def stateFunction [Inhabited OStatement] : (oracleVerifier oSpec OStatement).Sta
   toFun_full := fun ⟨stmt, oStmt⟩ tr h => by
     sorry
     -- simp_all only [Fin.reduceLast, Fin.isValue, OStmtIn, Nat.reduceAdd, Fin.coe_ofNat_eq_mod,
-    --   Nat.reduceMod, Fin.zero_eta, StmtOut, OStmtOut, StmtIn, StateT.run'_eq, Set.language, WitOut,
-    --   relOut, Set.mem_image, Set.mem_setOf_eq, Prod.exists, exists_const, exists_eq_right,
+    --   Nat.reduceMod, Fin.zero_eta, StmtOut, OStmtOut, StmtIn, StateT.run'_eq, Set.language,
+    --   WitOut, relOut, Set.mem_image, Set.mem_setOf_eq, Prod.exists, exists_const,
+    --   exists_eq_right,
     --   probEvent_eq_zero_iff, support_bind, support_map, Set.mem_iUnion, exists_and_right,
     --   exists_prop, forall_exists_index, and_imp, Prod.forall]
     -- intro a b s hs s' hSupp
@@ -294,8 +295,9 @@ end RandomQuery
 --   Random query where we throw away the second oracle, and replace with the response:
 --   - The input relation is `{ ⟨⟨_, 𝒪⟩, _⟩ | 𝒪 0 = 𝒪 1 }`.
 --   - The output relation is `{ ⟨⟨q, r⟩, 𝒪⟩, _⟩ | oracle (𝒪 0) q = r }`.
---   - The (oracle) verifier sends a single random query `q` to the prover, queries the oracle `𝒪 1` at
---     `q` to get response `r`, returns `(q, r)` as the output statement, and drop `𝒪 1` from the
+--   - The (oracle) verifier sends a single random query `q` to the prover, queries the oracle
+--     `𝒪 1` at `q` to get response `r`, returns `(q, r)` as the output statement, and drop `𝒪 1`
+--     from the
 --     output oracle statement.
 
 --   This is just the concatenation of `RandomQuery` and `ReduceClaim`.
@@ -315,8 +317,8 @@ end RandomQuery
 --   oracles 0 = oracles 1
 
 -- /--
--- The final relation states that the first oracle `oStmt ()` agrees with the response `r` at the query
--- `q`.
+-- The final relation states that the first oracle `oStmt ()` agrees with the response `r` at the
+-- query `q`.
 -- -/
 -- @[reducible, simp]
 -- def relOut : (StmtOut OStatement × ∀ i, OStmtOut OStatement i) → WitOut → Prop :=

--- a/ArkLib/ProofSystem/Component/ReduceClaim.lean
+++ b/ArkLib/ProofSystem/Component/ReduceClaim.lean
@@ -103,7 +103,7 @@ theorem reduction_completeness --(h : init.neverFails)
       (Prod.fst <$> (pure (some ((default, (mapStmt stmtIn, mapWit stmtIn witIn)),
         mapStmt stmtIn)) : StateT σ ProbComp _).run s) at hx
     rw [StateT.run_pure] at hx
-    simp [map_pure, support_pure] at hx
+    simp only [map_pure, support_pure, Set.mem_singleton_iff, Option.some.injEq] at hx
     cases hx
     exact ⟨(hRel stmtIn witIn).mp hIn, rfl⟩
 
@@ -121,14 +121,14 @@ variable {mapWitInv : StmtIn → WitOut → WitIn}
 @[simp]
 lemma support_liftM (m : Type _ → Type _) [Monad m] [HasEvalSet m]
     {α} (mx : m α) : support (liftM mx : OptionT m α) = support mx := by
-  simp [support_def, HasEvalSet.toSet, OptionT.mapM']
+  simp [support_def, HasEvalSet.toSet]
   sorry
 
 @[simp]
 lemma support_mk (m : Type _ → Type _) [Monad m] [HasEvalSet m]
     {α} (mx : m (Option α)) :
     support (OptionT.mk mx) = {x | some x ∈ support mx} := by
-  simp [support_def, HasEvalSet.toSet, OptionT.mapM']
+  simp [support_def, HasEvalSet.toSet]
   sorry
 
 /-- The knowledge state function for the `ReduceClaim` reduction. -/

--- a/ArkLib/ProofSystem/Component/SendClaim.lean
+++ b/ArkLib/ProofSystem/Component/SendClaim.lean
@@ -82,7 +82,7 @@ def oracleVerifier : OracleVerifier oSpec Statement OStatement Unit (OStatement 
     intro i
     match i with
     | .inl _ => rfl
-    | .inr j => simp [ProtocolSpec.Message]; exact congrArg OStatement (Unique.uniq _ j)
+    | .inr j => simp only [ProtocolSpec.Message]; exact congrArg OStatement (Unique.uniq _ j)
 
 /--
 Combine the prover and verifier into an oracle reduction.

--- a/ArkLib/ProofSystem/Fri/RoundConsistency.lean
+++ b/ArkLib/ProofSystem/Fri/RoundConsistency.lean
@@ -73,7 +73,6 @@ lemma generalised_round_consistency_completeness
     ext i
     rw [eval_mul]
     simp
-
   apply Eq.trans (b := eval γ <| ∑ i : Fin n, X ^ (↑i : ℕ) * C (eval (s₀ ^ n) (f.splitNth n i)))
   · rw [Lagrange.eq_interpolate (ι := Fin n)
         (v := fun i => ω i * s₀)

--- a/ArkLib/ProofSystem/Fri/Spec/General.lean
+++ b/ArkLib/ProofSystem/Fri/Spec/General.lean
@@ -65,18 +65,21 @@ instance : ∀ j, OracleInterface ((pSpecFold (ω := ω) k s).Message j) :=
 instance : ∀ j, OracleInterface (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F)).Message j) :=
   instOracleInterfaceMessageAppend
 
-instance : ∀ j, OracleInterface (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F)).Challenge j) :=
+instance :
+    ∀ j, OracleInterface (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F)).Challenge j) :=
   ProtocolSpec.challengeOracleInterface
 
 instance :
     ∀ i, OracleInterface
-          ((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F ++ₚ QueryRound.pSpec (ω := ω) l).Message i) :=
+          ((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F ++ₚ
+            QueryRound.pSpec (ω := ω) l).Message i) :=
   instOracleInterfaceMessageAppend
 
 instance :
     ∀ j,
       OracleInterface
-        (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F ++ₚ QueryRound.pSpec (ω := ω) l)).Challenge j) :=
+        (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F ++ₚ
+            QueryRound.pSpec (ω := ω) l)).Challenge j) :=
   ProtocolSpec.challengeOracleInterface
 
 /- Oracle reduction for all folding rounds of the FRI protocol -/

--- a/ArkLib/ProofSystem/Fri/Spec/General.lean
+++ b/ArkLib/ProofSystem/Fri/Spec/General.lean
@@ -65,21 +65,18 @@ instance : ∀ j, OracleInterface ((pSpecFold (ω := ω) k s).Message j) :=
 instance : ∀ j, OracleInterface (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F)).Message j) :=
   instOracleInterfaceMessageAppend
 
-instance :
-    ∀ j, OracleInterface (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F)).Challenge j) :=
+instance : ∀ j, OracleInterface (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F)).Challenge j) :=
   ProtocolSpec.challengeOracleInterface
 
 instance :
     ∀ i, OracleInterface
-          ((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F ++ₚ
-            QueryRound.pSpec (ω := ω) l).Message i) :=
+          ((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F ++ₚ QueryRound.pSpec (ω := ω) l).Message i) :=
   instOracleInterfaceMessageAppend
 
 instance :
     ∀ j,
       OracleInterface
-        (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F ++ₚ
-            QueryRound.pSpec (ω := ω) l)).Challenge j) :=
+        (((pSpecFold k (ω := ω) s ++ₚ FinalFoldPhase.pSpec F ++ₚ QueryRound.pSpec (ω := ω) l)).Challenge j) :=
   ProtocolSpec.challengeOracleInterface
 
 /- Oracle reduction for all folding rounds of the FRI protocol -/


### PR DESCRIPTION
In this PR, I asked Claude to fix non-sorry warnings, in an attempt to declutter the build. I asked it to avoid files that are touched recently or by open PRs to try to limit merge conflicts.

Unfortunately, I think it has not made much of a dent, but might still be useful.