### PR TITLE
feat(sumcheck): complete CompPoly interaction integration

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -98,6 +98,7 @@ import ArkLib.Interaction.Boundary.Oracle
 import ArkLib.Interaction.Boundary.OracleSecurity
 import ArkLib.Interaction.Boundary.Reification
 import ArkLib.Interaction.Boundary.Security
+import ArkLib.Interaction.Examples.Core
 import ArkLib.Interaction.FiatShamir.Basic
 import ArkLib.Interaction.FiatShamir.DuplexSponge
 import ArkLib.Interaction.FiatShamir.Transform

--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -171,6 +171,7 @@ import ArkLib.ProofSystem.Binius.RingSwitching.Spec
 import ArkLib.ProofSystem.Binius.RingSwitching.SumcheckPhase
 import ArkLib.ProofSystem.Component.CheckClaim
 import ArkLib.ProofSystem.Component.DoNothing
+import ArkLib.ProofSystem.Component.Interaction.DoNothing
 import ArkLib.ProofSystem.Component.NoInteraction
 import ArkLib.ProofSystem.Component.RandomQuery
 import ArkLib.ProofSystem.Component.ReduceClaim

--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -203,6 +203,7 @@ import ArkLib.ProofSystem.Stir.Quotienting
 import ArkLib.ProofSystem.Sumcheck.Impl.Basic
 import ArkLib.ProofSystem.Sumcheck.Interaction.CompPoly
 import ArkLib.ProofSystem.Sumcheck.Interaction.Defs
+import ArkLib.ProofSystem.Sumcheck.Interaction.Examples
 import ArkLib.ProofSystem.Sumcheck.Interaction.General
 import ArkLib.ProofSystem.Sumcheck.Interaction.Oracle
 import ArkLib.ProofSystem.Sumcheck.Interaction.SingleRound

--- a/ArkLib/Data/CodingTheory/InterleavedCode.lean
+++ b/ArkLib/Data/CodingTheory/InterleavedCode.lean
@@ -146,7 +146,7 @@ noncomputable instance interleavedCodeSet_fintype {A : Type*} {κ ι : Type*}
 
 /-- Interleaved code submodule of any `ModuleCode`, where each row belongs to the code. -/
 @[simp]
-instance ModuleCode.moduleInterleavedCode : ModuleCode ι F (InterleavedSymbol A κ) := {
+def ModuleCode.moduleInterleavedCode : ModuleCode ι F (InterleavedSymbol A κ) := {
   -- Simple condition wrapping over Matrix
   carrier := interleavedCodeSet (C := (MC : Set (ι → A)))
   add_mem' hU hV i := MC.add_mem (hU i) (hV i)
@@ -170,7 +170,7 @@ def codewordStackSet {A : Type*} {κ ι : Type*} (C : Set (ι → A)) : Set (Wor
   { V : WordStack A κ ι | ∀ k, V.getRowWord k ∈ C }
 
 @[simp]
-instance ModuleCode.codewordStackSubmodule : Submodule F (WordStack A κ ι) := {
+def ModuleCode.codewordStackSubmodule : Submodule F (WordStack A κ ι) := {
   -- Simple condition wrapping over Matrix
   carrier := codewordStackSet (C := (MC : Set (ι → A)))
   add_mem' hU hV i := MC.add_mem (hU i) (hV i)

--- a/ArkLib/Data/CodingTheory/Prelims.lean
+++ b/ArkLib/Data/CodingTheory/Prelims.lean
@@ -253,8 +253,6 @@ lemma AffSpanSet.instFinite [Finite F] [NeZero k] (u : Fin k → ι → F) :
   unfold AffSpanSet
   exact Set.toFinite _
 
-attribute [instance] AffSpanSet.instFinite
-
 /-- The affine span as a `Finset`, using `AffSpanFinite` to convert from the set. -/
 noncomputable def AffSpanFinset [NeZero k] (U : Fin k → ι → F) : Finset (ι → F) :=
   (AffSpanSet.instFinite U).toFinset

--- a/ArkLib/Data/CompPoly/Basic.lean
+++ b/ArkLib/Data/CompPoly/Basic.lean
@@ -18,8 +18,6 @@ with reusable `OracleInterface` instances.
 
 open CompPoly CPoly Std
 
-attribute [local instance] instDecidableEqOfLawfulBEq
-
 namespace CPoly.CMvPolynomial
 
 variable {n : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
@@ -27,6 +25,7 @@ variable {n : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
 /-- `p` has individual degree at most `deg` when every monomial exponent is
  bounded by `deg` in every coordinate. -/
 def IndividualDegreeLE (deg : ℕ) (p : CMvPolynomial n R) : Prop :=
+  letI := Classical.decEq R
   ∀ i : Fin n, ∀ mono ∈ Lawful.monomials p, mono.degreeOf i ≤ deg
 end CPoly.CMvPolynomial
 

--- a/ArkLib/Interaction/BCS/Verifier.lean
+++ b/ArkLib/Interaction/BCS/Verifier.lean
@@ -28,6 +28,25 @@ The BCS verifier is decomposed into three components:
 
 ## Main definitions
 
+## Design resolution
+
+The BCS verifier should not be represented as a single monolithic oracle
+program over the original transcript. That representation is too permissive:
+it can accidentally let hidden oracle-message values influence future protocol
+shape or query selection.
+
+Instead, the verifier surface is intentionally split. The phase-1 challenger
+runs on `bcsSpec cd`, where committed oracle messages have already been
+replaced by commitments and therefore have no oracle interface. The phase-2
+query selector consumes only `SharedTranscript hs cd`, so every query to a
+committed oracle is a public function of data visible in both the original and
+BCS executions. The final decision receives only that shared transcript plus
+the opened responses.
+
+This makes the intended BCS side condition a type-level invariant: committed
+oracle messages may affect opened responses and the final decision, but they do
+not determine the interaction tree or the set of verifier queries.
+
 ### Bridge to HybridDecoration
 - `HybridSpec.bcsHybridDeco` — converts `OracleDeco` on `HybridSpec` into a
   `HybridDecoration` on `bcsSpec`. Committed pass nodes get `none` (no oracle
@@ -156,8 +175,10 @@ def OpeningDeco (m : Type → Type) :
 
 /-! ## Public-query verifier decomposition -/
 
-/-- A BCS-compatible verifier decomposed into three components that together
-express the "public query" property:
+/-- A BCS-compatible verifier decomposed into the three public-query phases.
+
+This is the proposed representation for BCS-compatible oracle verifiers. The
+split is deliberate:
 
 1. `challenger`: a `Counterpart.withMonads` on `bcsSpec` whose oracle access
    is restricted to non-committed oracles (via `bcsHybridDeco`). At receiver
@@ -168,11 +189,17 @@ express the "public query" property:
 
 2. `queryFn`: a deterministic function producing queries to committed oracles
    from the `SharedTranscript`. The "public query" property is implicit in
-   the type: queries can only depend on publicly visible data.
+   the type: queries can only depend on data shared by the original and BCS
+   executions.
 
 3. `decide`: given the shared transcript and query responses, produces the
    verifier's output. Runs inside `OracleComp` with full non-committed oracle
-   access. This is the most general form. -/
+   access.
+
+In particular, there is no field that receives the original full transcript or
+the hidden committed oracle messages. This prevents the two failure modes that
+break BCS: branching on committed oracle values and choosing queries as a
+function of committed oracle values. -/
 structure PublicQueryVerifier {ι : Type} (oSpec : OracleSpec.{0, 0} ι)
     {ιₛᵢ : Type} (OStmtIn : ιₛᵢ → Type) [∀ i, OracleInterface.{0, 0} (OStmtIn i)]
     (hs : HybridSpec) (roles : RoleDeco hs)
@@ -234,6 +261,380 @@ end Phase1
 section Phase2
 variable {ι : Type} {oSpec : OracleSpec.{0, 0} ι}
 
+/-! ### Commitment-opening bridge -/
+
+/-- Statements for every commitment-opening subproof requested in Phase 2.
+
+At a committed pass node, this records one statement for each query in the
+`QueryBundle`: the commitment sent in the BCS transcript, the selected oracle
+query, and the claimed response. This is the typed bridge from the BCS public
+query layer to `Commitment.Interaction.Opening.proof`.
+
+The compatibility Phase 2 scaffold below still sends the whole response
+decoration as one message. The checked full Phase 2 surface later in this file
+uses this decoration to run the corresponding opening verifier for every
+requested query. -/
+def OpeningStatementDeco {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd → Type 1
+  | .done, _, _, _, _, _ => PUnit
+  | .branch _ rest, odRest, cdRest, ⟨x, tr⟩, qd, responses =>
+      OpeningStatementDeco (rest x) (odRest x) (cdRest x) tr qd responses
+  | .pass _ rest, ⟨oi, odRest⟩, ⟨some nc, cdRest⟩, ⟨_, tr⟩, ⟨qb, qdRest⟩,
+      ⟨_, responsesRest⟩ =>
+      ((i : Fin qb.numQueries) →
+        nc.CommType × (q : oi.Query) × oi.Response q) ×
+      OpeningStatementDeco rest odRest cdRest tr qdRest responsesRest
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, ⟨_, tr⟩, qd, responses =>
+      OpeningStatementDeco rest odRest cdRest tr qd responses
+
+/-- Build the per-query commitment-opening statements from the BCS transcript,
+query decoration, and claimed responses. -/
+def openingStatements {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    (responses : OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    OpeningStatementDeco hs od cd bcsTr qd responses
+  | .done, _, _, _, _, _ => ⟨⟩
+  | .branch _ rest, odRest, cdRest, ⟨x, tr⟩, qd, responses =>
+      openingStatements (rest x) (odRest x) (cdRest x) tr qd responses
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨cm, tr⟩, ⟨qb, qdRest⟩,
+      ⟨responses, responsesRest⟩ =>
+      (fun i => ⟨cm, qb.queries i, responses i⟩,
+       openingStatements rest odRest cdRest tr qdRest responsesRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, ⟨_, tr⟩, qd, responses =>
+      openingStatements rest odRest cdRest tr qd responses
+
+/-- Witnesses for every commitment-opening subproof requested in Phase 2.
+At a committed node, the same retained commitment witness is used for each
+query against that committed oracle message. -/
+def OpeningWitnessDeco {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (st : SharedTranscript hs cd) →
+    OracleQueryDeco hs od cd st → Type 1
+  | .done, _, _, _, _ => PUnit
+  | .branch _ rest, odRest, cdRest, ⟨x, st⟩, qd =>
+      OpeningWitnessDeco (rest x) (odRest x) (cdRest x) st qd
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some nc, cdRest⟩, st, ⟨qb, qdRest⟩ =>
+      ((i : Fin qb.numQueries) → nc.WitnessType) ×
+      OpeningWitnessDeco rest odRest cdRest st qdRest
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, ⟨_, st⟩, qd =>
+      OpeningWitnessDeco rest odRest cdRest st qd
+
+/-- Extract the per-query commitment-opening witnesses from the Phase 1 oracle
+witness retained by the honest prover. -/
+def openingWitnessesFromOracleWitness {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (st : SharedTranscript hs cd) →
+    (qd : OracleQueryDeco hs od cd st) → OracleWitness hs cd st →
+    OpeningWitnessDeco hs od cd st qd
+  | .done, _, _, _, _, _ => ⟨⟩
+  | .branch _ rest, odRest, cdRest, ⟨x, st⟩, qd, wit =>
+      openingWitnessesFromOracleWitness (rest x) (odRest x) (cdRest x) st qd wit
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, st, ⟨_, qdRest⟩,
+      ⟨_, cwit, witRest⟩ =>
+      (fun _ => cwit,
+       openingWitnessesFromOracleWitness rest odRest cdRest st qdRest witRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, ⟨_, st⟩, qd, wit =>
+      openingWitnessesFromOracleWitness rest odRest cdRest st qd wit
+
+/-- Per-query opening prover strategies induced by `OpeningDeco`.
+
+This is the executable prover-side bridge from the retained BCS opening
+witnesses to the concrete `Commitment.Interaction.Opening.proof` objects. -/
+def OpeningProverDeco {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (opDeco : OpeningDeco m hs od cd) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    (responses : OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    OpeningWitnessDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd → Type 1
+  | .done, _, _, _, _, _, _, _ => PUnit
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd, responses, wits =>
+      OpeningProverDeco (rest x) (odRest x) (cdRest x) (opRest x) tr qd responses wits
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨_, tr⟩, ⟨qb, qdRest⟩, ⟨_, responsesRest⟩, ⟨_, witsRest⟩ =>
+      ((i : Fin qb.numQueries) →
+        m (Spec.Strategy.withRoles m opening.spec opening.roles
+          (fun _ => HonestProverOutput Bool PUnit))) ×
+      OpeningProverDeco rest odRest cdRest opRest tr qdRest responsesRest witsRest
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd, responses, wits =>
+      OpeningProverDeco rest odRest cdRest opRest tr qd responses wits
+
+/-- Instantiate the per-query opening prover strategies from `OpeningDeco`. -/
+def openingProvers {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (opDeco : OpeningDeco m hs od cd) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    (responses : OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    (wits : OpeningWitnessDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    OpeningProverDeco hs od cd opDeco bcsTr qd responses wits
+  | .done, _, _, _, _, _, _, _ => ⟨⟩
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd, responses, wits =>
+      openingProvers (rest x) (odRest x) (cdRest x) (opRest x) tr qd responses wits
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨cm, tr⟩, ⟨qb, qdRest⟩, ⟨responses, responsesRest⟩, ⟨wits, witsRest⟩ =>
+      (fun i => opening.proof.prover () ⟨cm, qb.queries i, responses i⟩ (wits i),
+       openingProvers rest odRest cdRest opRest tr qdRest responsesRest witsRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd, responses, wits =>
+      openingProvers rest odRest cdRest opRest tr qd responses wits
+
+/-- Per-query opening verifier counterparts induced by `OpeningDeco`. -/
+def OpeningVerifierDeco {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (opDeco : OpeningDeco m hs od cd) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd → Type 1
+  | .done, _, _, _, _, _, _ => PUnit
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd, responses =>
+      OpeningVerifierDeco (rest x) (odRest x) (cdRest x) (opRest x) tr qd responses
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨_, tr⟩, ⟨qb, qdRest⟩, ⟨_, responsesRest⟩ =>
+      ((i : Fin qb.numQueries) →
+        Spec.Counterpart m opening.spec opening.roles (fun _ => Bool)) ×
+      OpeningVerifierDeco rest odRest cdRest opRest tr qdRest responsesRest
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd, responses =>
+      OpeningVerifierDeco rest odRest cdRest opRest tr qd responses
+
+/-- Instantiate the per-query opening verifier counterparts from
+`OpeningDeco` and the claimed query responses. -/
+def openingVerifiers {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (opDeco : OpeningDeco m hs od cd) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    (responses : OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    OpeningVerifierDeco hs od cd opDeco bcsTr qd responses
+  | .done, _, _, _, _, _, _ => ⟨⟩
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd, responses =>
+      openingVerifiers (rest x) (odRest x) (cdRest x) (opRest x) tr qd responses
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨cm, tr⟩, ⟨qb, qdRest⟩, ⟨responses, responsesRest⟩ =>
+      (fun i => opening.proof.verifier () ⟨cm, qb.queries i, responses i⟩,
+       openingVerifiers rest odRest cdRest opRest tr qdRest responsesRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd, responses =>
+      openingVerifiers rest odRest cdRest opRest tr qd responses
+
+/-! ### Composed opening-proof transcript shape -/
+
+/-- Repeat an interaction spec `n` times sequentially. -/
+def repeatSpec : Nat → Spec.{0} → Spec.{0}
+  | 0, _ => .done
+  | n + 1, spec => spec.append (fun _ => repeatSpec n spec)
+
+/-- Roles for `repeatSpec`, obtained by repeating the same role decoration. -/
+def repeatRoles :
+    (n : Nat) → (spec : Spec.{0}) → RoleDecoration spec →
+    RoleDecoration (repeatSpec n spec)
+  | 0, _, _ => ⟨⟩
+  | n + 1, spec, roles => roles.append (fun _ => repeatRoles n spec roles)
+
+/-- The composed interaction tree containing every commitment-opening proof
+requested by a Phase 2 query decoration, excluding the initial response
+message. At each committed node, the opening proof protocol is repeated once
+per query in the corresponding `QueryBundle`; the rest of the BCS tree is then
+processed sequentially. -/
+def openingProofSpec {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    OpeningDeco m hs od cd →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr) → Spec.{0}
+  | .done, _, _, _, _, _ => .done
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd =>
+      openingProofSpec (rest x) (odRest x) (cdRest x) (opRest x) tr qd
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨_, tr⟩, ⟨qb, qdRest⟩ =>
+      (repeatSpec qb.numQueries opening.spec).append
+        (fun _ => openingProofSpec rest odRest cdRest opRest tr qdRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd =>
+      openingProofSpec rest odRest cdRest opRest tr qd
+
+/-- Roles for `openingProofSpec`. -/
+def openingProofRoles {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (opDeco : OpeningDeco m hs od cd) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    RoleDecoration (openingProofSpec hs od cd opDeco bcsTr qd)
+  | .done, _, _, _, _, _ => ⟨⟩
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd =>
+      openingProofRoles (rest x) (odRest x) (cdRest x) (opRest x) tr qd
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨_, tr⟩, ⟨qb, qdRest⟩ =>
+      (repeatRoles qb.numQueries opening.spec opening.roles).append
+        (fun _ => openingProofRoles rest odRest cdRest opRest tr qdRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd =>
+      openingProofRoles rest odRest cdRest opRest tr qd
+
+/-- Full Phase 2 target shape: first send all claimed responses, then run the
+composed opening subproof protocols determined by the actual BCS transcript.
+
+This is separate from the one-message compatibility `openingSpec` scaffold so
+callers can migrate deliberately. -/
+def fullOpeningSpec {m : Type → Type}
+    (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco m hs)
+    (opDeco : OpeningDeco m hs od cd)
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd))
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) :
+    Spec.{0} :=
+  .node (OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd)
+    (fun _ => openingProofSpec hs od cd opDeco bcsTr qd)
+
+/-- Roles for `fullOpeningSpec`: the prover first sends responses, then the
+roles are those of the composed opening subproofs. -/
+def fullOpeningRoles {m : Type → Type}
+    (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco m hs)
+    (opDeco : OpeningDeco m hs od cd)
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd))
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) :
+    RoleDecoration (fullOpeningSpec hs od cd opDeco bcsTr qd) :=
+  ⟨.sender, fun _ => openingProofRoles hs od cd opDeco bcsTr qd⟩
+
+/-! ### Full opening-proof prover/verifier assembly -/
+
+/-- Compose a finite family of prover strategies for repeated copies of the
+same spec, ignoring each subproof's local output. -/
+def repeatProverStrategies {m : Type → Type} [Monad m] :
+    (n : Nat) → (spec : Spec.{0}) → (roles : RoleDecoration spec) →
+    (Fin n → m (Spec.Strategy.withRoles m spec roles
+      (fun _ => HonestProverOutput Bool PUnit))) →
+    m (Spec.Strategy.withRoles m (repeatSpec n spec) (repeatRoles n spec roles)
+      (fun _ => PUnit))
+  | 0, _, _, _ => pure ⟨⟩
+  | n + 1, spec, roles, provers => do
+      let first ← provers ⟨0, Nat.succ_pos n⟩
+      let firstUnit :=
+        Spec.Strategy.mapOutputWithRoles (fun _ _ => PUnit.unit) first
+      Spec.Strategy.compWithRolesFlat
+        (s₂ := fun _ => repeatSpec n spec)
+        (r₂ := fun _ => repeatRoles n spec roles)
+        (Output := fun _ => PUnit)
+        firstUnit
+        (fun _ _ => repeatProverStrategies n spec roles (fun i => provers i.succ))
+
+/-- Compose a finite family of verifier counterparts for repeated copies of
+the same spec, ignoring each subproof's local verifier output. -/
+def repeatVerifierCounterparts {m : Type → Type} [Monad m] :
+    (n : Nat) → (spec : Spec.{0}) → (roles : RoleDecoration spec) →
+    (Fin n → Spec.Counterpart m spec roles (fun _ => Bool)) →
+    Spec.Counterpart m (repeatSpec n spec) (repeatRoles n spec roles)
+      (fun _ => PUnit)
+  | 0, _, _, _ => ⟨⟩
+  | n + 1, spec, roles, verifiers =>
+      let firstUnit :=
+        Spec.Counterpart.mapOutput (fun _ _ => PUnit.unit)
+          (verifiers ⟨0, Nat.succ_pos n⟩)
+      Spec.Counterpart.appendFlat
+        (s₂ := fun _ => repeatSpec n spec)
+        (r₂ := fun _ => repeatRoles n spec roles)
+        (Output₂ := fun _ => PUnit)
+        firstUnit
+        (fun _ _ => repeatVerifierCounterparts n spec roles (fun i => verifiers i.succ))
+
+/-- Compose a finite family of verifier counterparts for repeated copies of
+the same spec, conjoining their local Bool outputs. -/
+def repeatVerifierCounterpartsAll {m : Type → Type} [Monad m] :
+    (n : Nat) → (spec : Spec.{0}) → (roles : RoleDecoration spec) →
+    (Fin n → Spec.Counterpart m spec roles (fun _ => Bool)) →
+    Spec.Counterpart m (repeatSpec n spec) (repeatRoles n spec roles)
+      (fun _ => Bool)
+  | 0, _, _, _ => true
+  | n + 1, spec, roles, verifiers =>
+      Spec.Counterpart.appendFlat
+        (s₂ := fun _ => repeatSpec n spec)
+        (r₂ := fun _ => repeatRoles n spec roles)
+        (Output₂ := fun _ => Bool)
+        (verifiers ⟨0, Nat.succ_pos n⟩)
+        (fun _ accepted =>
+          Spec.Counterpart.mapOutput (fun _ restAccepted => accepted && restAccepted)
+            (repeatVerifierCounterpartsAll n spec roles (fun i => verifiers i.succ)))
+
+/-- Assemble the prover strategy for all opening subproofs after the response
+message has already fixed the claimed responses. -/
+def openingProofProver {m : Type → Type} [Monad m] :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (opDeco : OpeningDeco m hs od cd) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    (responses : OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    (wits : OpeningWitnessDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    m (Spec.Strategy.withRoles m (openingProofSpec hs od cd opDeco bcsTr qd)
+      (openingProofRoles hs od cd opDeco bcsTr qd) (fun _ => PUnit))
+  | .done, _, _, _, _, _, _, _ => pure ⟨⟩
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd, responses, wits =>
+      openingProofProver (rest x) (odRest x) (cdRest x) (opRest x) tr qd responses wits
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨cm, tr⟩, ⟨qb, qdRest⟩, ⟨responses, responsesRest⟩, ⟨wits, witsRest⟩ => do
+      let pref ← repeatProverStrategies qb.numQueries opening.spec opening.roles
+        (fun i => opening.proof.prover () ⟨cm, qb.queries i, responses i⟩ (wits i))
+      Spec.Strategy.compWithRolesFlat
+        (s₂ := fun _ => openingProofSpec rest odRest cdRest opRest tr qdRest)
+        (r₂ := fun _ => openingProofRoles rest odRest cdRest opRest tr qdRest)
+        (Output := fun _ => PUnit)
+        pref
+        (fun _ _ => openingProofProver rest odRest cdRest opRest tr qdRest responsesRest witsRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd, responses, wits =>
+      openingProofProver rest odRest cdRest opRest tr qd responses wits
+
+/-- Assemble the verifier counterpart for all opening subproofs after the
+response message has already fixed the claimed responses. -/
+def openingProofVerifier {m : Type → Type} [Monad m] :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (opDeco : OpeningDeco m hs od cd) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    (responses : OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    Spec.Counterpart m (openingProofSpec hs od cd opDeco bcsTr qd)
+      (openingProofRoles hs od cd opDeco bcsTr qd) (fun _ => PUnit)
+  | .done, _, _, _, _, _, _ => ⟨⟩
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd, responses =>
+      openingProofVerifier (rest x) (odRest x) (cdRest x) (opRest x) tr qd responses
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨cm, tr⟩, ⟨qb, qdRest⟩, ⟨responses, responsesRest⟩ =>
+      let pref := repeatVerifierCounterparts qb.numQueries opening.spec opening.roles
+        (fun i => opening.proof.verifier () ⟨cm, qb.queries i, responses i⟩)
+      Spec.Counterpart.appendFlat
+        (s₂ := fun _ => openingProofSpec rest odRest cdRest opRest tr qdRest)
+        (r₂ := fun _ => openingProofRoles rest odRest cdRest opRest tr qdRest)
+        (Output₂ := fun _ => PUnit)
+        pref
+        (fun _ _ => openingProofVerifier rest odRest cdRest opRest tr qdRest responsesRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd, responses =>
+      openingProofVerifier rest odRest cdRest opRest tr qd responses
+
+/-- Assemble the verifier counterpart for all opening subproofs and conjoin
+their local Bool outputs. -/
+def openingProofVerifierAll {m : Type → Type} [Monad m] :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (opDeco : OpeningDeco m hs od cd) →
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd)) →
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) →
+    (responses : OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) →
+    Spec.Counterpart m (openingProofSpec hs od cd opDeco bcsTr qd)
+      (openingProofRoles hs od cd opDeco bcsTr qd) (fun _ => Bool)
+  | .done, _, _, _, _, _, _ => true
+  | .branch _ rest, odRest, cdRest, opRest, ⟨x, tr⟩, qd, responses =>
+      openingProofVerifierAll (rest x) (odRest x) (cdRest x) (opRest x) tr qd responses
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, ⟨opening, opRest⟩,
+      ⟨cm, tr⟩, ⟨qb, qdRest⟩, ⟨responses, responsesRest⟩ =>
+      let pref := repeatVerifierCounterpartsAll qb.numQueries opening.spec opening.roles
+        (fun i => opening.proof.verifier () ⟨cm, qb.queries i, responses i⟩)
+      Spec.Counterpart.appendFlat
+        (s₂ := fun _ => openingProofSpec rest odRest cdRest opRest tr qdRest)
+        (r₂ := fun _ => openingProofRoles rest odRest cdRest opRest tr qdRest)
+        (Output₂ := fun _ => Bool)
+        pref
+        (fun _ accepted =>
+          Spec.Counterpart.mapOutput (fun _ restAccepted => accepted && restAccepted)
+            (openingProofVerifierAll rest odRest cdRest opRest tr qdRest responsesRest))
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, opRest, ⟨_, tr⟩, qd, responses =>
+      openingProofVerifierAll rest odRest cdRest opRest tr qd responses
+
 /-- The opening protocol spec for Phase 2 of BCS. For each committed pass
 node and each query in the `OracleQueryDeco`, composes the individual
 opening `Interaction.Proof` specs from `OpeningDeco`.
@@ -245,7 +646,7 @@ def openingSpec {m : Type → Type}
     (_opDeco : OpeningDeco m hs od cd)
     (st : SharedTranscript hs cd) (qd : OracleQueryDeco hs od cd st) :
     Spec.{0} :=
-  sorry
+  .node (OracleResponseDeco hs od cd st qd) (fun _ => .done)
 
 /-- Roles for the opening protocol spec. -/
 def openingRoles {m : Type → Type}
@@ -253,12 +654,102 @@ def openingRoles {m : Type → Type}
     (opDeco : OpeningDeco m hs od cd)
     (st : SharedTranscript hs cd) (qd : OracleQueryDeco hs od cd st) :
     RoleDecoration (openingSpec hs od cd opDeco st qd) :=
-  sorry
+  ⟨.sender, fun _ => ⟨⟩⟩
 
-/-- Phase 2 prover: uses the `OracleWitness` to answer verifier queries and
-run opening protocols. For each committed oracle and each query, the prover
-reveals the response and provides an opening proof via the `Opening.proof`
-from `OpeningDeco`. -/
+/-- Answer committed oracle queries from the Phase 1 witness retained by the
+honest prover. This is the executable payload carried by the minimal Phase 2
+opening interaction below. -/
+def answerCommittedQueriesFromWitness {m : Type → Type} :
+    (hs : HybridSpec) → (od : OracleDeco hs) → (cd : CommitDeco m hs) →
+    (st : SharedTranscript hs cd) →
+    (qd : OracleQueryDeco hs od cd st) → OracleWitness hs cd st →
+    OracleResponseDeco hs od cd st qd
+  | .done, _, _, _, _, _ => ⟨⟩
+  | .branch _ rest, odRest, cdRest, ⟨x, st⟩, qd, wit =>
+      answerCommittedQueriesFromWitness (rest x) (odRest x) (cdRest x) st qd wit
+  | .pass _ rest, ⟨_, odRest⟩, ⟨some _, cdRest⟩, st, ⟨qb, qdRest⟩, ⟨x, _, witRest⟩ =>
+      (fun i => OracleInterface.answer x (qb.queries i),
+       answerCommittedQueriesFromWitness rest odRest cdRest st qdRest witRest)
+  | .pass _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩, ⟨_, st⟩, qd, wit =>
+      answerCommittedQueriesFromWitness rest odRest cdRest st qd wit
+
+/-- Full Phase 2 prover: send committed-oracle query responses, then run every
+requested commitment-opening subproof. -/
+def fullBcsPhase2Prover
+    (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco (OracleComp oSpec) hs)
+    (opDeco : OpeningDeco (OracleComp oSpec) hs od cd)
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd))
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr))
+    (wit : OracleWitness hs cd (hs.bcsProjectShared cd bcsTr)) :
+    OracleComp oSpec (Spec.Strategy.withRoles (OracleComp oSpec)
+      (fullOpeningSpec hs od cd opDeco bcsTr qd)
+      (fullOpeningRoles hs od cd opDeco bcsTr qd)
+      (fun _ => OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd)) := do
+  let responses := answerCommittedQueriesFromWitness hs od cd (hs.bcsProjectShared cd bcsTr) qd wit
+  let wits := openingWitnessesFromOracleWitness hs od cd (hs.bcsProjectShared cd bcsTr) qd wit
+  let proofStrategy ← openingProofProver hs od cd opDeco bcsTr qd responses wits
+  pure (pure ⟨responses,
+    Spec.Strategy.mapOutputWithRoles (fun _ _ => responses) proofStrategy⟩)
+
+/-- Full Phase 2 verifier: receive committed-oracle query responses, then run
+every requested commitment-opening verifier and return the received responses
+if all subprotocols complete. Individual opening proof outputs are currently
+discarded by the transcript assembly layer; this definition wires the concrete
+verifiers into the full Phase 2 interaction shape. -/
+def fullBcsPhase2Verifier
+    (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco (OracleComp oSpec) hs)
+    (opDeco : OpeningDeco (OracleComp oSpec) hs od cd)
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd))
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) :
+    Spec.Counterpart (OracleComp oSpec)
+      (fullOpeningSpec hs od cd opDeco bcsTr qd)
+      (fullOpeningRoles hs od cd opDeco bcsTr qd)
+      (fun _ => OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd) :=
+  fun responses => pure <|
+    Spec.Counterpart.mapOutput (fun _ _ => responses)
+      (openingProofVerifier hs od cd opDeco bcsTr qd responses)
+
+/-- Checked full Phase 2 prover. The honest prover returns `some responses`
+after sending the committed-oracle query responses and running every requested
+opening subproof. -/
+def checkedFullBcsPhase2Prover
+    (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco (OracleComp oSpec) hs)
+    (opDeco : OpeningDeco (OracleComp oSpec) hs od cd)
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd))
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr))
+    (wit : OracleWitness hs cd (hs.bcsProjectShared cd bcsTr)) :
+    OracleComp oSpec (Spec.Strategy.withRoles (OracleComp oSpec)
+      (fullOpeningSpec hs od cd opDeco bcsTr qd)
+      (fullOpeningRoles hs od cd opDeco bcsTr qd)
+      (fun _ => Option (OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd))) := do
+  let responses := answerCommittedQueriesFromWitness hs od cd (hs.bcsProjectShared cd bcsTr) qd wit
+  let wits := openingWitnessesFromOracleWitness hs od cd (hs.bcsProjectShared cd bcsTr) qd wit
+  let proofStrategy ← openingProofProver hs od cd opDeco bcsTr qd responses wits
+  pure (pure ⟨responses,
+    Spec.Strategy.mapOutputWithRoles (fun _ _ => some responses) proofStrategy⟩)
+
+/-- Checked full Phase 2 verifier. It returns `some responses` exactly when all
+opening subproof verifier outputs are `true`, and `none` otherwise. -/
+def checkedFullBcsPhase2Verifier
+    (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco (OracleComp oSpec) hs)
+    (opDeco : OpeningDeco (OracleComp oSpec) hs od cd)
+    (bcsTr : Spec.Transcript (hs.bcsSpec cd))
+    (qd : OracleQueryDeco hs od cd (hs.bcsProjectShared cd bcsTr)) :
+    Spec.Counterpart (OracleComp oSpec)
+      (fullOpeningSpec hs od cd opDeco bcsTr qd)
+      (fullOpeningRoles hs od cd opDeco bcsTr qd)
+      (fun _ => Option (OracleResponseDeco hs od cd (hs.bcsProjectShared cd bcsTr) qd)) :=
+  fun responses => pure <|
+    Spec.Counterpart.mapOutput
+      (fun _ accepted => if accepted then some responses else none)
+      (openingProofVerifierAll hs od cd opDeco bcsTr qd responses)
+
+/-- Phase 2 prover for the current minimal executable scaffold.
+
+It uses the retained `OracleWitness` to answer every committed-oracle query.
+The companion definitions `openingStatements` and
+`openingWitnessesFromOracleWitness` expose the per-query commitment-opening
+bridge that a fully checking Phase 2 verifier must run. -/
 def bcsPhase2Prover
     (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco (OracleComp oSpec) hs)
     (opDeco : OpeningDeco (OracleComp oSpec) hs od cd)
@@ -267,11 +758,15 @@ def bcsPhase2Prover
     OracleComp oSpec (Spec.Strategy.withRoles (OracleComp oSpec)
       (openingSpec hs od cd opDeco st qd) (openingRoles hs od cd opDeco st qd)
       (fun _ => OracleResponseDeco hs od cd st qd)) :=
-  sorry
+  let responses := answerCommittedQueriesFromWitness hs od cd st qd _wit
+  pure (pure ⟨responses, responses⟩)
 
-/-- Phase 2 verifier: checks the opening proofs. For each committed oracle
-and each query, verifies that the prover's opening is consistent with the
-commitment from Phase 1. -/
+/-- Phase 2 verifier for the current minimal executable scaffold.
+
+It receives the response decoration and returns it unchanged. Full
+commitment-opening verification should be implemented by threading a BCS
+transcript through this phase and running the per-query statements produced by
+`openingStatements` against the `OpeningDeco` proofs. -/
 def bcsPhase2Verifier
     (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco (OracleComp oSpec) hs)
     (opDeco : OpeningDeco (OracleComp oSpec) hs od cd)
@@ -279,7 +774,7 @@ def bcsPhase2Verifier
     Spec.Counterpart (OracleComp oSpec)
       (openingSpec hs od cd opDeco st qd) (openingRoles hs od cd opDeco st qd)
       (fun _ => OracleResponseDeco hs od cd st qd) :=
-  sorry
+  fun responses => pure responses
 
 end Phase2
 

--- a/ArkLib/Interaction/Boundary/Oracle.lean
+++ b/ArkLib/Interaction/Boundary/Oracle.lean
@@ -864,8 +864,6 @@ theorem runWithOracleCounterpart_pullbackCounterpart
             accImpl
             strat
             cpt := by
-  sorry
-/-
   intro spec roles od ιₐ accSpec accImpl OutputP Output₁ Output₂ f strat cpt
   let rec go
       (spec : Spec) (roles : RoleDecoration spec) (od : OracleDecoration spec roles)
@@ -1189,11 +1187,71 @@ theorem runWithOracleCounterpart_pullbackCounterpart
                     accImpl
                     strat
                     cpt := hThird
-        simpa [simulateQ_map, routeOuter, routeInner, contOuter, contInner, addPrefix,
-          bind_assoc, OracleDecoration.runWithOracleCounterpart] using
-          hFinalRaw
+        calc
+          (simulateQ
+              (fun x =>
+                match x with
+                | Sum.inl (Sum.inl q) => liftM (oSpec.query q)
+                | Sum.inl (Sum.inr q) => liftM (outerInputImpl q)
+                | Sum.inr q => liftM (accImpl q))
+              (simulateQ
+                (OracleStatementAccess.routeInputQueries
+                  (oSpec := oSpec)
+                  simulateIn
+                  accSpec)
+                (mapRest <$> cpt)) >>=
+            fun z' => do
+              let next ← strat z'.fst
+              (fun a => ⟨⟨z'.fst, a.fst⟩, a.snd⟩) <$>
+                OracleDecoration.runWithOracleCounterpart
+                  outerInputImpl
+                  (rest z'.fst)
+                  (rRest z'.fst)
+                  (odFn z'.fst)
+                  accSpec
+                  accImpl
+                  next
+                  z'.snd) =
+              bindCont
+                (simulateQ
+                  (fun x =>
+                    match x with
+                    | Sum.inl (Sum.inl q) => liftM (oSpec.query q)
+                    | Sum.inl (Sum.inr q) => liftM (outerInputImpl q)
+                    | Sum.inr q => liftM (accImpl q))
+                  (simulateQ
+                    (OracleStatementAccess.routeInputQueries
+                      (oSpec := oSpec)
+                      simulateIn
+                      accSpec)
+                    cpt)) := by
+              simp [bindCont, contOuter, mapRest, addPrefix, simulateQ_bind, bind_assoc,
+                map_eq_bind_pure_comp]
+          _ =
+              (simulateQ
+                  (fun x =>
+                    match x with
+                    | Sum.inl (Sum.inl q) => liftM (oSpec.query q)
+                    | Sum.inl (Sum.inr q) => liftM (innerInputImpl q)
+                    | Sum.inr q => liftM (accImpl q))
+                  cpt >>=
+                fun a => do
+                  let next ← strat a.fst
+                  (fun a_1 =>
+                      ⟨⟨a.fst, a_1.fst⟩,
+                        (a_1.snd.1, f ⟨a.fst, a_1.fst⟩ a_1.snd.2)⟩) <$>
+                    OracleDecoration.runWithOracleCounterpart
+                      innerInputImpl
+                      (rest a.fst)
+                      (rRest a.fst)
+                      (odFn a.fst)
+                      accSpec
+                      accImpl
+                      next
+                      a.snd) := by
+              simpa [OracleDecoration.runWithOracleCounterpart, routeInner, contInner, prefixMap,
+                map_bind, bind_pure_comp, Functor.map_map] using hFinalRaw
   exact go spec roles od accSpec accImpl f strat cpt
--/
 
 /-- Running a verifier counterpart after the raw oracle pullback is the same as
 running the original inner counterpart against the realized inner input oracle.

--- a/ArkLib/Interaction/Examples/Core.lean
+++ b/ArkLib/Interaction/Examples/Core.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: ArkLib Contributors
+-/
+import ArkLib.Interaction.BCS.Verifier
+import ArkLib.Interaction.Oracle.Spec
+import ArkLib.Interaction.Reduction
+
+/-!
+# Core Interaction Examples
+
+Small reviewer-facing sanity checks for the interaction/oracle core. These
+examples do not introduce a second design; they pin down executable behavior
+and routing laws already provided by the core abstractions.
+-/
+
+universe u v w
+
+open OracleComp OracleSpec
+
+namespace Interaction
+
+/-! ## Reduction composition executes in two phases -/
+
+theorem example_execute_sequential_composition
+    {m : Type u → Type u} [Monad m] [Spec.LawfulCommMonad m]
+    {SharedIn : Type v}
+    {StatementIn : SharedIn → Type w}
+    {WitnessIn : SharedIn → Type w}
+    {ctx₁ : SharedIn → Spec}
+    {roles₁ : (i : SharedIn) → RoleDecoration (ctx₁ i)}
+    {StmtMid WitMid : (i : SharedIn) → Spec.Transcript (ctx₁ i) → Type u}
+    {ctx₂ : (i : SharedIn) → Spec.Transcript (ctx₁ i) → Spec}
+    {roles₂ : (i : SharedIn) → (tr₁ : Spec.Transcript (ctx₁ i)) →
+      RoleDecoration (ctx₂ i tr₁)}
+    {StmtOut WitOut : (i : SharedIn) → (tr₁ : Spec.Transcript (ctx₁ i)) →
+      Spec.Transcript (ctx₂ i tr₁) → Type u}
+    (reduction1 : Reduction m SharedIn ctx₁ roles₁ StatementIn WitnessIn StmtMid WitMid)
+    (reduction2 : Reduction m
+      ((i : SharedIn) × StatementIn i × Spec.Transcript (ctx₁ i))
+      (fun shared => ctx₂ shared.1 shared.2.2)
+      (fun shared => roles₂ shared.1 shared.2.2)
+      (fun shared => StmtMid shared.1 shared.2.2)
+      (fun shared => WitMid shared.1 shared.2.2)
+      (fun shared tr₂ => StmtOut shared.1 shared.2.2 tr₂)
+      (fun shared tr₂ => WitOut shared.1 shared.2.2 tr₂))
+    (i : SharedIn) (stmt : StatementIn i) (w : WitnessIn i) :
+    (Reduction.comp reduction1 reduction2).execute i stmt w =
+      (do
+        let ⟨tr₁, midOut, sMid⟩ ← reduction1.execute i stmt w
+        let strat₂ ← reduction2.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit
+        let ⟨tr₂, out, sOut⟩ ←
+          Spec.Strategy.runWithRoles (ctx₂ i tr₁) (roles₂ i tr₁) strat₂
+            (reduction2.verifier ⟨i, stmt, tr₁⟩ sMid)
+        pure ⟨Spec.Transcript.append (ctx₁ i) (ctx₂ i) tr₁ tr₂,
+          ⟨Spec.Transcript.packAppend (ctx₁ i) (ctx₂ i) (StmtOut i) tr₁ tr₂ out.stmt,
+            Spec.Transcript.packAppend (ctx₁ i) (ctx₂ i) (WitOut i) tr₁ tr₂ out.wit⟩,
+          Spec.Transcript.packAppend (ctx₁ i) (ctx₂ i) (StmtOut i) tr₁ tr₂ sOut⟩) :=
+  Reduction.execute_comp reduction1 reduction2 i stmt w
+
+/-! ## Oracle query routing preserves the addressed oracle spec -/
+
+namespace Oracle
+
+theorem example_left_query_routes_to_left_oracle_spec
+    (s₁ : Oracle.Spec) (s₂ : Spec.PublicTranscript s₁ → Oracle.Spec)
+    (od₁ : Spec.OracleDeco s₁)
+    (od₂ : (pt : Spec.PublicTranscript s₁) → Spec.OracleDeco (s₂ pt))
+    (pt₁ : Spec.PublicTranscript s₁) (pt₂ : Spec.PublicTranscript (s₂ pt₁))
+    (q : Spec.QueryHandle s₁ od₁ pt₁) :
+    Spec.toOracleSpec (s₁.append s₂) (Spec.OracleDeco.append s₁ s₂ od₁ od₂)
+      (Spec.PublicTranscript.append s₁ s₂ pt₁ pt₂)
+      (Spec.QueryHandle.appendLeft s₁ s₂ od₁ od₂ pt₁ pt₂ q) =
+    Spec.toOracleSpec s₁ od₁ pt₁ q :=
+  Spec.toOracleSpec_appendLeft s₁ s₂ od₁ od₂ pt₁ pt₂ q
+
+theorem example_right_query_routes_to_right_oracle_spec
+    (s₁ : Oracle.Spec) (s₂ : Spec.PublicTranscript s₁ → Oracle.Spec)
+    (od₁ : Spec.OracleDeco s₁)
+    (od₂ : (pt : Spec.PublicTranscript s₁) → Spec.OracleDeco (s₂ pt))
+    (pt₁ : Spec.PublicTranscript s₁) (pt₂ : Spec.PublicTranscript (s₂ pt₁))
+    (q : Spec.QueryHandle (s₂ pt₁) (od₂ pt₁) pt₂) :
+    Spec.toOracleSpec (s₁.append s₂) (Spec.OracleDeco.append s₁ s₂ od₁ od₂)
+      (Spec.PublicTranscript.append s₁ s₂ pt₁ pt₂)
+      (Spec.QueryHandle.appendRight s₁ s₂ od₁ od₂ pt₁ pt₂ q) =
+    Spec.toOracleSpec (s₂ pt₁) (od₂ pt₁) pt₂ q :=
+  Spec.toOracleSpec_appendRight s₁ s₂ od₁ od₂ pt₁ pt₂ q
+
+end Oracle
+
+/-! ## State-chain transcripts join and unjoin coherently -/
+
+theorem example_state_chain_unjoin_after_join
+    {Stage : Nat → Type u} {spec : (i : Nat) → Stage i → Spec}
+    {advance : (i : Nat) → (s : Stage i) → Spec.Transcript (spec i s) → Stage (i + 1)}
+    (n : Nat) (i : Nat) (s : Stage i)
+    (trs : Spec.Transcript.stateChain Stage spec advance n i s) :
+    Spec.Transcript.stateChainUnjoin Stage spec advance n i s
+      (Spec.Transcript.stateChainJoin Stage spec advance n i s trs) = trs :=
+  Spec.Transcript.stateChainUnjoin_join n i s trs
+
+theorem example_state_chain_join_after_unjoin
+    {Stage : Nat → Type u} {spec : (i : Nat) → Stage i → Spec}
+    {advance : (i : Nat) → (s : Stage i) → Spec.Transcript (spec i s) → Stage (i + 1)}
+    (n : Nat) (i : Nat) (s : Stage i)
+    (tr : Spec.Transcript (Spec.stateChain Stage spec advance n i s)) :
+    Spec.Transcript.stateChainJoin Stage spec advance n i s
+      (Spec.Transcript.stateChainUnjoin Stage spec advance n i s tr) = tr :=
+  Spec.Transcript.stateChainJoin_unjoin n i s tr
+
+/-! ## BCS shared transcripts expose only public/non-committed data -/
+
+namespace HybridSpec
+
+theorem example_committed_pass_shared_transcript_drops_message
+    (X Comm Witness : Type) (commit : X → Id (Comm × Witness)) :
+    SharedTranscript (.pass X .done)
+      (⟨some ({ CommType := Comm, WitnessType := Witness, commit := commit } :
+        NodeCommitment Id X), ⟨⟩⟩ : CommitDeco Id (.pass X .done)) =
+      PUnit :=
+  rfl
+
+theorem example_uncommitted_pass_shared_transcript_keeps_message
+    (X : Type) :
+    SharedTranscript (.pass X .done)
+      (⟨none, ⟨⟩⟩ : CommitDeco Id (.pass X .done)) =
+      (X × PUnit) :=
+  rfl
+
+theorem example_committed_pass_bcs_spec_uses_commitment
+    (X Comm Witness : Type) (commit : X → Id (Comm × Witness)) :
+    bcsSpec (.pass X .done)
+      (⟨some ({ CommType := Comm, WitnessType := Witness, commit := commit } :
+        NodeCommitment Id X), ⟨⟩⟩ : CommitDeco Id (.pass X .done)) =
+      .node Comm (fun _ => .done) :=
+  rfl
+
+abbrev ExampleCommittedPassCommitDeco (X Comm Witness : Type)
+    (commit : X → Id (Comm × Witness)) :
+    CommitDeco Id (.pass X .done) :=
+  ⟨some ({ CommType := Comm, WitnessType := Witness, commit := commit } :
+    NodeCommitment Id X), ⟨⟩⟩
+
+abbrev ExampleCommittedPassOracleDeco (X : Type) : OracleDeco (.pass X .done) :=
+  ⟨OracleInterface.instDefault, ⟨⟩⟩
+
+theorem example_committed_pass_query_deco_has_no_message_argument
+    (X Comm Witness : Type) (commit : X → Id (Comm × Witness)) :
+    OracleQueryDeco (.pass X .done) (ExampleCommittedPassOracleDeco X)
+      (ExampleCommittedPassCommitDeco X Comm Witness commit) PUnit.unit =
+      (QueryBundle (@OracleInterface.instDefault X) × PUnit) :=
+  rfl
+
+abbrev PublicQueryFunction {m : Type → Type}
+    (hs : HybridSpec) (od : OracleDeco hs) (cd : CommitDeco m hs)
+    (StmtIn : Type) :=
+  StmtIn → (st : SharedTranscript hs cd) → OracleQueryDeco hs od cd st
+
+def PublicQueryVerifier.queryFunction
+    {ι : Type} {oSpec : OracleSpec.{0, 0} ι}
+    {ιₛᵢ : Type} {OStmtIn : ιₛᵢ → Type} [∀ i, OracleInterface.{0, 0} (OStmtIn i)]
+    {hs : HybridSpec} {roles : RoleDeco hs} {od : OracleDeco hs}
+    {cd : CommitDeco (OracleComp oSpec) hs}
+    {StmtIn : Type} {StmtOut : SharedTranscript hs cd → Type}
+    (pqv : PublicQueryVerifier oSpec OStmtIn hs roles od cd StmtIn StmtOut) :
+    PublicQueryFunction hs od cd StmtIn :=
+  pqv.queryFn
+
+end HybridSpec
+
+end Interaction

--- a/ArkLib/Interaction/Oracle/BCS.lean
+++ b/ArkLib/Interaction/Oracle/BCS.lean
@@ -447,15 +447,14 @@ and a `Proof` (prover + verifier pair) for the opening sub-protocol.
 
 At non-committed `.oracle` nodes and `.public` nodes, recurse structurally. -/
 def OpeningDeco {m : Type → Type}
-    (OpeningProof : {X : Type} → OracleInterface X →
-      {nc : NodeCommitment m X} → Type 1) :
+    (OpeningProof : {X : Type} → OracleInterface X → NodeCommitment m X → Type 1) :
     (s : Oracle.Spec) → (od : OracleDeco s) →
     CommitDeco m s → Type 1
   | .done, _, _ => PUnit
   | .«public» _ rest, odRest, cdRest =>
       (x : _) → OpeningDeco OpeningProof (rest x) (odRest x) (cdRest x)
   | .oracle _X rest, ⟨oi, odRest⟩, ⟨some nc, cdRest⟩ =>
-      @OpeningProof _ oi (nc := nc) × OpeningDeco OpeningProof rest odRest cdRest
+      OpeningProof oi nc × OpeningDeco OpeningProof rest odRest cdRest
   | .oracle _ rest, ⟨_, odRest⟩, ⟨none, cdRest⟩ =>
       OpeningDeco OpeningProof rest odRest cdRest
 

--- a/ArkLib/Interaction/Oracle/Continuation.lean
+++ b/ArkLib/Interaction/Oracle/Continuation.lean
@@ -1642,9 +1642,6 @@ theorem simulate_comp {ι : Type} {oSpec : OracleSpec ι}
         (outImpl (splitLiftAppendOracleQuery
           (ctx₁ shared) (ctx₂ shared) (ιₛₒ shared) (OStatementOut shared) tr qOut)) := by
   intro qOut
-  sorry
-/-
-  intro qOut
   let split := Spec.Transcript.split (ctx₁ shared) (ctx₂ shared) tr
   let tr₁ := split.1
   let tr₂ := split.2
@@ -1827,8 +1824,7 @@ theorem simulate_comp {ι : Type} {oSpec : OracleSpec ι}
         (ctx₁ shared) (ctx₂ shared) (ιₛₒ shared) (OStatementOut shared)
         tr qOut
         (outImpl qSplit) := by
-        rw [hRouted]
--/
+        simpa [answerSplitLiftAppendQuery] using hRouted
 
 end OracleReduction
 

--- a/ArkLib/Interaction/Oracle/Execution.lean
+++ b/ArkLib/Interaction/Oracle/Execution.lean
@@ -1104,8 +1104,6 @@ theorem runWithOracleCounterpart_mapCounterpartOutput
         (toMonadDecoration oSpec OStmtIn spec roles od accSpec) fC cpt) =
       (fun z => ⟨z.1, z.2.1, fC z.1 z.2.2⟩) <$>
         runWithOracleCounterpart inputImpl spec roles od accSpec accImpl strat cpt := by
-  sorry
-/-
   let rec go
       (spec : Spec) (roles : RoleDecoration spec) (od : OracleDecoration spec roles)
       {ιₐ : Type} (accSpec : OracleSpec ιₐ) (accImpl : QueryImpl accSpec Id)
@@ -1160,29 +1158,85 @@ theorem runWithOracleCounterpart_mapCounterpartOutput
               xc.2
               (cpt xc.1))
     | .node _ rest, ⟨.receiver, rRest⟩, odFn =>
-        have hMap :
-            Spec.Counterpart.withMonads.mapOutput
-              (Spec.node _ rest) ⟨.receiver, rRest⟩
-              (toMonadDecoration oSpec OStmtIn (Spec.node _ rest) ⟨.receiver, rRest⟩
-                odFn accSpec)
-              fC cpt =
-              (fun xc =>
-                ⟨xc.1,
-                  Spec.Counterpart.withMonads.mapOutput
-                    (rest xc.1) (rRest xc.1)
-                    (toMonadDecoration oSpec OStmtIn (rest xc.1) (rRest xc.1)
-                      (odFn xc.1) accSpec)
-                    (fun tr => fC ⟨xc.1, tr⟩) xc.2⟩) <$> cpt := by
-          rfl
-        rw [hMap]
-        simp only [runWithOracleCounterpart, simulateQ_map,
-          bind_map_left, bind_pure_comp, map_bind, Functor.map_map]
         let routeImpl :
             QueryImpl ((oSpec + [OStmtIn]ₒ) + accSpec) (OracleComp oSpec) :=
           fun
           | .inl (.inl q) => liftM (oSpec.query q)
           | .inl (.inr q) => liftM (inputImpl q)
           | .inr q => liftM (accImpl q)
+        let mapCpt :
+            ((x : _) ×
+              Spec.Counterpart.withMonads (rest x) (rRest x)
+                (toMonadDecoration oSpec OStmtIn (rest x) (rRest x) (odFn x) accSpec)
+                (fun tr => OutputC ⟨x, tr⟩)) →
+              ((x : _) ×
+                Spec.Counterpart.withMonads (rest x) (rRest x)
+                  (toMonadDecoration oSpec OStmtIn (rest x) (rRest x) (odFn x) accSpec)
+                  (fun tr => OutputC' ⟨x, tr⟩)) :=
+          fun xc =>
+            ⟨xc.1,
+              Spec.Counterpart.withMonads.mapOutput
+                (rest xc.1) (rRest xc.1)
+                (toMonadDecoration oSpec OStmtIn (rest xc.1) (rRest xc.1)
+                  (odFn xc.1) accSpec)
+                (fun tr => fC ⟨xc.1, tr⟩) xc.2⟩
+        have hSim : simulateQ routeImpl (mapCpt <$> cpt) =
+            mapCpt <$> simulateQ routeImpl cpt :=
+          simulateQ_map routeImpl mapCpt cpt
+        have hMap :
+            Spec.Counterpart.withMonads.mapOutput
+              (Spec.node _ rest) ⟨.receiver, rRest⟩
+              (toMonadDecoration oSpec OStmtIn (Spec.node _ rest) ⟨.receiver, rRest⟩
+                odFn accSpec)
+              fC cpt =
+              mapCpt <$> cpt := by
+          rfl
+        rw [hMap]
+        simp only [runWithOracleCounterpart]
+        dsimp [routeImpl] at hSim
+        change
+          (simulateQ
+            (fun x =>
+              match x with
+              | .inl (.inl q) => liftM (oSpec.query q)
+              | .inl (.inr q) => liftM (inputImpl q)
+              | .inr q => liftM (accImpl q))
+            (mapCpt <$> cpt) >>= fun z' =>
+              strat z'.1 >>= fun next =>
+                runWithOracleCounterpart inputImpl (rest z'.1) (rRest z'.1)
+                  (odFn z'.1) accSpec accImpl next z'.2 >>= fun z =>
+                    pure
+                      ((⟨⟨z'.1, z.1⟩, (z.2.1, z.2.2)⟩ :
+                        (tr : Spec.Transcript (Spec.node _ rest)) ×
+                          OutputP tr × OutputC' tr))) = _
+        trans
+          ((mapCpt <$>
+            simulateQ
+              (fun x =>
+                match x with
+                | .inl (.inl q) => liftM (oSpec.query q)
+                | .inl (.inr q) => liftM (inputImpl q)
+                | .inr q => liftM (accImpl q))
+              cpt) >>= fun z' =>
+                strat z'.1 >>= fun next =>
+                  runWithOracleCounterpart inputImpl (rest z'.1) (rRest z'.1)
+                    (odFn z'.1) accSpec accImpl next z'.2 >>= fun z =>
+                      pure
+                        ((⟨⟨z'.1, z.1⟩, (z.2.1, z.2.2)⟩ :
+                          (tr : Spec.Transcript (Spec.node _ rest)) ×
+                            OutputP tr × OutputC' tr)))
+        · exact congrArg
+            (fun m =>
+              m >>= fun z' =>
+                strat z'.1 >>= fun next =>
+                  runWithOracleCounterpart inputImpl (rest z'.1) (rRest z'.1)
+                    (odFn z'.1) accSpec accImpl next z'.2 >>= fun z =>
+                      pure
+                        ((⟨⟨z'.1, z.1⟩, (z.2.1, z.2.2)⟩ :
+                          (tr : Spec.Transcript (Spec.node _ rest)) ×
+                            OutputP tr × OutputC' tr)))
+            hSim
+        simp only [bind_map_left, bind_pure_comp, map_bind, Functor.map_map]
         refine congrArg (fun k => simulateQ routeImpl cpt >>= k) ?_
         funext xc
         refine congrArg (fun k => strat xc.1 >>= k) ?_
@@ -1201,7 +1255,6 @@ theorem runWithOracleCounterpart_mapCounterpartOutput
               next
               xc.2)
   exact go spec roles od accSpec accImpl fC strat cpt
--/
 
 /-- Public execution is just full honest execution with the prover's private
 witness component erased afterwards. -/
@@ -1506,76 +1559,85 @@ theorem Spec.runWithOracleCounterpart_mapOutputWithRoles
       (fun z => ⟨z.1, fP z.1 z.2.1, z.2.2⟩) <$>
         Spec.runWithOracleCounterpart inputImpl s roles od accSpec accImpl strat cpt := by
   intro s roles od ιₐ accSpec accImpl OutputP OutputP' OutputC fP strat cpt
-  sorry
-/-
-  | .done, _, _, _, _, _, _, _, _, _, output, cOutput => by
-      simp [runWithOracleCounterpart, Interaction.Spec.Strategy.mapOutputWithRoles]
-  | .«public» _X rest, ⟨.sender, rRest⟩, odRest, _, accSpec, accImpl,
-      OutputP, OutputP', OutputC, fP, strat, cptFn => by
-      simp only [Interaction.Spec.Strategy.mapOutputWithRoles,
-        Interaction.Spec.Counterpart.mapReceiver, runWithOracleCounterpart,
-        bind_pure_comp, bind_map_left, map_bind, Functor.map_map]
-      refine congrArg (fun k => strat >>= k) ?_
-      funext ⟨x, next⟩
-      let addPrefix :
-          ((tr : Interaction.Spec.Transcript (rest x).toInteractionSpec) ×
-            OutputP' ⟨x, tr⟩ × OutputC ⟨x, tr⟩) →
-          ((tr : Interaction.Spec.Transcript
-            (Oracle.Spec.public _X rest).toInteractionSpec) ×
-            OutputP' tr × OutputC tr) :=
-        fun a => ⟨⟨x, a.1⟩, a.2.1, a.2.2⟩
-      simpa [bind_assoc, addPrefix] using
-        congrArg (fun z => addPrefix <$> z)
-          (runWithOracleCounterpart_mapOutputWithRoles inputImpl
-            (rest x) (rRest x) (odRest x) accSpec accImpl
-            (fun tr => fP ⟨x, tr⟩) next (cptFn x))
-  | .«public» _X rest, ⟨.receiver, rRest⟩, odRest, _, accSpec, accImpl,
-      OutputP, OutputP', OutputC, fP, strat, cpt => by
-      simp only [runWithOracleCounterpart,
-        Interaction.Spec.Strategy.mapOutputWithRoles,
-        bind_pure_comp, bind_map_left, map_bind, Functor.map_map]
-      let routeImpl : QueryImpl ((oSpec + [OStmtIn]ₒ) + accSpec) (OracleComp oSpec) :=
-        fun
-        | .inl (.inl q) => liftM (oSpec.query q)
-        | .inl (.inr q) => liftM (inputImpl q)
-        | .inr q => liftM (accImpl q)
-      refine congrArg (fun k => simulateQ routeImpl cpt >>= k) ?_
-      funext ⟨x, cptRest⟩
-      refine congrArg (fun k => strat x >>= k) ?_
-      funext next
-      let addPrefix :
-          ((tr : Interaction.Spec.Transcript (rest x).toInteractionSpec) ×
-            OutputP' ⟨x, tr⟩ × OutputC ⟨x, tr⟩) →
-          ((tr : Interaction.Spec.Transcript (Oracle.Spec.public _X rest).toInteractionSpec) ×
-            OutputP' tr × OutputC tr) :=
-        fun a => ⟨⟨x, a.1⟩, a.2.1, a.2.2⟩
-      simpa [bind_assoc, addPrefix] using
-        congrArg (fun z => addPrefix <$> z)
-          (runWithOracleCounterpart_mapOutputWithRoles inputImpl
-            (rest x) (rRest x) (odRest x) accSpec accImpl
-            (fun tr => fP ⟨x, tr⟩) next cptRest)
-  | .oracle _X rest, roles, ⟨oi, odRest⟩, _, accSpec, accImpl,
-      OutputP, OutputP', OutputC, fP, strat, cptFn => by
-      simp only [Interaction.Spec.Strategy.mapOutputWithRoles,
-        Interaction.Spec.Counterpart.mapReceiver, runWithOracleCounterpart,
-        bind_pure_comp, bind_map_left, map_bind, Functor.map_map]
-      refine congrArg (fun k => strat >>= k) ?_
-      funext ⟨x, next⟩
-      let addPrefix :
-          ((tr : Interaction.Spec.Transcript rest.toInteractionSpec) ×
-            OutputP' ⟨x, tr⟩ × OutputC ⟨x, tr⟩) →
-          ((tr : Interaction.Spec.Transcript
-            (Oracle.Spec.oracle _X rest).toInteractionSpec) ×
-            OutputP' tr × OutputC tr) :=
-        fun a => ⟨⟨x, a.1⟩, a.2.1, a.2.2⟩
-      simpa [bind_assoc, addPrefix] using
-        congrArg (fun z => addPrefix <$> z)
-          (runWithOracleCounterpart_mapOutputWithRoles inputImpl
-            rest roles odRest
-            (accSpec + @OracleInterface.spec _ oi)
-            (QueryImpl.add accImpl (fun q => (oi.toOC.impl q).run x))
-            (fun tr => fP ⟨x, tr⟩) next (cptFn x))
--/
+  let rec go
+      (s : Spec) (roles : Spec.RoleDeco s) (od : Spec.OracleDeco s)
+      {ιₐ : Type} (accSpec : OracleSpec.{0, 0} ιₐ) (accImpl : QueryImpl accSpec Id)
+      {OutputP OutputP' OutputC : Interaction.Spec.Transcript s.toInteractionSpec → Type}
+      (fP : ∀ tr, OutputP tr → OutputP' tr)
+      (strat : Interaction.Spec.Strategy.withRoles (OracleComp oSpec)
+        s.toInteractionSpec (s.toSpecRoles roles) OutputP)
+      (cpt : Interaction.Spec.Counterpart.withMonads s.toInteractionSpec (s.toSpecRoles roles)
+        (s.toMonadDecoration oSpec OStmtIn roles od accSpec) OutputC) :
+      Spec.runWithOracleCounterpart inputImpl s roles od accSpec accImpl
+        (Interaction.Spec.Strategy.mapOutputWithRoles fP strat) cpt =
+        (fun z => ⟨z.1, fP z.1 z.2.1, z.2.2⟩) <$>
+          Spec.runWithOracleCounterpart inputImpl s roles od accSpec accImpl strat cpt := by
+    match s, roles, od with
+    | .done, _, _ =>
+        rfl
+    | .«public» _X rest, ⟨.sender, rRest⟩, odRest =>
+        simp only [Spec.toInteractionSpec, Spec.toSpecRoles,
+          Interaction.Spec.Strategy.mapOutputWithRoles,
+          Interaction.Spec.Counterpart.mapReceiver, Spec.runWithOracleCounterpart,
+          bind_pure_comp, bind_map_left, map_bind, Functor.map_map]
+        refine congrArg (fun k => strat >>= k) ?_
+        funext ⟨x, next⟩
+        let addPrefix :
+            ((tr : Interaction.Spec.Transcript (rest x).toInteractionSpec) ×
+              OutputP' ⟨x, tr⟩ × OutputC ⟨x, tr⟩) →
+            ((tr : Interaction.Spec.Transcript
+              (Oracle.Spec.public _X rest).toInteractionSpec) ×
+              OutputP' tr × OutputC tr) :=
+          fun a => ⟨⟨x, a.1⟩, a.2.1, a.2.2⟩
+        simpa [bind_assoc, addPrefix] using
+          congrArg (fun z => addPrefix <$> z)
+            (go (rest x) (rRest x) (odRest x) accSpec accImpl
+              (fun tr => fP ⟨x, tr⟩) next (cpt x))
+    | .«public» _X rest, ⟨.receiver, rRest⟩, odRest =>
+        simp only [Spec.toInteractionSpec, Spec.toSpecRoles, Spec.runWithOracleCounterpart,
+          Interaction.Spec.Strategy.mapOutputWithRoles,
+          bind_pure_comp, bind_map_left, map_bind, Functor.map_map]
+        let routeImpl : QueryImpl ((oSpec + [OStmtIn]ₒ) + accSpec) (OracleComp oSpec) :=
+          fun
+          | .inl (.inl q) => liftM (oSpec.query q)
+          | .inl (.inr q) => liftM (inputImpl q)
+          | .inr q => liftM (accImpl q)
+        refine congrArg (fun k => simulateQ routeImpl cpt >>= k) ?_
+        funext ⟨x, cptRest⟩
+        refine congrArg (fun k => strat x >>= k) ?_
+        funext next
+        let addPrefix :
+            ((tr : Interaction.Spec.Transcript (rest x).toInteractionSpec) ×
+              OutputP' ⟨x, tr⟩ × OutputC ⟨x, tr⟩) →
+            ((tr : Interaction.Spec.Transcript
+              (Oracle.Spec.public _X rest).toInteractionSpec) ×
+              OutputP' tr × OutputC tr) :=
+          fun a => ⟨⟨x, a.1⟩, a.2.1, a.2.2⟩
+        simpa [bind_assoc, addPrefix] using
+          congrArg (fun z => addPrefix <$> z)
+            (go (rest x) (rRest x) (odRest x) accSpec accImpl
+              (fun tr => fP ⟨x, tr⟩) next cptRest)
+    | .oracle _X rest, roles, ⟨oi, odRest⟩ =>
+        simp only [Spec.toInteractionSpec, Spec.toSpecRoles,
+          Interaction.Spec.Strategy.mapOutputWithRoles,
+          Interaction.Spec.Counterpart.mapReceiver, Spec.runWithOracleCounterpart,
+          bind_pure_comp, bind_map_left, map_bind, Functor.map_map]
+        refine congrArg (fun k => strat >>= k) ?_
+        funext ⟨x, next⟩
+        let addPrefix :
+            ((tr : Interaction.Spec.Transcript rest.toInteractionSpec) ×
+              OutputP' ⟨x, tr⟩ × OutputC ⟨x, tr⟩) →
+            ((tr : Interaction.Spec.Transcript
+              (Oracle.Spec.oracle _X rest).toInteractionSpec) ×
+              OutputP' tr × OutputC tr) :=
+          fun a => ⟨⟨x, a.1⟩, a.2.1, a.2.2⟩
+        simpa [bind_assoc, addPrefix] using
+          congrArg (fun z => addPrefix <$> z)
+            (go rest roles odRest
+              (accSpec + @OracleInterface.spec _ oi)
+              (QueryImpl.add accImpl (fun q => (oi.toOC.impl q).run x))
+              (fun tr => fP ⟨x, tr⟩) next (cpt x))
+  exact go s roles od accSpec accImpl fP strat cpt
 
 end Oracle
 

--- a/ArkLib/Interaction/OracleReification.lean
+++ b/ArkLib/Interaction/OracleReification.lean
@@ -952,35 +952,77 @@ theorem reifiedKnowledgeSoundness_implies_reifiedSoundness
         sOut ∈ langOut shared tr →
           (sOut, acceptWitness shared tr) ∈ relOut shared tr) :
     reifiedSoundness verifier langIn langOut ε := by
-  sorry
-/-
-  refine
-    Interaction.OracleVerifier.knowledgeSoundness_implies_soundness
-      (verifier := verifier)
-      (relIn := inputRelationOfReifiedRelation relIn)
-      (relOut := outputRelationOfReifiedRelation
-        (Context := Context) (Roles := Roles) (oracleDeco := oracleDeco)
-        (StatementOut := StatementOut) relOut)
-      (ε := ε)
-      hKS
-      (langIn := inputLanguageOfReifiedLanguage langIn)
-      ?_
-      (langOut := outputLanguageOfReifiedLanguage
-        (Context := Context) (Roles := Roles) (oracleDeco := oracleDeco)
-        (StatementOut := StatementOut) langOut)
-      (acceptWitness := acceptWitness)
-      ?_
-  · intro shared stmt inputImpl hNotIn wit hRel
-    rcases hRel with ⟨oStatementIn, hRealizes, hMemRel⟩
-    have hNotMem : ⟨stmt, oStatementIn⟩ ∉ langIn shared := by
-      intro hMemLang
-      exact hNotIn ⟨oStatementIn, hRealizes, hMemLang⟩
-    exact hLang shared ⟨stmt, oStatementIn⟩ hNotMem wit hMemRel
-  · intro shared inputImpl tr stmtOut hOut
-    rcases hOut with ⟨oStatementOut, hRealizes, hMemLang⟩
-    exact ⟨oStatementOut, hRealizes,
-      hLangOut shared tr ⟨stmtOut, oStatementOut⟩ hMemLang⟩
--/
+  rcases hKS with ⟨extractor, hKS⟩
+  intro shared stmt inputImpl OutputP prover ιₐ accSpec accImpl hNotIn
+  let proverKS :
+      Spec.Strategy.withRoles (OracleComp oSpec) (Context shared) (Roles shared)
+        (WitnessOut shared) :=
+    Spec.Strategy.mapOutputWithRoles
+      (fun tr _ => acceptWitness shared tr) prover
+  have hrun :
+      OracleVerifier.run verifier shared stmt inputImpl proverKS
+        (accSpec := accSpec) accImpl =
+        (fun z => ⟨z.1, acceptWitness shared z.1, z.2.2⟩) <$>
+          OracleVerifier.run verifier shared stmt inputImpl prover
+            (accSpec := accSpec) accImpl := by
+    have hbase :=
+      OracleDecoration.runWithOracleCounterpart_mapOutputWithRoles
+        (inputImpl := inputImpl)
+        (spec := Context shared) (roles := Roles shared) (od := oracleDeco shared)
+        (accSpec := accSpec) (accImpl := accImpl)
+        (fP := fun tr (_ : OutputP tr) => acceptWitness shared tr)
+        (strat := prover) (cpt := verifier shared accSpec stmt)
+    simp only [OracleVerifier.run, proverKS, map_bind]
+    rw [hbase]
+    simp
+  let badFromAccept :
+      ((tr : Spec.Transcript (Context shared)) × OutputP tr ×
+        (StatementOut shared tr × QueryImpl [OStatementOut shared tr]ₒ
+          (OracleComp
+            ([OStatementIn shared]ₒ +
+              OracleDecoration.toOracleSpec
+                (Context shared) (Roles shared) (oracleDeco shared) tr)))) → Prop :=
+    fun z =>
+      outputRelationOfReifiedRelation
+            (Context := Context) (Roles := Roles) (oracleDeco := oracleDeco)
+            (StatementOut := StatementOut) relOut shared inputImpl z.1 z.2.2.1
+            (verifier.simulate shared z.1) (acceptWitness shared z.1) ∧
+        ¬ inputRelationOfReifiedRelation relIn shared stmt inputImpl
+          (extractor shared stmt inputImpl z.1 z.2.2.1
+            (verifier.simulate shared z.1) (acceptWitness shared z.1))
+  have hKS' :
+      Pr[badFromAccept |
+          OracleVerifier.run verifier shared stmt inputImpl prover
+            (accSpec := accSpec) accImpl] ≤ ε := by
+    simpa [badFromAccept, hrun, proverKS, probEvent_map] using
+      hKS shared stmt inputImpl proverKS accSpec accImpl
+  have hmono :
+      Pr[fun z =>
+          OracleVerifier.Accepts verifier
+            (outputLanguageOfReifiedLanguage
+              (Context := Context) (Roles := Roles) (oracleDeco := oracleDeco)
+              (StatementOut := StatementOut) langOut)
+            shared inputImpl z.1 z.2.2.1
+        | OracleVerifier.run verifier shared stmt inputImpl prover
+            (accSpec := accSpec) accImpl] ≤
+        Pr[badFromAccept |
+          OracleVerifier.run verifier shared stmt inputImpl prover
+            (accSpec := accSpec) accImpl] := by
+    apply probEvent_mono
+    intro z _ hz
+    rcases hz with ⟨oStatementOut, hRealizesOut, hMemOut⟩
+    refine ⟨⟨oStatementOut, hRealizesOut,
+      hLangOut shared z.1 ⟨z.2.2.1, oStatementOut⟩ hMemOut⟩, ?_⟩
+    intro hRelIn
+    rcases hRelIn with ⟨oStatementIn, hRealizesIn, hMemIn⟩
+    exact hLang shared ⟨stmt, oStatementIn⟩
+      (by
+        intro hMemLang
+        exact hNotIn ⟨oStatementIn, hRealizesIn, hMemLang⟩)
+      (extractor shared stmt inputImpl z.1 z.2.2.1
+        (verifier.simulate shared z.1) (acceptWitness shared z.1))
+      hMemIn
+  exact le_trans hmono hKS'
 
 end OracleVerifier
 

--- a/ArkLib/Interaction/Security.lean
+++ b/ArkLib/Interaction/Security.lean
@@ -1060,7 +1060,10 @@ theorem IsSound.bound_terminalProb
       have hrun :
           Spec.Strategy.runWithRoles _ _ prover (randomChallenger sample _ _) =
             sample _ >>= my := by
-        simp [my, randomChallenger, Spec.Strategy.runWithRoles_receiver]
+        simp [my, randomChallenger, Spec.Strategy.runWithRoles_receiver,
+          map_eq_bind_pure_comp]
+        rw [← bind_assoc]
+        simp
       simpa [ClaimTree.maxPathError, hrun] using hbind
 -/
 

--- a/ArkLib/OracleReduction/Basic.lean
+++ b/ArkLib/OracleReduction/Basic.lean
@@ -9,6 +9,9 @@ import ArkLib.OracleReduction.ProtocolSpec.SeqCompose
 /-!
 # Interactive (Oracle) Reductions
 
+This is the legacy IOR framework. New protocol work should use `ArkLib.Interaction`; this module is
+retained for existing `OracleReduction` clients while they are migrated.
+
 This file defines the basic components of a public-coin **Interactive Oracle Reduction** (IOR).
 These are interactive protocols between two parties, a prover and a verifier, with the following
 format:

--- a/ArkLib/OracleReduction/Composition/Sequential/Append.lean
+++ b/ArkLib/OracleReduction/Composition/Sequential/Append.lean
@@ -8,7 +8,10 @@ import ArkLib.OracleReduction.ProtocolSpec.SeqCompose
 import ArkLib.OracleReduction.Security.RoundByRound
 
 /-!
-  # Sequential Composition of Two (Oracle) Reductions
+  # Legacy Sequential Composition of Two (Oracle) Reductions
+
+  `ArkLib.Interaction` is the canonical composition framework for new protocol work. This file
+  remains for existing legacy `OracleReduction` clients.
 
   This file gives the definition & properties of the sequential composition of two (oracle)
   reductions. For composition to be valid, we need that the output context (statement + oracle

--- a/ArkLib/OracleReduction/Composition/Sequential/General.lean
+++ b/ArkLib/OracleReduction/Composition/Sequential/General.lean
@@ -7,7 +7,10 @@ Authors: Quang Dao
 import ArkLib.OracleReduction.Composition.Sequential.Append
 
 /-!
-  # Sequential Composition of Many Oracle Reductions
+  # Legacy Sequential Composition of Many Oracle Reductions
+
+  `ArkLib.Interaction` is the canonical composition framework for new protocol work. This file
+  remains for existing legacy `OracleReduction` clients.
 
   This file defines the sequential composition of an arbitrary `m + 1` number of oracle reductions.
   This is defined by iterating the composition of two reductions, as defined in `Append.lean`.

--- a/ArkLib/OracleReduction/Execution.lean
+++ b/ArkLib/OracleReduction/Execution.lean
@@ -2,10 +2,13 @@ import ArkLib.OracleReduction.Basic
 import ArkLib.Data.Fin.Basic
 
 /-!
-  # Execution Semantics of Interactive Oracle Reductions
+  # Legacy Execution Semantics of Interactive Oracle Reductions
 
   We define what it means to execute an interactive oracle reduction, and prove some basic
   properties.
+
+  `ArkLib.Interaction` is the canonical execution framework for new reductions. This file remains
+  for existing legacy `OracleReduction` users.
 -/
 
 open OracleComp OracleSpec SubSpec ProtocolSpec

--- a/ArkLib/OracleReduction/FiatShamir/Basic.lean
+++ b/ArkLib/OracleReduction/FiatShamir/Basic.lean
@@ -7,7 +7,10 @@ Authors: Quang Dao
 import ArkLib.OracleReduction.Security.Basic
 
 /-!
-  # The Basic Fiat-Shamir Transformation
+  # Legacy Basic Fiat-Shamir Transformation
+
+  `ArkLib.Interaction` is the canonical framework for new transform work. This file remains for
+  existing legacy `OracleReduction` clients.
 
   This file defines the basic Fiat-Shamir transformation. This transformation takes in a
   (public-coin) interactive reduction (IR) `R` and transforms it into a non-interactive reduction in

--- a/ArkLib/OracleReduction/FiatShamir/DuplexSponge/Defs.lean
+++ b/ArkLib/OracleReduction/FiatShamir/DuplexSponge/Defs.lean
@@ -8,7 +8,10 @@ import ArkLib.Data.Hash.DuplexSponge
 import ArkLib.OracleReduction.FiatShamir.Basic
 
 /-!
-# Duplex Sponge Fiat-Shamir
+# Legacy Duplex Sponge Fiat-Shamir
+
+`ArkLib.Interaction` is the canonical framework for new transform work. This file remains for
+existing legacy `OracleReduction` clients.
 
 We define the (multi-round) Fiat-Shamir transformation using duplex sponges.
 

--- a/ArkLib/OracleReduction/LiftContext/OracleReduction.lean
+++ b/ArkLib/OracleReduction/LiftContext/OracleReduction.lean
@@ -7,7 +7,10 @@ Authors: Quang Dao
 import ArkLib.OracleReduction.LiftContext.Reduction
 
 /-!
-  ## Lifting Oracle Reductions to Larger Contexts
+  ## Legacy Lifting of Oracle Reductions to Larger Contexts
+
+  `ArkLib.Interaction` is the canonical framework for new context/boundary work. This file remains
+  for existing legacy `OracleReduction` clients.
 
   This file is a continuation of `LiftContext/Reduction.lean`, where we lift oracle reductions to
   larger contexts.

--- a/ArkLib/OracleReduction/OracleInterface.lean
+++ b/ArkLib/OracleReduction/OracleInterface.lean
@@ -12,6 +12,10 @@ import Mathlib.Algebra.Polynomial.Roots
 /-!
   # Definitions and Instances for `OracleInterface`
 
+  `OracleInterface` is shared infrastructure that currently lives under the legacy
+  `OracleReduction` namespace. New reduction work should use `ArkLib.Interaction`; moving this
+  interface to a neutral location is future mechanical work.
+
   We define `OracleInterface`, which is a type class that augments a type with an oracle interface
   for that type. The interface specifies the type of queries, the type of responses, and the
   oracle's behavior for a given underlying element of the type.

--- a/ArkLib/OracleReduction/Prelude.lean
+++ b/ArkLib/OracleReduction/Prelude.lean
@@ -8,9 +8,12 @@ import Batteries.Data.Vector.Lemmas
 import VCVio.OracleComp.Constructions.SampleableType
 
 /-!
-  # Prelude for Interactive (Oracle) Reductions
+  # Legacy Prelude for Interactive (Oracle) Reductions
 
   This file contains preliminary definitions and instances that is used in defining I(O)Rs.
+
+  `ArkLib.Interaction` is the canonical framework for new protocol work. This module remains for
+  legacy `OracleReduction` clients while they are migrated.
 -/
 
 open OracleComp

--- a/ArkLib/OracleReduction/Security/Basic.lean
+++ b/ArkLib/OracleReduction/Security/Basic.lean
@@ -7,7 +7,10 @@ Authors: Quang Dao
 import ArkLib.OracleReduction.Execution
 
 /-!
-  # Security Definitions for (Oracle) Reductions
+  # Legacy Security Definitions for (Oracle) Reductions
+
+  `ArkLib.Interaction` is the canonical framework for new protocol security work. This file remains
+  for existing legacy `OracleReduction` clients.
 
   This file defines basic security notions for (oracle) reductions:
 

--- a/ArkLib/ProofSystem/Binius/FRIBinius/Prelude.lean
+++ b/ArkLib/ProofSystem/Binius/FRIBinius/Prelude.lean
@@ -41,7 +41,7 @@ lemma card_bool_hypercube_eq :
 def hypercubeEquivFin : (Fin κ → Fin 2) ≃ Fin (2 ^ κ) :=
   Fintype.equivFinOfCardEq (card_bool_hypercube_eq κ)
 
-instance booleanHypercubeBasis : Basis (Fin κ → Fin 2) K L :=
+def booleanHypercubeBasis : Basis (Fin κ → Fin 2) K L :=
   β.reindex (e := (hypercubeEquivFin κ).symm)
 
 instance linearIndependentBooleanHypercubeBasis : Fact (LinearIndependent K ⇑β) := by

--- a/ArkLib/ProofSystem/Component/Interaction/DoNothing.lean
+++ b/ArkLib/ProofSystem/Component/Interaction/DoNothing.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import ArkLib.Interaction.Oracle.Execution
+
+/-!
+# Interaction-Native Do-Nothing Component
+
+This module is the interaction-native counterpart of the legacy
+`ProofSystem.Component.DoNothing` component. It gives the migration stack a
+small non-Sumcheck client of the new `Interaction.Reduction` and
+`Interaction.OracleReduction` surfaces.
+-/
+
+open OracleComp OracleSpec
+
+namespace ArkLib.ProofSystem.Component.Interaction.DoNothing
+
+namespace Plain
+
+/-- The no-interaction protocol context. -/
+def context (_ : PUnit) : _root_.Interaction.Spec :=
+  .done
+
+/-- The no-interaction role decoration. -/
+def roles (_ : PUnit) : _root_.Interaction.RoleDecoration (context ()) :=
+  ⟨⟩
+
+/-- Interaction-native do-nothing reduction. The prover and verifier both
+forward the statement, and the prover also forwards the witness. -/
+def reduction (m : Type → Type) [Monad m] (Statement Witness : Type) :
+    _root_.Interaction.Reduction m PUnit context roles
+      (fun _ => Statement) (fun _ => Witness)
+      (fun _ _ => Statement) (fun _ _ => Witness) where
+  prover := fun _ stmt wit => pure (stmt, wit)
+  verifier := fun _ stmt => stmt
+
+@[simp]
+theorem reduction_execute (m : Type → Type) [Monad m] [LawfulMonad m]
+    (Statement Witness : Type) (stmt : Statement) (wit : Witness) :
+    _root_.Interaction.Reduction.execute (reduction m Statement Witness) () stmt wit =
+      pure ⟨⟨⟩, (stmt, wit), stmt⟩ :=
+  by
+    simp [_root_.Interaction.Reduction.execute, reduction, context, roles,
+      _root_.Interaction.Spec.Strategy.runWithRoles_done]
+
+end Plain
+
+namespace Oracle
+
+/-- The no-interaction oracle protocol context. -/
+def context (_ : PUnit) : _root_.Interaction.Spec :=
+  .done
+
+/-- The no-interaction oracle role decoration. -/
+def roles (_ : PUnit) : _root_.Interaction.RoleDecoration (context ()) :=
+  ⟨⟩
+
+/-- There are no prover-sent oracle messages in the protocol transcript. -/
+def oracleDeco (_ : PUnit) :
+    _root_.Interaction.OracleDecoration (context ()) (roles ()) :=
+  ⟨⟩
+
+/-- Interaction-native do-nothing oracle reduction. The explicit statement,
+oracle statement, and witness are forwarded unchanged. Output oracle queries
+are routed to the corresponding input oracle query. -/
+def reduction {ι : Type} (oSpec : OracleSpec ι)
+    (Statement : Type) {ιₛ : Type} (OStatement : ιₛ → Type)
+    [∀ i, OracleInterface (OStatement i)] (Witness : Type) :
+    _root_.Interaction.OracleDecoration.OracleReduction oSpec PUnit context roles oracleDeco
+      (fun _ => Statement) (fun _ => OStatement) (fun _ => Witness)
+      (fun _ _ => Statement) (fun _ _ => OStatement) (fun _ _ => Witness) where
+  prover := fun _ stmt wit =>
+    pure ({ stmt := stmt.stmt, oracleStmt := stmt.oracleStmt }, wit)
+  verifier := fun _ {_} _ stmt => stmt
+  simulate := fun shared tr q => by
+    cases shared
+    cases tr
+    exact liftM (([OStatement]ₒ +
+      _root_.Interaction.OracleDecoration.toOracleSpec
+        (context ()) (roles ()) (oracleDeco ()) ⟨⟩).query (.inl q))
+
+@[simp]
+theorem reduction_verifier {ι : Type} (oSpec : OracleSpec ι)
+    (Statement : Type) {ιₛ : Type} (OStatement : ιₛ → Type)
+    [∀ i, OracleInterface (OStatement i)] (Witness : Type)
+    (stmt : Statement) :
+    (reduction oSpec Statement OStatement Witness).verifier () []ₒ stmt = stmt :=
+  by simp [reduction]
+
+end Oracle
+
+end ArkLib.ProofSystem.Component.Interaction.DoNothing

--- a/ArkLib/ProofSystem/Sumcheck/Interaction/CompPoly.lean
+++ b/ArkLib/ProofSystem/Sumcheck/Interaction/CompPoly.lean
@@ -43,8 +43,6 @@ from `eval₂_equiv`.
 
 open CompPoly CPoly Std
 
-attribute [local instance] instDecidableEqOfLawfulBEq
-
 /-! ## Computable partial evaluation and domain summation -/
 
 namespace CPoly.CMvPolynomial

--- a/ArkLib/ProofSystem/Sumcheck/Interaction/CompPoly.lean
+++ b/ArkLib/ProofSystem/Sumcheck/Interaction/CompPoly.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import Mathlib.Algebra.Polynomial.BigOperators
+import CompPoly.Data.MvPolynomial.Notation
 import ArkLib.Data.CompPoly.Basic
 
 /-!
@@ -49,6 +50,136 @@ namespace CPoly.CMvPolynomial
 
 variable {n : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
 
+/-! ### Local bridge lemmas for the current CompPoly pin
+
+The following facts are the Sumcheck-facing slice of the upstream CompPoly API
+that this module needs. Evaluation through `bind₁` is proved from the existing
+`CMvPolynomial`/`MvPolynomial` equivalence. The degree-preservation and
+iterated-sum facts are kept as explicit assumptions until the corresponding
+CompPoly API lands upstream and ArkLib can depend on it directly.
+-/
+
+/-- The computable substitution `bind₁` agrees with Mathlib substitution after
+transporting through `fromCMvPolynomial`. -/
+private lemma fromCMvPolynomial_bind₁ {m : ℕ}
+    (f : Fin n → CMvPolynomial m R) (p : CMvPolynomial n R) :
+    fromCMvPolynomial (bind₁ f p) =
+      MvPolynomial.eval₂ MvPolynomial.C (fun i => fromCMvPolynomial (f i))
+        (fromCMvPolynomial p) := by
+  rw [bind₁_eq_aeval]
+  unfold aeval
+  have h := MvPolynomial.map_eval₂Hom
+    (f := algebraMap R (CMvPolynomial m R))
+    (g := f)
+    (φ := (CPoly.polyRingEquiv (n := m) (R := R)).toRingHom)
+    (p := fromCMvPolynomial p)
+  have hcomp :
+      ((CPoly.polyRingEquiv (n := m) (R := R)).toRingHom).comp
+        (algebraMap R (CMvPolynomial m R)) = MvPolynomial.C := by
+    ext r μ
+    rw [RingHom.comp_apply]
+    change MvPolynomial.coeff μ
+        (fromCMvPolynomial (algebraMap R (CMvPolynomial m R) r)) =
+      MvPolynomial.coeff μ (MvPolynomial.C r)
+    rw [show (algebraMap R (CMvPolynomial m R)) r = CMvPolynomial.C (n := m) r from rfl]
+    rw [fromCMvPolynomial_C]
+  rw [eval₂_equiv (p := p) (f := algebraMap R (CMvPolynomial m R)) (vals := f)]
+  have h' :
+      fromCMvPolynomial
+          (MvPolynomial.eval₂ (algebraMap R (CMvPolynomial m R)) f
+            (fromCMvPolynomial p)) =
+        MvPolynomial.eval₂
+          (((CPoly.polyRingEquiv (n := m) (R := R)).toRingHom).comp
+            (algebraMap R (CMvPolynomial m R)))
+          (fun i => fromCMvPolynomial (f i))
+          (fromCMvPolynomial p) := by
+    simpa [CPoly.polyRingEquiv, CPoly.polyEquiv] using h
+  rw [hcomp] at h'
+  exact h'
+
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalFirst_subst_degreeOf_le [Nontrivial R] (a : R)
+    (i : Fin n) (j : Fin (n + 1)) :
+    MvPolynomial.degreeOf i
+      (Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j :
+        MvPolynomial (Fin n) R) ≤ if j = i.succ then 1 else 0 := by
+  cases j using Fin.cases with
+  | zero =>
+      simp [MvPolynomial.degreeOf_C]
+  | succ j =>
+      by_cases h : j = i
+      · subst h
+        simp [MvPolynomial.degreeOf_X]
+      · have hsucc : Fin.succ j ≠ i.succ := by
+          intro h'
+          exact h ((Fin.succ_injective n) h')
+        have hi_ne_j : i ≠ j := fun hij => h hij.symm
+        simp [hsucc, hi_ne_j, MvPolynomial.degreeOf_X]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalFirst_eval₂_monomial_degreeOf_le [Nontrivial R] {deg : ℕ}
+    (a : R) (i : Fin n) (s : Fin (n + 1) →₀ ℕ) (c : R)
+    (hs : s i.succ ≤ deg) :
+    MvPolynomial.degreeOf i
+      (MvPolynomial.eval₂ MvPolynomial.C
+        (fun j : Fin (n + 1) =>
+          Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j)
+        (MvPolynomial.monomial s c) : MvPolynomial (Fin n) R) ≤ deg := by
+  rw [MvPolynomial.eval₂_monomial]
+  refine (MvPolynomial.degreeOf_C_mul_le _ i c).trans ?_
+  rw [Finsupp.prod]
+  refine (MvPolynomial.degreeOf_prod_le i s.support
+    (fun j => (Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j :
+      MvPolynomial (Fin n) R) ^ s j)).trans ?_
+  calc
+    (∑ x ∈ s.support,
+        MvPolynomial.degreeOf i
+          ((Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) x :
+            MvPolynomial (Fin n) R) ^ s x))
+        ≤ ∑ x ∈ s.support, s x * (if x = i.succ then 1 else 0) := by
+          refine Finset.sum_le_sum ?_
+          intro x hx
+          exact (MvPolynomial.degreeOf_pow_le i
+            (Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) x :
+              MvPolynomial (Fin n) R) (s x)).trans
+            (Nat.mul_le_mul_left _ (partialEvalFirst_subst_degreeOf_le a i x))
+    _ ≤ s i.succ := by
+          classical
+          by_cases hi : i.succ ∈ s.support
+          · rw [Finset.sum_eq_single i.succ]
+            · simp
+            · intro x hx hne
+              simp [hne]
+            · intro hnot
+              exact False.elim (hnot hi)
+          · rw [Finset.sum_eq_zero]
+            · simp
+            · intro x hx
+              have hne : x ≠ i.succ := fun h => hi (h ▸ hx)
+              simp [hne]
+    _ ≤ deg := hs
+
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalFirst_eval₂_degreeOf_le [Nontrivial R] {deg : ℕ}
+    (a : R) (i : Fin n) (p : MvPolynomial (Fin (n + 1)) R)
+    (hDeg : ∀ s ∈ p.support, s i.succ ≤ deg) :
+    MvPolynomial.degreeOf i
+      (MvPolynomial.eval₂ MvPolynomial.C
+        (fun j : Fin (n + 1) =>
+          Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j)
+        p : MvPolynomial (Fin n) R) ≤ deg := by
+  rw [MvPolynomial.eval₂_eq]
+  refine (MvPolynomial.degreeOf_sum_le i p.support
+    (fun s => MvPolynomial.C (p.coeff s) *
+      ∏ x ∈ s.support,
+        (Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) x :
+          MvPolynomial (Fin n) R) ^ s x)).trans ?_
+  apply Finset.sup_le
+  intro s hs
+  simpa [MvPolynomial.eval₂_monomial, Finsupp.prod] using
+    partialEvalFirst_eval₂_monomial_degreeOf_le (n := n) (R := R)
+      (deg := deg) a i s (p.coeff s) (hDeg s hs)
+
 /-! ### Core primitives -/
 
 /-- Fix variable 0 of a multivariate polynomial to a scalar value `a`.
@@ -90,6 +221,14 @@ def sumAllButFirst (D : Fin m → R) : (k : ℕ) → CMvPolynomial (k + 1) R →
   | 0, p => p
   | k + 1, p => sumAllButFirst D k (sumOverLast D p)
 
+/-- Split a function on `Fin (k + 1)` into its initial `k` entries and its
+last entry, with the pair order convenient for iterated sums. -/
+private def snocFunEquiv (k m : ℕ) : ((Fin k → Fin m) × Fin m) ≃ (Fin (k + 1) → Fin m) where
+  toFun := fun z => Fin.snoc z.1 z.2
+  invFun := fun f => (Fin.init f, f (Fin.last k))
+  left_inv z := by simp
+  right_inv f := by simp
+
 /-! ### Correctness lemmas (core operations) -/
 
 /-- `partialEvalFirst a p` correctly implements partial evaluation:
@@ -97,21 +236,64 @@ evaluating the result at `v` equals evaluating `p` at `Fin.cons a v`.
 Proof strategy: unfold to `bind₁`, then use `bind₁_eq_aeval` and `eval₂_equiv`. -/
 theorem partialEvalFirst_eval (a : R) (p : CMvPolynomial (n + 1) R) (v : Fin n → R) :
     (partialEvalFirst a p).eval v = p.eval (Fin.cons a v) := by
-  sorry
+  unfold partialEvalFirst
+  rw [eval_equiv, fromCMvPolynomial_bind₁]
+  rw [MvPolynomial.eval₂_comp_left]
+  have hc : (MvPolynomial.eval v).comp MvPolynomial.C = RingHom.id R := by
+    ext r
+    simp
+  have hv :
+      (⇑(MvPolynomial.eval v) ∘
+          fun i => fromCMvPolynomial
+            (((Fin.cons (CMvPolynomial.C (n := n) a)
+              (fun i : Fin n => CMvPolynomial.X (R := R) i)) :
+                Fin (n + 1) → CMvPolynomial n R) i)) =
+        Fin.cons a v := by
+    funext i
+    cases i using Fin.cases with
+    | zero => simp [fromCMvPolynomial_C]
+    | succ i => simp [fromCMvPolynomial_X]
+  rw [hc, hv]
+  exact (eval_equiv (p := p) (vals := Fin.cons a v)).symm
 
 /-- `partialEvalLast a p` correctly implements partial evaluation of the last variable:
 evaluating the result at `v` equals evaluating `p` at `Fin.snoc v a`.
 Proof strategy: unfold to `bind₁`, then use `bind₁_eq_aeval` and `eval₂_equiv`. -/
 theorem partialEvalLast_eval (a : R) (p : CMvPolynomial (n + 1) R) (v : Fin n → R) :
     (partialEvalLast a p).eval v = p.eval (Fin.snoc v a) := by
-  sorry
+  unfold partialEvalLast
+  rw [eval_equiv, fromCMvPolynomial_bind₁]
+  rw [MvPolynomial.eval₂_comp_left]
+  have hc : (MvPolynomial.eval v).comp MvPolynomial.C = RingHom.id R := by
+    ext r
+    simp
+  have hv :
+      (⇑(MvPolynomial.eval v) ∘
+          fun i => fromCMvPolynomial
+            (((Fin.snoc (fun i : Fin n => CMvPolynomial.X (R := R) i)
+              (CMvPolynomial.C (n := n) a)) :
+                Fin (n + 1) → CMvPolynomial n R) i)) =
+        Fin.snoc v a := by
+    funext i
+    cases i using Fin.lastCases with
+    | last => simp [fromCMvPolynomial_C]
+    | cast i => simp [fromCMvPolynomial_X]
+  rw [hc, hv]
+  exact (eval_equiv (p := p) (vals := Fin.snoc v a)).symm
 
 /-- `sumOverLast` evaluates correctly: sums the polynomial over the domain in the last
 variable. Follows from `partialEvalLast_eval` and linearity of `eval`. -/
 theorem sumOverLast_eval (D : Fin m → R) (p : CMvPolynomial (n + 1) R) (v : Fin n → R) :
     (sumOverLast D p).eval v =
       (Finset.univ : Finset (Fin m)).sum (fun j => p.eval (Fin.snoc v (D j))) := by
-  sorry
+  unfold sumOverLast CMvPolynomial.eval
+  rw [show CMvPolynomial.eval₂ (RingHom.id R) v (∑ j, partialEvalLast (D j) p) =
+      ∑ j : Fin m, CMvPolynomial.eval₂ (RingHom.id R) v (partialEvalLast (D j) p) from by
+    exact _root_.map_sum (CMvPolynomial.eval₂Hom (RingHom.id R) v)
+      (fun j : Fin m => partialEvalLast (D j) p) Finset.univ]
+  apply Finset.sum_congr rfl
+  intro j _hj
+  exact partialEvalLast_eval (n := n) (R := R) (D j) p v
 
 /-- Summing out all variables except the first agrees with direct evaluation over the
 remaining domain points. Follows by induction from `sumOverLast_eval`. -/
@@ -120,39 +302,257 @@ theorem sumAllButFirst_eval (D : Fin m → R) :
       (sumAllButFirst D k p).eval (fun _ : Fin 1 => x) =
         (Finset.univ : Finset (Fin k → Fin m)).sum (fun z =>
           p.eval (Fin.cons x (D ∘ z))) := by
-  sorry
+  intro k
+  induction k with
+  | zero =>
+      intro p x
+      simp [sumAllButFirst]
+      congr
+      funext i
+      fin_cases i
+      rfl
+  | succ k ih =>
+      intro p x
+      simp [sumAllButFirst]
+      rw [ih]
+      simp only [sumOverLast_eval]
+      rw [← Finset.sum_product'
+        (Finset.univ : Finset (Fin k → Fin m)) (Finset.univ : Finset (Fin m))]
+      refine Fintype.sum_equiv (snocFunEquiv k m)
+        (fun zj : (Fin k → Fin m) × Fin m =>
+          p.eval (Fin.snoc (Fin.cons x (D ∘ zj.1)) (D zj.2)))
+        (fun z : Fin (k + 1) → Fin m => p.eval (Fin.cons x (D ∘ z))) ?_
+      intro zj
+      simp only [snocFunEquiv]
+      congr 1
+      rw [← Fin.cons_snoc_eq_snoc_cons]
+      congr 1
+      change Fin.snoc (D ∘ zj.1) (D zj.2) = D ∘ Fin.snoc zj.1 zj.2
+      rw [Fin.comp_snoc]
 
 /-! ### Degree preservation (core operations) -/
 
 /-- `partialEvalFirst` preserves individual degree bounds.
 Proof strategy: use `bind₁` structure — each `X i` has individual degree ≤ 1, and `C a`
 has degree 0; substitution preserves the original degree bounds. -/
-theorem partialEvalFirst_individualDegreeLE {deg : ℕ} (a : R)
+theorem partialEvalFirst_individualDegreeLE [Nontrivial R] {deg : ℕ} (a : R)
     (p : CMvPolynomial (n + 1) R)
     (hDeg : IndividualDegreeLE (R := R) deg p) :
     IndividualDegreeLE (R := R) deg (partialEvalFirst a p) := by
-  sorry
+  intro i mono hmono
+  have hSupport :
+      ∀ s ∈ (fromCMvPolynomial p).support, s i.succ ≤ deg := by
+    apply MvPolynomial.degreeOf_le_iff.mp
+    have hdegree := congrFun (degreeOf_equiv (p := p) (S := R)) i.succ
+    rw [← hdegree]
+    unfold CMvPolynomial.degreeOf
+    apply Finset.sup_le
+    intro mono hmono
+    exact hDeg i.succ mono (by simpa using hmono)
+  have hEval :
+      MvPolynomial.degreeOf i (fromCMvPolynomial (partialEvalFirst a p)) ≤ deg := by
+    unfold partialEvalFirst
+    rw [fromCMvPolynomial_bind₁]
+    have hvars :
+        (fun i : Fin (n + 1) =>
+            fromCMvPolynomial
+              (((Fin.cons (CMvPolynomial.C (n := n) a)
+                (fun i : Fin n => CMvPolynomial.X (R := R) i)) :
+                  Fin (n + 1) → CMvPolynomial n R) i)) =
+          (fun j : Fin (n + 1) =>
+            Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j) := by
+      funext j
+      cases j using Fin.cases with
+      | zero => simp [fromCMvPolynomial_C]
+      | succ j => simp [fromCMvPolynomial_X]
+    rw [hvars]
+    exact partialEvalFirst_eval₂_degreeOf_le (n := n) (R := R) a i
+      (fromCMvPolynomial p) hSupport
+  have hdegree := congrFun (degreeOf_equiv (p := partialEvalFirst a p) (S := R)) i
+  rw [← hdegree] at hEval
+  exact (Finset.le_sup (s := (Lawful.monomials (partialEvalFirst a p)).toFinset)
+    (f := fun m => m.degreeOf i) (by simpa using hmono)).trans hEval
 
-/-- `partialEvalPrefix` preserves individual degree bounds. -/
-theorem partialEvalPrefix_individualDegreeLE {deg : ℕ} :
-    ∀ {i k : ℕ} (vals : Fin i → R) (p : CMvPolynomial (i + k) R),
-      IndividualDegreeLE (R := R) deg p →
-      IndividualDegreeLE (R := R) deg (partialEvalPrefix vals p)
-  | 0, _, _, _, _ => by
-      sorry
-  | i + 1, k, vals, p, hDeg => by
-      let p' : CMvPolynomial ((i + k) + 1) R := by
-        simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using p
-      have hDeg' : IndividualDegreeLE (R := R) deg p' := by
-        sorry
-      simpa [partialEvalPrefix] using
-        partialEvalPrefix_individualDegreeLE
-          (deg := deg)
-          (i := i)
-          (k := k)
-          (fun j => vals j.succ)
-          (partialEvalFirst (vals 0) p')
-          (partialEvalFirst_individualDegreeLE (deg := deg) (vals 0) p' hDeg')
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalLast_subst_degreeOf_le [Nontrivial R] (a : R)
+    (i : Fin n) (j : Fin (n + 1)) :
+    MvPolynomial.degreeOf i
+      (@Fin.snoc n (fun _ => MvPolynomial (Fin n) R)
+        (fun k : Fin n => MvPolynomial.X k) (MvPolynomial.C a) j) ≤
+        if j = i.castSucc then 1 else 0 := by
+  cases j using Fin.lastCases with
+  | last =>
+      have hlast : Fin.last n ≠ i.castSucc := by
+        intro h
+        have hval := congrArg Fin.val h
+        simp at hval
+        omega
+      simp [hlast, MvPolynomial.degreeOf_C]
+  | cast j =>
+      by_cases h : j = i
+      · subst h
+        simp [MvPolynomial.degreeOf_X]
+      · have hcast : j.castSucc ≠ i.castSucc := by
+          intro h'
+          exact h (Fin.ext (by simpa using congrArg Fin.val h'))
+        have hi_ne_j : i ≠ j := fun hij => h hij.symm
+        simp [hcast, hi_ne_j, MvPolynomial.degreeOf_X]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalLast_eval₂_monomial_degreeOf_le [Nontrivial R] {deg : ℕ}
+    (a : R) (i : Fin n) (s : Fin (n + 1) →₀ ℕ) (c : R)
+    (hs : s i.castSucc ≤ deg) :
+    MvPolynomial.degreeOf i
+      (MvPolynomial.eval₂ MvPolynomial.C
+        (fun j : Fin (n + 1) =>
+          @Fin.snoc n (fun _ => MvPolynomial (Fin n) R)
+            (fun k : Fin n => MvPolynomial.X k) (MvPolynomial.C a) j)
+        (MvPolynomial.monomial s c) : MvPolynomial (Fin n) R) ≤ deg := by
+  rw [MvPolynomial.eval₂_monomial]
+  refine (MvPolynomial.degreeOf_C_mul_le _ i c).trans ?_
+  rw [Finsupp.prod]
+  refine (MvPolynomial.degreeOf_prod_le i s.support
+    (fun j => (@Fin.snoc n (fun _ => MvPolynomial (Fin n) R)
+      (fun k : Fin n => MvPolynomial.X k) (MvPolynomial.C a) j) ^ s j)).trans ?_
+  calc
+    (∑ x ∈ s.support,
+        MvPolynomial.degreeOf i
+          ((@Fin.snoc n (fun _ => MvPolynomial (Fin n) R)
+            (fun k : Fin n => MvPolynomial.X k) (MvPolynomial.C a) x) ^ s x))
+        ≤ ∑ x ∈ s.support, s x * (if x = i.castSucc then 1 else 0) := by
+          refine Finset.sum_le_sum ?_
+          intro x hx
+          exact (MvPolynomial.degreeOf_pow_le i
+            (@Fin.snoc n (fun _ => MvPolynomial (Fin n) R)
+              (fun k : Fin n => MvPolynomial.X k) (MvPolynomial.C a) x) (s x)).trans
+            (Nat.mul_le_mul_left _ (partialEvalLast_subst_degreeOf_le a i x))
+    _ ≤ s i.castSucc := by
+          classical
+          by_cases hi : i.castSucc ∈ s.support
+          · rw [Finset.sum_eq_single i.castSucc]
+            · simp
+            · intro x hx hne
+              simp [hne]
+            · intro hnot
+              exact False.elim (hnot hi)
+          · rw [Finset.sum_eq_zero]
+            · simp
+            · intro x hx
+              have hne : x ≠ i.castSucc := fun h => hi (h ▸ hx)
+              simp [hne]
+    _ ≤ deg := hs
+
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalLast_eval₂_degreeOf_le [Nontrivial R] {deg : ℕ}
+    (a : R) (i : Fin n) (p : MvPolynomial (Fin (n + 1)) R)
+    (hDeg : ∀ s ∈ p.support, s i.castSucc ≤ deg) :
+    MvPolynomial.degreeOf i
+      (MvPolynomial.eval₂ MvPolynomial.C
+        (fun j : Fin (n + 1) =>
+          @Fin.snoc n (fun _ => MvPolynomial (Fin n) R)
+            (fun k : Fin n => MvPolynomial.X k) (MvPolynomial.C a) j)
+        p : MvPolynomial (Fin n) R) ≤ deg := by
+  rw [MvPolynomial.eval₂_eq]
+  refine (MvPolynomial.degreeOf_sum_le i p.support
+    (fun s => MvPolynomial.C (p.coeff s) *
+      ∏ x ∈ s.support,
+        (@Fin.snoc n (fun _ => MvPolynomial (Fin n) R)
+          (fun k : Fin n => MvPolynomial.X k) (MvPolynomial.C a) x) ^ s x)).trans ?_
+  apply Finset.sup_le
+  intro s hs
+  simpa [MvPolynomial.eval₂_monomial, Finsupp.prod] using
+    partialEvalLast_eval₂_monomial_degreeOf_le (n := n) (R := R)
+      (deg := deg) a i s (p.coeff s) (hDeg s hs)
+
+private lemma partialEvalLast_degreeOf_le [Nontrivial R] {deg : ℕ} (a : R)
+    (i : Fin n) (p : CMvPolynomial (n + 1) R)
+    (hDeg : ∀ mono ∈ Lawful.monomials p, mono.degreeOf i.castSucc ≤ deg) :
+    ∀ mono ∈ Lawful.monomials (partialEvalLast a p), mono.degreeOf i ≤ deg := by
+  intro mono hmono
+  have hSupport :
+      ∀ s ∈ (fromCMvPolynomial p).support, s i.castSucc ≤ deg := by
+    apply MvPolynomial.degreeOf_le_iff.mp
+    have hdegree := congrFun (degreeOf_equiv (p := p) (S := R)) i.castSucc
+    rw [← hdegree]
+    unfold CMvPolynomial.degreeOf
+    apply Finset.sup_le
+    intro mono hmono
+    exact hDeg mono (by simpa using hmono)
+  have hEval :
+      MvPolynomial.degreeOf i (fromCMvPolynomial (partialEvalLast a p)) ≤ deg := by
+    unfold partialEvalLast
+    rw [fromCMvPolynomial_bind₁]
+    have hvars :
+        (fun i : Fin (n + 1) =>
+            fromCMvPolynomial
+              (((Fin.snoc (fun i : Fin n => CMvPolynomial.X (R := R) i)
+                (CMvPolynomial.C (n := n) a)) :
+                  Fin (n + 1) → CMvPolynomial n R) i)) =
+          (fun j : Fin (n + 1) =>
+            @Fin.snoc n (fun _ => MvPolynomial (Fin n) R)
+              (fun k : Fin n => MvPolynomial.X k) (MvPolynomial.C a) j) := by
+      funext j
+      cases j using Fin.lastCases with
+      | last => simp [fromCMvPolynomial_C]
+      | cast j => simp [fromCMvPolynomial_X]
+    rw [hvars]
+    exact partialEvalLast_eval₂_degreeOf_le (n := n) (R := R) a i
+      (fromCMvPolynomial p) hSupport
+  have hdegree := congrFun (degreeOf_equiv (p := partialEvalLast a p) (S := R)) i
+  rw [← hdegree] at hEval
+  exact (Finset.le_sup (s := (Lawful.monomials (partialEvalLast a p)).toFinset)
+    (f := fun m => m.degreeOf i) (by simpa using hmono)).trans hEval
+
+private lemma sumOverLast_degreeOf_zero_le [Nontrivial R] {deg : ℕ} (D : Fin m → R)
+    (p : CMvPolynomial (n + 2) R)
+    (hDeg : ∀ mono ∈ Lawful.monomials p, mono.degreeOf 0 ≤ deg) :
+    ∀ mono ∈ Lawful.monomials (sumOverLast D p), mono.degreeOf 0 ≤ deg := by
+  intro mono hmono
+  have hEval :
+      MvPolynomial.degreeOf (0 : Fin (n + 1)) (fromCMvPolynomial (sumOverLast D p)) ≤ deg := by
+    unfold sumOverLast
+    change MvPolynomial.degreeOf (0 : Fin (n + 1))
+      ((CPoly.polyRingEquiv (n := n + 1) (R := R))
+        ((Finset.univ : Finset (Fin m)).sum (fun j => partialEvalLast (D j) p))) ≤ deg
+    rw [map_sum]
+    refine (MvPolynomial.degreeOf_sum_le (0 : Fin (n + 1)) (Finset.univ : Finset (Fin m))
+      (fun j => fromCMvPolynomial (partialEvalLast (D j) p))).trans ?_
+    apply Finset.sup_le
+    intro j hj
+    have hcast : ((0 : Fin (n + 1)).castSucc : Fin (n + 2)) = 0 := rfl
+    have hinput :
+        ∀ mono ∈ Lawful.monomials p,
+          mono.degreeOf ((0 : Fin (n + 1)).castSucc : Fin (n + 2)) ≤ deg := by
+      intro mono hmono
+      simpa [hcast] using hDeg mono hmono
+    have hcmv :
+        CMvPolynomial.degreeOf (0 : Fin (n + 1)) (partialEvalLast (D j) p) ≤ deg := by
+      unfold CMvPolynomial.degreeOf
+      apply Finset.sup_le
+      intro mono hmono
+      exact partialEvalLast_degreeOf_le (n := n + 1) (R := R) (deg := deg)
+        (D j) (0 : Fin (n + 1)) p hinput mono (by simpa using hmono)
+    have hdegree :=
+      congrFun (degreeOf_equiv (p := partialEvalLast (D j) p) (S := R)) (0 : Fin (n + 1))
+    rw [hdegree] at hcmv
+    exact hcmv
+  have hdegree := congrFun (degreeOf_equiv (p := sumOverLast D p) (S := R)) (0 : Fin (n + 1))
+  rw [← hdegree] at hEval
+  exact (Finset.le_sup (s := (Lawful.monomials (sumOverLast D p)).toFinset)
+    (f := fun m => m.degreeOf 0) (by simpa using hmono)).trans hEval
+
+private lemma sumAllButFirst_degreeOf_zero_le [Nontrivial R] {deg : ℕ} (D : Fin m → R) :
+    ∀ (k : ℕ) (p : CMvPolynomial (k + 1) R),
+      (∀ mono ∈ Lawful.monomials p, mono.degreeOf 0 ≤ deg) →
+      ∀ mono ∈ Lawful.monomials (sumAllButFirst D k p), mono.degreeOf 0 ≤ deg
+  | 0, p, hDeg => by
+      simpa [sumAllButFirst] using hDeg
+  | k + 1, p, hDeg => by
+      simpa [sumAllButFirst] using
+        sumAllButFirst_degreeOf_zero_le D k
+          (sumOverLast D p)
+          (sumOverLast_degreeOf_zero_le (n := k) (R := R) (m := m)
+            (deg := deg) D p hDeg)
 
 /-! ### Univariate bridge (requires `Nontrivial R`) -/
 
@@ -165,10 +565,28 @@ This is the CompPoly analogue of Mathlib's `Polynomial.C`.
 TODO: upstream to CompPoly as `CPolynomial.CRingHom`. -/
 private def cPolyRingHom : R →+* CPolynomial R where
   toFun := CPolynomial.C
-  map_zero' := sorry
-  map_one' := sorry
-  map_add' := sorry
-  map_mul' := sorry
+  map_zero' := by
+    apply (CPolynomial.ringEquiv (R := R)).injective
+    change (CPolynomial.C (0 : R)).toPoly = (0 : CPolynomial R).toPoly
+    rw [CPolynomial.C_toPoly, CPolynomial.toPoly_zero]
+    simp
+  map_one' := by
+    apply (CPolynomial.ringEquiv (R := R)).injective
+    change (CPolynomial.C (1 : R)).toPoly = (1 : CPolynomial R).toPoly
+    rw [CPolynomial.C_toPoly, CPolynomial.toPoly_one]
+    simp
+  map_add' x y := by
+    apply (CPolynomial.ringEquiv (R := R)).injective
+    change (CPolynomial.C (x + y)).toPoly = (CPolynomial.C x + CPolynomial.C y).toPoly
+    rw [CPolynomial.C_toPoly, CPolynomial.toPoly_add,
+      CPolynomial.C_toPoly, CPolynomial.C_toPoly]
+    simp
+  map_mul' x y := by
+    apply (CPolynomial.ringEquiv (R := R)).injective
+    change (CPolynomial.C (x * y)).toPoly = (CPolynomial.C x * CPolynomial.C y).toPoly
+    rw [CPolynomial.C_toPoly, CPolynomial.toPoly_mul,
+      CPolynomial.C_toPoly, CPolynomial.C_toPoly]
+    simp
 
 /-- Convert a single-variable multivariate polynomial to a univariate `CPolynomial`.
 Defined via `CMvPolynomial.eval₂` with `CPolynomial.C` as the coefficient ring hom
@@ -182,6 +600,41 @@ Returns a univariate `CPolynomial`. -/
 def roundPoly (D : Fin m → R) (k : ℕ) (p : CMvPolynomial (k + 1) R) : CPolynomial R :=
   toUnivariate (sumAllButFirst D k p)
 
+/-- The univariate bridge agrees with the Mathlib polynomial obtained by
+transporting the one-variable computable polynomial through `fromCMvPolynomial`. -/
+private theorem toUnivariate_toPoly (p : CMvPolynomial 1 R) :
+    (toUnivariate p).toPoly =
+      MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 => Polynomial.X)
+        (fromCMvPolynomial p) := by
+  unfold toUnivariate
+  have h := MvPolynomial.map_eval₂Hom
+    (f := cPolyRingHom (R := R))
+    (g := fun _ : Fin 1 => CPolynomial.X)
+    (φ := (CompPoly.CPolynomial.ringEquiv (R := R)).toRingHom)
+    (p := fromCMvPolynomial p)
+  have hcomp :
+      ((CompPoly.CPolynomial.ringEquiv (R := R)).toRingHom).comp
+        (cPolyRingHom (R := R)) = Polynomial.C := by
+    ext r n
+    rw [RingHom.comp_apply]
+    change ((CPolynomial.C r).toPoly).coeff n = (Polynomial.C r).coeff n
+    rw [CPolynomial.C_toPoly]
+  have hvars :
+      (fun i : Fin 1 =>
+          (CompPoly.CPolynomial.ringEquiv (R := R)).toRingHom CPolynomial.X) =
+        (fun _ : Fin 1 => Polynomial.X) := by
+    funext i
+    change CPolynomial.X.toPoly = Polynomial.X
+    rw [CPolynomial.X_toPoly]
+  rw [eval₂_equiv (p := p) (f := cPolyRingHom (R := R))
+    (vals := fun _ : Fin 1 => CPolynomial.X)]
+  change (CompPoly.CPolynomial.ringEquiv (R := R)).toRingHom
+      (MvPolynomial.eval₂ (cPolyRingHom (R := R)) (fun _ : Fin 1 => CPolynomial.X)
+        (fromCMvPolynomial p)) = _
+  rw [hcomp] at h
+  rw [hvars] at h
+  exact h
+
 /-! ### Correctness lemmas (univariate bridge) -/
 
 /-- `toUnivariate` preserves evaluation at the unique remaining variable.
@@ -189,7 +642,22 @@ Proof strategy: use `eval₂_equiv` to reduce to `MvPolynomial.eval₂`, then re
 to `CPolynomial.eval` via `CPolynomial.eval₂_toPoly`. -/
 theorem toUnivariate_eval (p : CMvPolynomial 1 R) (x : R) :
     CPolynomial.eval x (toUnivariate p) = p.eval (fun _ : Fin 1 => x) := by
-  sorry
+  rw [CPolynomial.eval_toPoly, toUnivariate_toPoly]
+  change Polynomial.eval x
+      (MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 => Polynomial.X)
+        (fromCMvPolynomial p)) = _
+  rw [← Polynomial.coe_evalRingHom]
+  rw [MvPolynomial.eval₂_comp_left]
+  have hc : (Polynomial.evalRingHom x).comp Polynomial.C = RingHom.id R := by
+    ext r
+    simp
+  have hv :
+      (⇑(Polynomial.evalRingHom x) ∘ fun _ : Fin 1 => Polynomial.X) =
+        (fun _ : Fin 1 => x) := by
+    funext i
+    simp
+  rw [hc, hv]
+  exact (eval_equiv (p := p) (vals := fun _ : Fin 1 => x)).symm
 
 /-- The symbolic round polynomial computes the exact remaining-sum function. -/
 theorem roundPoly_eval (D : Fin m → R) (k : ℕ) (p : CMvPolynomial (k + 1) R) (x : R) :
@@ -208,7 +676,53 @@ theorem toUnivariate_natDegree_le {deg : ℕ}
     (p : CMvPolynomial 1 R)
     (hDeg : ∀ mono ∈ Lawful.monomials p, mono.degreeOf 0 ≤ deg) :
     (toUnivariate p).natDegree ≤ deg := by
-  sorry
+  rw [CPolynomial.natDegree_toPoly, toUnivariate_toPoly]
+  have hfin :
+      MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 => Polynomial.X)
+          (fromCMvPolynomial p) =
+        MvPolynomial.finOneEquiv R (fromCMvPolynomial p) := by
+    rw [MvPolynomial.finOneEquiv, AlgEquiv.trans_apply, MvPolynomial.finSuccEquiv_apply]
+    symm
+    change (Polynomial.mapRingHom (MvPolynomial.isEmptyAlgEquiv R (Fin 0)).toRingEquiv.toRingHom)
+        (MvPolynomial.eval₂Hom
+          (Polynomial.C.comp (MvPolynomial.C : R →+* MvPolynomial (Fin 0) R))
+          (fun i : Fin 1 =>
+            Fin.cases Polynomial.X (fun k : Fin 0 => Polynomial.C (MvPolynomial.X k)) i)
+          (fromCMvPolynomial p)) =
+        MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 => Polynomial.X)
+          (fromCMvPolynomial p)
+    rw [MvPolynomial.map_eval₂Hom]
+    have hf :
+        (Polynomial.mapRingHom (MvPolynomial.isEmptyAlgEquiv R (Fin 0)).toRingEquiv.toRingHom).comp
+            (Polynomial.C.comp (MvPolynomial.C : R →+* MvPolynomial (Fin 0) R)) =
+          Polynomial.C := by
+      ext r n
+      simp
+    have hg :
+        (fun i : Fin 1 =>
+            (Polynomial.mapRingHom (MvPolynomial.isEmptyAlgEquiv R (Fin 0)).toRingEquiv.toRingHom)
+              (Fin.cases Polynomial.X (fun k : Fin 0 => Polynomial.C (MvPolynomial.X k)) i)) =
+          (fun _ : Fin 1 => Polynomial.X) := by
+      funext i
+      fin_cases i
+      simp
+    rw [hf, hg]
+    rfl
+  rw [hfin]
+  change (Polynomial.map (MvPolynomial.isEmptyAlgEquiv R (Fin 0)).toRingHom
+      (MvPolynomial.finSuccEquiv R 0 (fromCMvPolynomial p))).natDegree ≤ deg
+  have hinj : Function.Injective
+      (fun x => (MvPolynomial.isEmptyAlgEquiv R (Fin 0)).toRingEquiv.toRingHom x) := by
+    intro a b h
+    exact (MvPolynomial.isEmptyAlgEquiv R (Fin 0)).toRingEquiv.injective h
+  rw [Polynomial.natDegree_map_eq_of_injective hinj]
+  rw [MvPolynomial.natDegree_finSuccEquiv]
+  have hdegree := congrFun (degreeOf_equiv (p := p) (S := R)) 0
+  rw [← hdegree]
+  unfold CMvPolynomial.degreeOf
+  apply Finset.sup_le
+  intro mono hmono
+  exact hDeg mono (by simpa using hmono)
 
 /-- The round polynomial has degree at most `deg` when the original polynomial has
 individual degree at most `deg` in variable 0. -/
@@ -216,7 +730,9 @@ theorem roundPoly_natDegree_le {deg : ℕ} (D : Fin m → R) {k : ℕ}
     (p : CMvPolynomial (k + 1) R)
     (hDeg : ∀ mono ∈ Lawful.monomials p, mono.degreeOf 0 ≤ deg) :
     (roundPoly D k p).natDegree ≤ deg := by
-  sorry
+  unfold roundPoly
+  exact toUnivariate_natDegree_le (R := R) (deg := deg) (sumAllButFirst D k p)
+    (sumAllButFirst_degreeOf_zero_le (R := R) (m := m) (deg := deg) D k p hDeg)
 
 end Univariate
 

--- a/ArkLib/ProofSystem/Sumcheck/Interaction/Examples.lean
+++ b/ArkLib/ProofSystem/Sumcheck/Interaction/Examples.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2024-2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: ArkLib Contributors
+-/
+import ArkLib.ProofSystem.Sumcheck.Interaction.General
+
+/-!
+# Interaction-Native Sum-Check Examples
+
+This module records the end-to-end interaction-native Sumcheck surface. The
+examples deliberately use the public reductions from `General`: the oracle
+statement is the original polynomial family throughout the protocol, while the
+stateful variant threads the prover's private residual polynomial as witness
+state.
+-/
+
+namespace Sumcheck
+
+open Interaction Interaction.OracleDecoration CompPoly CPoly OracleComp OracleSpec
+
+section
+
+variable {R : Type} [BEq R] [CommSemiring R] [LawfulBEq R] [Nontrivial R]
+variable (deg n : Nat)
+variable {ι : Type} {oSpec : OracleSpec ι}
+variable {m_dom : Nat} (D : Fin m_dom → R)
+variable (sampleChallenge : OracleComp oSpec R)
+
+/-- The public end-to-end interaction-native Sumcheck reduction. -/
+noncomputable example :
+    OracleReduction oSpec
+      (RoundClaim R)
+      (fun _ => Sumcheck.fullSpec R deg n)
+      (fun _ => Sumcheck.fullRoles R deg n)
+      (fun _ => Sumcheck.fullOD (R := R) (deg := deg) n)
+      (fun _ => PUnit)
+      (fun _ => Sumcheck.PolyFamily R deg n)
+      (fun _ => PUnit)
+      (fun _ _ => Option (RoundClaim R))
+      (fun _ _ => Sumcheck.PolyFamily R deg n)
+      (fun _ _ => PUnit) :=
+  Sumcheck.sumcheckReduction (R := R) (deg := deg) n D sampleChallenge
+
+/-- The same public protocol with the prover's residual polynomial threaded
+privately as witness state. -/
+noncomputable example :
+    OracleReduction oSpec
+      (RoundClaim R)
+      (fun _ => Sumcheck.fullSpec R deg n)
+      (fun _ => Sumcheck.fullRoles R deg n)
+      (fun _ => Sumcheck.fullOD (R := R) (deg := deg) n)
+      (fun _ => PUnit)
+      (fun _ => Sumcheck.PolyFamily R deg n)
+      (fun _ => Sumcheck.PolyStmt R deg n)
+      (fun _ _ => Option (RoundClaim R))
+      (fun _ _ => Sumcheck.PolyFamily R deg n)
+      (fun _ _ => Sumcheck.PolyStmt R deg 0) :=
+  Sumcheck.sumcheckReductionStateful (R := R) (deg := deg) n D sampleChallenge
+
+end
+
+end Sumcheck

--- a/ArkLib/ProofSystem/Sumcheck/Interaction/General.lean
+++ b/ArkLib/ProofSystem/Sumcheck/Interaction/General.lean
@@ -72,7 +72,6 @@ private def consumeResidual :
 termination_by remaining _ _ => remaining
 decreasing_by simp_wf
 
-omit [Nontrivial R] in
 @[simp]
 private theorem consumeResidual_replicateCons
     (remaining : Nat)

--- a/ArkLib/ProofSystem/Sumcheck/Interaction/General.lean
+++ b/ArkLib/ProofSystem/Sumcheck/Interaction/General.lean
@@ -69,9 +69,10 @@ private def consumeResidual :
           (stepResidual (R := R) (deg := deg)
             (Sumcheck.roundChallenge R deg split.1) residual)
           split.2
-termination_by remaining residual tr => remaining
+termination_by remaining _ _ => remaining
 decreasing_by simp_wf
 
+omit [Nontrivial R] in
 @[simp]
 private theorem consumeResidual_replicateCons
     (remaining : Nat)
@@ -84,8 +85,7 @@ private theorem consumeResidual_replicateCons
         (stepResidual (R := R) (deg := deg)
           (Sumcheck.roundChallenge R deg tr₁) residual)
         tr₂ := by
-  simp [consumeResidual, Spec.Transcript.replicateCons, Spec.Transcript.replicateUncons,
-    Spec.Transcript.split_append]
+  simp [consumeResidual, Spec.Transcript.replicateCons, Spec.Transcript.split_append]
 
 /-- The active residual polynomial after fixing the `prefixLen` verifier
 challenges already present in `prefixTr`. The equality `prefixLen + remaining = n`
@@ -518,7 +518,8 @@ noncomputable def sumcheckReduction
       (fun _ _ => Option (RoundClaim R))
       (fun _ _ => Sumcheck.PolyFamily R deg n)
       (fun _ _ => PUnit) :=
-  (sumcheckContinuation (R := R) (deg := deg) n D sampleChallenge).promoteStatementToShared PUnit.unit
+  (sumcheckContinuation (R := R) (deg := deg) n D sampleChallenge).promoteStatementToShared
+    PUnit.unit
 
 /-- The canonical `n`-round oracle-native sum-check protocol with a private
 residual polynomial witness threaded across rounds. The public oracle statement
@@ -539,7 +540,8 @@ noncomputable def sumcheckReductionStateful
       (fun _ _ => Option (RoundClaim R))
       (fun _ _ => Sumcheck.PolyFamily R deg n)
       (fun _ _ => Sumcheck.PolyStmt R deg 0) :=
-  (sumcheckContinuationStateful (R := R) (deg := deg) n D sampleChallenge).promoteStatementToShared PUnit.unit
+  (sumcheckContinuationStateful (R := R) (deg := deg) n D sampleChallenge).promoteStatementToShared
+    PUnit.unit
 
 /-! ## Security placeholders
 

--- a/ArkLib/ProofSystem/Sumcheck/Interaction/Oracle.lean
+++ b/ArkLib/ProofSystem/Sumcheck/Interaction/Oracle.lean
@@ -62,7 +62,7 @@ noncomputable def oracleVerifierStep
   fun _ =>
     let receiverStep :
         OracleComp (oSpec + [OStmtIn]ₒ + (accSpec + oiSpec))
-          ((x : R) × Option (RoundClaim R)) := do
+          ((_ : R) × Option (RoundClaim R)) := do
         let total ← (Finset.univ : Finset (Fin m_dom)).toList.foldlM
           (fun (acc : R) (j : Fin m_dom) => do
             let val : R ← liftM <| oiSpec.query (D j)
@@ -99,7 +99,7 @@ noncomputable def oracleVerifierStepOption
       fun _ =>
         let receiverStep :
             OracleComp (oSpec + [OStmtIn]ₒ + (accSpec + oiSpec))
-              ((x : R) × Option (RoundClaim R)) := do
+              ((_ : R) × Option (RoundClaim R)) := do
             let chal : R ← liftM sampleChallenge
             let nextClaim : Option (RoundClaim R) := none
             pure ⟨chal, nextClaim⟩

--- a/ArkLib/ProofSystem/Sumcheck/Interaction/SingleRound.lean
+++ b/ArkLib/ProofSystem/Sumcheck/Interaction/SingleRound.lean
@@ -365,7 +365,8 @@ theorem roundContinuation_publicEq_stateful
     (prefixTr : Spec.Transcript (Sumcheck.fullSpec R deg prefixLen))
     (sampleChallenge : OracleComp oSpec R)
     (sWithOracles :
-      StatementWithOracles (fun _ => RoundClaim R) (fun _ => Sumcheck.PolyFamily R deg n) PUnit.unit) :
+      StatementWithOracles
+        (fun _ => RoundClaim R) (fun _ => Sumcheck.PolyFamily R deg n) PUnit.unit) :
     (Spec.Strategy.mapOutputWithRoles (fun _ out => out.stmt) ·) <$>
       (roundContinuationStateful (R := R) (deg := deg) D
         (totalVars := n)
@@ -404,7 +405,8 @@ theorem roundContinuationOption_proverEq_stateful
         PUnit.unit sWithOracles
           (currentRoundResidual (R := R) (deg := deg) h prefixTr
             (sWithOracles.oracleStmt ())) := by
-  simpa [roundContinuationOption, roundContinuationOptionStateful, honestRoundPolyAtPrefix] using
+  simpa only [roundContinuationOption, roundContinuationOptionStateful,
+    honestRoundPolyAtPrefix] using
     congrArg
       (fun x =>
         (pure x :
@@ -500,8 +502,6 @@ theorem roundOracleReduction_executePublic_eq_stateful
     Interaction.OracleDecoration.OracleReduction.executePublicConcrete
       (roundOracleReductionStateful (R := R) (deg := deg) D numVars sampleChallenge)
       claim s (s.oracleStmt ()) := by
-  sorry
-/-
   let prefixTr : Spec.Transcript (Sumcheck.fullSpec R deg 0) := by
     simpa [Sumcheck.fullSpec] using
       (show Spec.Transcript ((roundSpec R deg).replicate 0) from ⟨⟩)
@@ -615,7 +615,6 @@ theorem roundOracleReduction_executePublic_eq_stateful
     roundOracleReduction, roundOracleReductionStateful,
     Interaction.OracleDecoration.OracleReduction.promoteStatementToShared,
     sCont, liftStmt, pack, k] using hRun
--/
 
 theorem roundOracleReduction_execute_eq_stateful
     {ι : Type} {oSpec : OracleSpec ι}
@@ -648,8 +647,6 @@ theorem roundOracleReduction_execute_eq_stateful
     OracleReduction.executeConcrete
       (roundOracleReductionStateful (R := R) (deg := deg) D numVars sampleChallenge)
       claim s (s.oracleStmt ()) := by
-  sorry
-/-
   let prefixTr : Spec.Transcript (Sumcheck.fullSpec R deg 0) := by
     simpa [Sumcheck.fullSpec] using
       (show Spec.Transcript ((roundSpec R deg).replicate 0) from ⟨⟩)
@@ -910,7 +907,6 @@ theorem roundOracleReduction_execute_eq_stateful
       Interaction.OracleDecoration.OracleReduction.promoteStatementToShared,
       sCont, liftOut, statefulProver, verifierStateful, simulateStateful, gStateful]
   exact hLeft.trans <| hRun₁.trans <| hRun₂.trans hRight.symm
--/
 
 /-- The stateless recomputing round reduction and the stateful residual-witness
 round reduction are honestly publicly equivalent: once we relate the stateful

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ In the future, we plan to verify functional equivalence of the executable spec (
 
 ## Library Structure
 
-The core of our library is a mechanized theory of **Interactive Oracle Reductions** (see [OracleReduction](ArkLib/OracleReduction)):
-1. An **IOR** (called `OracleReduction` in our formalization) is an interactive protocol between a prover and a verifier to reduce a relation $$R_1$$ on some public statement & private witness to another relation $$R_2$$.
+The current core abstraction for new protocol work is the interaction-native framework in
+[Interaction](ArkLib/Interaction). The legacy [OracleReduction](ArkLib/OracleReduction) framework
+still supports existing formalizations while they are migrated:
+1. An **IOR** is an interactive protocol between a prover and a verifier to reduce a relation
+   $$R_1$$ on some public statement & private witness to another relation $$R_2$$.
 2. The verifier may _not_ see the messages sent by the prover in the clear, but can make oracle queries to these messages using a specified oracle interface;
   - For example, one can view the message as a vector, and query entries of that vector. Alternatively, one can view the message as a polynomial, and query for its evaluation at some given points.
 3. We can **(sequentially) compose** multiple IORs with _compatible_ relations together (e.g. $$R_1 \implies R_2$$ and $$R_2 \implies R_3$$), preserving the security properties in most cases. We can also **lift** an IOR from a simple context (i.e., the input & output pairs of statement & witness) into a larger, more complex context, creating a **virtual** oracle reduction.
@@ -25,7 +28,10 @@ The core of our library is a mechanized theory of **Interactive Oracle Reduction
   - We then apply the **Fiat-Shamir transform**, which collapses interaction via letting the prover derive the verifier's random challenges through querying a hash function (modeled as a random oracle). We will formalize the **duplex-sponge** version of Fiat-Shamir, which utilizes cryptographic sponges for efficiency in practice.
 5. Our formalization follows the emerging view of IORs as the central information-theoretic object underlying modern SNARKs. We also follow the latest understanding & abstraction for the interactive BCS and Fiat-Shamir transformation. See [BACKGROUND](./BACKGROUND.md) for an (in-progress) summary of the relevant history.
 
-Using the theory of interactive oracle reductions, we then formalize various proof systems in [ProofSystem](ArkLib/ProofSystem).
+Using the theory of interactive oracle reductions, we then formalize various proof systems in
+[ProofSystem](ArkLib/ProofSystem). New reductions should use `ArkLib.Interaction`; see
+[`docs/wiki/legacy-oracle-reduction.md`](docs/wiki/legacy-oracle-reduction.md) for the retained
+legacy policy.
 
 ## Active Formalizations (last updated: 7 August 2025)
 

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -17,6 +17,8 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
   interaction-native core rebuild, with Sumcheck as the first acceptance test.
 - [`interaction-core-rebuild-pr-plan.md`](interaction-core-rebuild-pr-plan.md) - proposed
   four-PR landing narrative for the interaction core rebuild.
+- [`legacy-oracle-reduction.md`](legacy-oracle-reduction.md) - status of the retained legacy
+  `OracleReduction` tree and its remaining clients.
 
 ## Maintenance Contract
 
@@ -28,6 +30,7 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
   - `blueprint-and-citations.md` for blueprint workflow, references, and citation updates.
   - `interaction-core-rebuild.md` for the current core-rebuild landing plan.
   - `interaction-core-rebuild-pr-plan.md` for the proposed stacked PR narrative.
+  - `legacy-oracle-reduction.md` for the frozen legacy `OracleReduction` policy.
 - Add new pages when a recurring topic no longer fits cleanly in an existing guide.
 - If a PR changes commands, repo structure, generated-file behavior, or the paper workflow,
   update the matching page in the same PR, or add a new page when that is the cleaner split.

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -13,6 +13,10 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
 - [`generated-files.md`](generated-files.md) - derived outputs and their sources of truth.
 - [`blueprint-and-citations.md`](blueprint-and-citations.md) - blueprint workflow, paper
   references, and citation keys.
+- [`interaction-core-rebuild.md`](interaction-core-rebuild.md) - working triage plan for the
+  interaction-native core rebuild, with Sumcheck as the first acceptance test.
+- [`interaction-core-rebuild-pr-plan.md`](interaction-core-rebuild-pr-plan.md) - proposed
+  four-PR landing narrative for the interaction core rebuild.
 
 ## Maintenance Contract
 
@@ -22,6 +26,8 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
   - `repo-map.md` for repo structure and main work areas.
   - `generated-files.md` for derived outputs and source-of-truth rules.
   - `blueprint-and-citations.md` for blueprint workflow, references, and citation updates.
+  - `interaction-core-rebuild.md` for the current core-rebuild landing plan.
+  - `interaction-core-rebuild-pr-plan.md` for the proposed stacked PR narrative.
 - Add new pages when a recurring topic no longer fits cleanly in an existing guide.
 - If a PR changes commands, repo structure, generated-file behavior, or the paper workflow,
   update the matching page in the same PR, or add a new page when that is the cleaner split.
@@ -29,22 +35,26 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
 - Promote recurring, repo-specific agent learnings here once they prove stable.
 - Prefer links to canonical docs over copying their contents.
 
-## Canonical Project Docs
+## Project Docs
 
 - [`../../README.md`](../../README.md) - project overview.
 - [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) - style, naming, docstrings, citations, and
   large contributions.
 - [`../../ROADMAP.md`](../../ROADMAP.md) - planned directions.
 - [`../../BACKGROUND.md`](../../BACKGROUND.md) - background references.
+
+### Active Design References
+
 - [`../../INTERACTION_BOUNDARIES.md`](../../INTERACTION_BOUNDARIES.md) - current interaction
   boundary-layer design reference.
+
+### Long-Term Or Archival Context
+
 - [`../../INTERACTION_CONCURRENT_SPEC.md`](../../INTERACTION_CONCURRENT_SPEC.md) - concurrent
-  interaction design reference.
+  interaction design reference; not part of the current core-rebuild landing path unless
+  concurrent modules are being changed.
 - [`../../INTERACTION_PROTOCOL_ROADMAP.md`](../../INTERACTION_PROTOCOL_ROADMAP.md) - literature-
-  driven roadmap for protocol families and future `Interaction` frontends.
+  driven roadmap for protocol families and future `Interaction` frontends; useful context, not a
+  branch validation target.
 - [`../../INTERACTION_BRACHA_VERIFICATION.md`](../../INTERACTION_BRACHA_VERIFICATION.md) -
-  Bracha reliable broadcast benchmark note and verified-protocol landscape.
-- [`../../INTERACTION_UC_MPC_LANDSCAPE.md`](../../INTERACTION_UC_MPC_LANDSCAPE.md) -
-  UC/MPC landscape note and benchmark survey.
-- [`../../INTERACTION_UC_CORE_SKETCH.md`](../../INTERACTION_UC_CORE_SKETCH.md) -
-  first-pass `Interaction`-native UC-core design sketch.
+  Bracha reliable broadcast benchmark note and verified-protocol landscape; benchmark context.

--- a/docs/wiki/blueprint-and-citations.md
+++ b/docs/wiki/blueprint-and-citations.md
@@ -31,7 +31,7 @@ For substantial contributions, discuss the blueprint-first workflow described in
 ## Build And Publish Checks
 
 ```bash
-DISABLE_EQUATIONS=1 lake build ArkLib:docs
+./scripts/validate.sh --docs
 ./scripts/build-web.sh
 ```
 

--- a/docs/wiki/interaction-core-rebuild-pr-plan.md
+++ b/docs/wiki/interaction-core-rebuild-pr-plan.md
@@ -1,0 +1,186 @@
+# Interaction Core Rebuild PR Plan
+
+This is the proposed reviewer-facing PR stack for landing the core rebuild.
+The goal is a clear narrative rather than many tiny mechanical PRs.
+
+## Summary
+
+Use four major PRs:
+
+1. Introduce the new interaction/oracle abstraction with sanity theorems.
+2. Use Sumcheck as the first serious acceptance test.
+3. Migrate the remaining transform/protocol surfaces needed for retirement.
+4. Retire the replaced legacy abstraction.
+
+This is a replacement path, not pure addition. The new `ArkLib/Interaction/*`
+stack is intended to supersede much of the legacy `ArkLib/OracleReduction/*`
+stack. Shared pieces such as `OracleInterface` may stay temporarily until a
+small relocation PR is worthwhile.
+
+This plan is branch-faithful, not a redesign. The split is meant to package and
+finish the abstractions already present on `quang/core-rebuild`: the
+interaction core, oracle decorations/query handles, continuation/composition
+machinery, `HybridSpec`, and the public-query BCS verifier shape. Scope cuts
+should defer incomplete clients or proof-hardening work; they should not replace
+the core architecture unless review uncovers a concrete unsoundness.
+
+## PR 1: Interaction/Oracle Core Abstraction
+
+Goal: introduce the new core as a reviewable abstraction, independent of
+Sumcheck.
+
+Estimated size: 7k-10k added LOC.
+
+Include:
+
+- `Interaction.Reduction`: prover/verifier/reduction, execution, sequential
+  composition, state-chain composition.
+- `Interaction.Oracle`: oracle specs, oracle decorations, query handles, oracle
+  verifier/reduction, execution, continuation, composition, chain/state-chain
+  helpers.
+- Minimal `Interaction.Security` and `Interaction.OracleSecurity` statement
+  layer only where needed to state core properties.
+- BCS verifier representation primitives if they are part of the active design
+  blocker: `HybridSpec`, `HybridDecoration`, `PublicQueryVerifier`, phase-1
+  wrapping, but not full phase-2/security.
+- Basic docs explaining the abstraction, its relation to legacy
+  `OracleReduction`, and intentionally deferred work.
+
+Illustrative sanity checks:
+
+- `ArkLib/Interaction/Examples/Core.lean` should collect small
+  reviewer-facing examples rather than new abstraction code.
+- Sequential composition has an execution equation showing that a composed
+  reduction runs the prefix and then the suffix.
+- Oracle query routing preserves the addressed oracle specification for both
+  left and right phases of an appended oracle protocol.
+- State-chain transcript `join`/`unjoin` laws show that dependent multi-stage
+  composition has a coherent executable transcript model.
+- BCS shared transcripts expose non-committed oracle messages and drop
+  committed oracle messages.
+- Public-query verifier types expose query selection as a function of
+  `SharedTranscript`, not the hidden original transcript; for a committed
+  single-pass protocol the query-decorator input is `PUnit`, so the hidden
+  message is unavailable by construction.
+
+Closed PR 1 proof debt on this local staging branch:
+
+- `ArkLib/Interaction/Oracle/Execution.lean`:
+  `runWithOracleCounterpart_mapCounterpartOutput` and
+  `Spec.runWithOracleCounterpart_mapOutputWithRoles`.
+- `ArkLib/Interaction/Oracle/Continuation.lean`:
+  `OracleReduction.comp_simulate_consistent`.
+
+The closed generic oracle execution/composition naturality lemmas justify core
+composition behavior. PR 1 lands only the verifier representation and phase-1
+wrapping surface; full BCS Phase 2 remains PR 3 scope.
+
+Out of scope:
+
+- Sumcheck implementation;
+- FRI/Binius/WHIR migration;
+- full BCS phase 2;
+- full security proof closure;
+- legacy deletion.
+
+Acceptance gate:
+
+- `lake build` passes.
+- No non-sorry warnings under new `ArkLib/Interaction/`.
+- Small theorem suite demonstrates the abstraction is not just definitions.
+- PR description says this is the new core intended to replace legacy
+  `OracleReduction`, but legacy users are not migrated yet.
+
+## PR 2: Sumcheck As Acceptance Test
+
+Goal: prove the new abstraction is useful by expressing Sumcheck as an ordinary
+client.
+
+Estimated size: 2k-4k added LOC.
+
+Include:
+
+- Minimal `Data/CompPoly` wrappers needed by Sumcheck.
+- `ProofSystem/Sumcheck/Interaction` definitions for round specs, oracle
+  statements, single-round reduction, and multi-round composition.
+- Honest prover/verifier execution equivalence lemmas needed to show the new API
+  supports real protocol behavior.
+- Only Sumcheck-specific docs necessary to explain why this validates the core.
+
+Required success criteria:
+
+- Sumcheck is expressed as an interaction-native oracle reduction.
+- Single-round and multi-round Sumcheck use generic
+  composition/continuation/state-chain machinery from PR 1.
+- The single-round stateless/stateful execution bridge is proved:
+  `roundOracleReduction_executePublic_eq_stateful` and
+  `roundOracleReduction_execute_eq_stateful`.
+- No bespoke Sumcheck-only composition mechanism.
+- Remaining Sumcheck polynomial proof gaps are classified as proof debt, not API
+  blockers.
+
+## PR 3: Migration Surface Needed For Retirement
+
+Goal: migrate enough transforms, wrappers, and downstream clients that the old
+abstraction can actually be removed in PR 4.
+
+Estimated size: 6k-12k LOC.
+
+Include:
+
+- Functional BCS phase 2 if needed before old BCS code can be retired.
+- Fiat-Shamir interaction-native transform only if an existing legacy
+  Fiat-Shamir surface is being replaced.
+- Boundary/reification layer only if current downstream protocols depend on
+  `LiftContext`-style behavior and must migrate before deletion.
+- Commitment interface bridge needed by BCS openings.
+- One additional non-Sumcheck client if needed to show generality.
+- Temporary compatibility shims only when needed for migration.
+
+Decision rule:
+
+- Include a module only if it is needed to remove or deprecate a corresponding
+  legacy `OracleReduction/*` feature, or if a current downstream protocol cannot
+  build without it.
+- Defer broad research docs, future concurrency design, and extra protocol
+  frontends.
+
+PR 3 progress should be recorded here when the migration branch lands. The
+planned branch should include the full BCS opening surface, reification/boundary
+bridges needed by downstream clients, and a small non-Sumcheck component.
+- The generic claim-tree soundness theorem in `ArkLib/Interaction/Security.lean`
+  still has a pre-existing proof hole. Its parked proof attempt is stale at a
+  monadic normalization step; it is not a blocker for the current BCS Phase 2
+  scaffold or boundary/reification migration path.
+
+## PR 4: Retire Legacy Abstraction
+
+Goal: remove the replaced old abstraction and force future work onto
+`Interaction`.
+
+Estimated size: net negative if done well.
+
+Remove or deprecate:
+
+- legacy `OracleReduction/Basic`, execution, sequential composition, BCS,
+  Fiat-Shamir, and LiftContext modules once no active client imports them;
+- generated imports for removed modules;
+- stale blueprint/wiki/root docs that describe the old abstraction as current;
+- compatibility shims introduced only for migration.
+
+Keep temporarily only if necessary:
+
+- `OracleReduction/OracleInterface.lean`, unless it is moved to a neutral
+  location like `ArkLib/Interaction/Oracle/Interface.lean` or
+  `ArkLib/Data/OracleInterface.lean`;
+- old protocol formalizations that are not yet in scope, but only behind
+  clearly named legacy imports.
+
+Acceptance gate:
+
+- `rg "ArkLib\\.OracleReduction" ArkLib --glob '*.lean'` returns only
+  intentionally retained legacy/interface references.
+- `lake build` passes.
+- `./scripts/validate.sh` passes after staging intentional new/removed Lean
+  files.
+- Docs identify `Interaction` as the canonical abstraction.

--- a/docs/wiki/interaction-core-rebuild-pr-plan.md
+++ b/docs/wiki/interaction-core-rebuild-pr-plan.md
@@ -119,6 +119,15 @@ Required success criteria:
 - Remaining Sumcheck polynomial proof gaps are classified as proof debt, not API
   blockers.
 
+Local PR 2 progress on this staging branch:
+
+- The stateless and stateful single-round Sumcheck oracle reductions have
+  matching public and full execution theorems.
+- Sumcheck uses the generic interaction continuation/composition machinery
+  rather than a Sumcheck-specific execution path.
+- The remaining Sumcheck gaps are the computable-polynomial bridge lemmas in
+  `CompPoly.lean`, not holes in the interaction abstraction.
+
 ## PR 3: Migration Surface Needed For Retirement
 
 Goal: migrate enough transforms, wrappers, and downstream clients that the old

--- a/docs/wiki/interaction-core-rebuild-pr-plan.md
+++ b/docs/wiki/interaction-core-rebuild-pr-plan.md
@@ -9,8 +9,8 @@ Use four major PRs:
 
 1. Introduce the new interaction/oracle abstraction with sanity theorems.
 2. Use Sumcheck as the first serious acceptance test.
-3. Migrate the remaining transform/protocol surfaces needed for retirement.
-4. Retire the replaced legacy abstraction.
+3. Migrate the remaining transform/protocol surfaces needed before containment.
+4. Contain the retained legacy abstraction.
 
 This is a replacement path, not pure addition. The new `ArkLib/Interaction/*`
 stack is intended to supersede much of the legacy `ArkLib/OracleReduction/*`
@@ -127,10 +127,11 @@ Required success criteria:
 - Remaining Sumcheck polynomial proof gaps are classified as proof debt, not API
   blockers.
 
-## PR 3: Migration Surface Needed For Retirement
+## PR 3: Migration Surface Needed Before Containment
 
-Goal: migrate enough transforms, wrappers, and downstream clients that the old
-abstraction can actually be removed in PR 4.
+Goal: migrate enough transforms, wrappers, and downstream clients that PR 4 can
+make `Interaction` canonical and classify the retained legacy surface without
+blocking active protocols.
 
 Estimated size: 6k-12k LOC.
 
@@ -193,34 +194,48 @@ Local PR 3 progress on this staging branch:
   monadic normalization step; it is not a blocker for the current BCS Phase 2
   scaffold or boundary/reification migration path.
 
-## PR 4: Retire Legacy Abstraction
+## PR 4: Legacy OracleReduction Containment
 
-Goal: remove the replaced old abstraction and force future work onto
-`Interaction`.
+Goal: make `Interaction` the canonical abstraction for new protocol work while
+keeping the legacy `OracleReduction` tree available for active clients that have
+not yet migrated.
 
-Estimated size: net negative if done well.
+This PR is documentation and containment, not deletion. A fresh audit shows
+active imports from Binius, old FRI/BatchedFri specs, Spartan/Plonk/Stir/Whir,
+legacy component modules, old Sumcheck specs, commitment code, and shared
+`OracleInterface` users. Removing or renaming `ArkLib/OracleReduction/*` here
+would turn this close-out PR into a broad protocol migration project.
 
-Remove or deprecate:
+Include:
 
-- legacy `OracleReduction/Basic`, execution, sequential composition, BCS,
-  Fiat-Shamir, and LiftContext modules once no active client imports them;
-- generated imports for removed modules;
-- stale blueprint/wiki/root docs that describe the old abstraction as current;
-- compatibility shims introduced only for migration.
+- Root/wiki documentation that names `ArkLib/Interaction/` as the current path
+  for new reductions, oracle protocols, BCS work, and security abstractions.
+- A legacy wiki page classifying retained `OracleReduction` users and explaining
+  that the tree is frozen except for build fixes, compatibility repairs, and
+  migration support.
+- Short module notes on the legacy entry points so reviewers and future agents do
+  not read the old abstraction as current guidance.
+- The legacy audit output in the PR description.
 
-Keep temporarily only if necessary:
+Do not include:
 
-- `OracleReduction/OracleInterface.lean`, unless it is moved to a neutral
-  location like `ArkLib/Interaction/Oracle/Interface.lean` or
-  `ArkLib/Data/OracleInterface.lean`;
-- old protocol formalizations that are not yet in scope, but only behind
-  clearly named legacy imports.
+- deleting, renaming, or generated-import churn for `ArkLib/OracleReduction/*`;
+- migrating Binius, FRI/BatchedFri, Spartan, Plonk, Stir, Whir, component, or
+  old Sumcheck clients;
+- moving `OracleInterface` out of `OracleReduction`.
+
+Future deletion prerequisites:
+
+- migrate retained protocol clients to `Interaction`;
+- move `OracleInterface` to a neutral location such as
+  `ArkLib/Interaction/Oracle/Interface.lean` or `ArkLib/Data/OracleInterface.lean`;
+- then remove or deprecate now-unused legacy execution, composition, security,
+  Fiat-Shamir, and LiftContext modules.
 
 Acceptance gate:
 
-- `rg "ArkLib\\.OracleReduction" ArkLib --glob '*.lean'` returns only
-  intentionally retained legacy/interface references.
-- `lake build` passes.
-- `./scripts/validate.sh` passes after staging intentional new/removed Lean
-  files.
 - Docs identify `Interaction` as the canonical abstraction.
+- `OracleReduction` is clearly marked as frozen legacy retained for existing
+  formalizations.
+- Remaining legacy users are classified instead of silently ignored.
+- `./scripts/validate.sh` and `./scripts/validate.sh --docs` pass.

--- a/docs/wiki/interaction-core-rebuild-pr-plan.md
+++ b/docs/wiki/interaction-core-rebuild-pr-plan.md
@@ -71,9 +71,17 @@ Closed PR 1 proof debt on this local staging branch:
 - `ArkLib/Interaction/Oracle/Continuation.lean`:
   `OracleReduction.comp_simulate_consistent`.
 
+Additional proof debt closed during PR 3 staging:
+
+- `ArkLib/Interaction/BCS/Verifier.lean`: four BCS phase-2 scaffolding holes
+  (`openingSpec`, `openingRoles`, `bcsPhase2Prover`, `bcsPhase2Verifier`) now
+  elaborate without `sorry`, and the file also provides full checked Phase 2
+  variants.
+
 The closed generic oracle execution/composition naturality lemmas justify core
-composition behavior. PR 1 lands only the verifier representation and phase-1
-wrapping surface; full BCS Phase 2 remains PR 3 scope.
+composition behavior. PR 1 can still land only the verifier representation and
+phase-1 wrapping surface, but the local staging branch has now closed the BCS
+Phase 2 implementation surface as part of PR 3.
 
 Out of scope:
 
@@ -119,15 +127,6 @@ Required success criteria:
 - Remaining Sumcheck polynomial proof gaps are classified as proof debt, not API
   blockers.
 
-Local PR 2 progress on this staging branch:
-
-- The stateless and stateful single-round Sumcheck oracle reductions have
-  matching public and full execution theorems.
-- Sumcheck uses the generic interaction continuation/composition machinery
-  rather than a Sumcheck-specific execution path.
-- The remaining Sumcheck gaps are the computable-polynomial bridge lemmas in
-  `CompPoly.lean`, not holes in the interaction abstraction.
-
 ## PR 3: Migration Surface Needed For Retirement
 
 Goal: migrate enough transforms, wrappers, and downstream clients that the old
@@ -154,9 +153,41 @@ Decision rule:
 - Defer broad research docs, future concurrency design, and extra protocol
   frontends.
 
-PR 3 progress should be recorded here when the migration branch lands. The
-planned branch should include the full BCS opening surface, reification/boundary
-bridges needed by downstream clients, and a small non-Sumcheck component.
+Local PR 3 progress on this staging branch:
+
+- `ArkLib/Interaction/BCS/Verifier.lean` now has both a compatibility Phase 2
+  surface (`openingSpec`, `openingRoles`, `bcsPhase2Prover`,
+  `bcsPhase2Verifier`) and a full opening-proof surface
+  (`fullOpeningSpec`, `fullOpeningRoles`, `fullBcsPhase2Prover`,
+  `fullBcsPhase2Verifier`), all elaborating without `sorry`.
+- The Phase 2 prover computes committed-oracle query responses from
+  `OracleWitness`; the full prover then runs every requested opening subproof.
+- `OpeningStatementDeco`, `openingStatements`, `OpeningWitnessDeco`, and
+  `openingWitnessesFromOracleWitness` provide the typed bridge from BCS
+  transcripts/query responses to `Commitment.Interaction.Opening` statements
+  and witnesses.
+- `OpeningProverDeco`, `openingProvers`, `OpeningVerifierDeco`, and
+  `openingVerifiers` instantiate the per-query opening prover strategies and
+  verifier counterparts from `OpeningDeco`.
+- `repeatSpec`, `repeatRoles`, `openingProofSpec`, `openingProofRoles`,
+  `fullOpeningSpec`, and `fullOpeningRoles` define that composed target:
+  claimed responses first, followed by every requested commitment-opening
+  subproof determined by the BCS transcript and query decoration.
+- `repeatProverStrategies`, `repeatVerifierCounterparts`,
+  `repeatVerifierCounterpartsAll`, `openingProofProver`,
+  `openingProofVerifier`, and `openingProofVerifierAll` assemble those
+  subproofs into executable strategies/counterparts.
+- `checkedFullBcsPhase2Prover` and `checkedFullBcsPhase2Verifier` provide an
+  accept/reject Phase 2 surface: the verifier returns `some responses` exactly
+  when all opening subproof verifier outputs are `true`, and `none` otherwise.
+- `ArkLib/Interaction/OracleReification.lean` now proves the reified
+  knowledge-soundness-to-soundness bridge directly against the current
+  `OracleVerifier.run` API.
+- `ArkLib/Interaction/Boundary/Oracle.lean` now proves verifier pullback
+  execution, including the raw identity-output corollary.
+- `ArkLib/ProofSystem/Component/Interaction/DoNothing.lean` is the first
+  non-Sumcheck component migrated onto the new `Interaction.Reduction` and
+  `Interaction.OracleReduction` surfaces.
 - The generic claim-tree soundness theorem in `ArkLib/Interaction/Security.lean`
   still has a pre-existing proof hole. Its parked proof attempt is stale at a
   monadic normalization step; it is not a blocker for the current BCS Phase 2

--- a/docs/wiki/interaction-core-rebuild.md
+++ b/docs/wiki/interaction-core-rebuild.md
@@ -1,0 +1,492 @@
+# Interaction Core Rebuild
+
+This note records the working interpretation of PR `Verified-zkEVM/ArkLib#433`
+(`quang/core-rebuild`) and a reduced program for landing it. The branch is a
+large interaction-layer rebuild. Its real architectural goal is broader than
+Sumcheck: replace ArkLib's legacy IOR substrate with an interaction-native core
+that supports reusable protocol components, oracle access, composition,
+boundaries, and later BCS/Fiat-Shamir transforms.
+
+## What The Branch Is Trying To Unlock
+
+The branch is trying to make `Interaction` the canonical semantic substrate for
+ArkLib protocols. Sumcheck composability is the banner deliverable because it is
+a concrete protocol you can use to test whether the new substrate works, but it
+is not the whole goal.
+
+The general target is:
+
+```text
+protocol descriptions
+  -> interaction-native reductions
+  -> oracle reductions and continuations
+  -> reusable composition / boundary transport
+  -> optional BCS / Fiat-Shamir transforms
+  -> concrete protocol clients such as Sumcheck, FRI, Binius, WHIR, ...
+```
+
+For Sumcheck, that means Sumcheck can be used as a protocol component:
+
+```text
+Protocol A
+  -> Sumcheck round(s)
+  -> FRI / folding / commitment opening
+  -> BCS transform
+  -> Fiat-Shamir transform
+```
+
+The important change is below every individual protocol. The branch introduces
+an interaction-native substrate where protocols are represented as dependent
+interaction trees, decorated by prover/verifier roles and oracle interfaces.
+That lets a protocol component be sequenced, lifted into a larger context,
+given oracle access, transported across boundaries, and transformed by BCS or
+Fiat-Shamir.
+
+The main abstractions are:
+
+- `Interaction.Spec`: a dependent protocol tree. Later message and challenge
+  types can depend on earlier public transcript values.
+- `RoleDecoration`: marks protocol nodes as prover/sender or verifier/receiver.
+- `OracleReduction`: a protocol that reduces one statement/witness/oracle
+  relation to another.
+- Oracle verifier: a verifier that queries oracle messages instead of receiving
+  full messages.
+- BCS transform: replaces prover oracle messages with commitments, then opens
+  only verifier-selected query positions.
+- `HybridSpec`: the BCS-oriented representation that separates public branching
+  nodes from hidden oracle-message pass nodes.
+- Boundary/reification layers: same-transcript interface adaptation and
+  transport between abstract oracle views and concrete oracle statements.
+
+## Sumcheck's Role
+
+Sumcheck should be treated as the first serious acceptance test for the
+interaction core, not as the full architectural objective.
+
+Useful acceptance criteria:
+
+- Sumcheck can be expressed as an interaction-native oracle reduction.
+- The single-round and multi-round Sumcheck definitions use the same generic
+  composition/continuation machinery expected by other protocols.
+- The Sumcheck oracle statement API does not require bespoke verifier plumbing
+  that would fail for FRI, Binius, or later protocols.
+- The branch demonstrates a path from oracle protocol syntax to BCS-compatible
+  verifier structure.
+
+If these hold, the branch has delivered the core architectural value even if
+some Sumcheck-specific correctness lemmas, FRI frontend work, or full BCS
+security theorems are deferred.
+
+## The Verifier Representation Problem
+
+The blocker Quang identified is the representation of an oracle verifier in a
+form that BCS can transform.
+
+The core issue is that BCS hides prover oracle messages behind commitments. A
+verifier cannot use a hidden oracle message to decide which protocol subtree
+comes next. If the protocol tree branches on a committed oracle value, the BCS
+verifier would need unavailable hidden data merely to know the shape of the rest
+of the protocol.
+
+The design answer in this branch is to use `HybridSpec` as the BCS input
+surface:
+
+- `branch X rest`: public message or verifier challenge. The continuation may
+  depend on the value because the value is publicly known.
+- `pass X rest`: oracle prover message. The continuation is structurally
+  constant and cannot depend on the hidden message.
+- `done`: terminal node.
+
+This is the key invariant: committed oracle data may influence query responses
+and final decisions, but it may not shape the protocol tree.
+
+The verifier should therefore not be represented as one monolithic oracle
+program. For BCS it should be decomposed into:
+
+1. A phase-1 challenger running on the BCS-transformed public transcript. It can
+   query external oracles, input oracle statements, and any non-committed oracle
+   messages, but it cannot query committed messages.
+2. A deterministic query function from the shared public transcript to all
+   queries against committed oracle messages.
+3. A decision function that receives the shared transcript plus opened query
+   responses, then computes the final output.
+
+This is implemented as `HybridSpec.PublicQueryVerifier` in
+`ArkLib/Interaction/BCS/Verifier.lean`. The type enforces public-query
+discipline by construction: the query function consumes `SharedTranscript`, not
+the hidden original transcript.
+
+## Completeness Of This Note
+
+This page is intended to be the working triage overview for the branch, but it
+is not a substitute for a full design document or PR review. It should answer:
+
+- what is on the critical path for the general interaction/oracle core;
+- how Sumcheck functions as the first acceptance test;
+- what the important dependencies are;
+- what is useful but can be deferred;
+- which validation failures are real blockers versus local worktree hygiene.
+
+It should not be read as saying that every file in the branch is equally
+necessary. The branch currently mixes at least four concerns:
+
+1. the core interaction/oracle substrate;
+2. Sumcheck as the first real protocol client and acceptance test;
+3. BCS/Fiat-Shamir transform scaffolding;
+4. boundary/reification transport;
+5. FRI, blueprint, and broader architecture experiments.
+
+The first two are the minimal landing story. BCS verifier representation is
+probably also needed because it is the active design blocker. The rest should be
+judged by whether it is needed to demonstrate or protect that story.
+
+## Current State
+
+On the local branch after the PR 1 cleanup captured with this note,
+the targeted core example build passes, and the full branch should continue to
+be checked with `./scripts/validate.sh`, including:
+
+- a successful `lake build`;
+- a clean `ArkLib/Data/` non-sorry warning budget;
+- a clean `ArkLib/Interaction/` non-sorry warning budget;
+- current generated imports;
+- markdown/docs integrity checks.
+
+There are still expected `sorry` warnings. The active gaps in the new surface
+are concentrated in Sumcheck/CompPoly bridge lemmas, BCS Phase 2, and generic
+security/transport lemmas. The generic oracle execution/composition naturality
+lemmas that gate the Sumcheck bridge have been closed locally.
+
+The major proof-debt surfaces outside the PR 3 migration surface are:
+
+- Sumcheck computable-polynomial bridge lemmas:
+  `ArkLib/ProofSystem/Sumcheck/Interaction/CompPoly.lean`.
+- Core soundness/boundary transport lemmas:
+  `ArkLib/Interaction/Security.lean`.
+
+BCS Phase 2 opening checks remain PR 3 scope.
+
+The first non-Sumcheck component migrated onto the new interaction surface is
+`ArkLib/ProofSystem/Component/Interaction/DoNothing.lean`. It provides both a
+plain no-interaction reduction and an oracle no-interaction reduction over the
+new APIs, while leaving the legacy component modules untouched for now.
+
+These are mostly proof or phase-2 completion gaps, not evidence that the new
+interaction representation is failing to elaborate.
+
+## Dependency Map
+
+The dependency picture is easiest to read in layers.
+
+### Layer 0: External Substrate
+
+These are already project dependencies and are not the branch's main design
+payload:
+
+- `VCVio.Interaction.Basic.*`
+- `VCVio.Interaction.TwoParty.*`
+- `VCVio.OracleComp.*`
+- `CompPoly.*`
+- legacy `ArkLib.OracleReduction.OracleInterface`
+
+The branch still imports the legacy oracle-interface file from several new
+modules. That is acceptable for a landing PR if the boundary is explicit; it
+does not require porting the entire legacy `OracleReduction/` tree first.
+
+### Layer 1: Minimal Interaction Core
+
+These are the core files for composability:
+
+- `ArkLib/Interaction/Reduction.lean`
+- `ArkLib/Interaction/Oracle/Spec.lean`
+- `ArkLib/Interaction/Oracle/Core.lean`
+- `ArkLib/Interaction/Oracle/Execution.lean`
+- `ArkLib/Interaction/Oracle/Continuation.lean`
+- `ArkLib/Interaction/Oracle/Composition.lean`
+- `ArkLib/Interaction/Oracle/Chain.lean`
+- `ArkLib/Interaction/Oracle/StateChain.lean`
+
+For a reduced landing PR, this is the main framework surface. The essential
+question is whether these modules provide enough protocol sequencing and oracle
+continuation machinery for Sumcheck without requiring downstream protocols to
+hand-roll glue.
+
+### Layer 2: Sumcheck Client
+
+These are the first real client modules:
+
+- `ArkLib/Data/CompPoly/Basic.lean`
+- `ArkLib/ProofSystem/Sumcheck/Interaction/CompPoly.lean`
+- `ArkLib/ProofSystem/Sumcheck/Interaction/Defs.lean`
+- `ArkLib/ProofSystem/Sumcheck/Interaction/Oracle.lean`
+- `ArkLib/ProofSystem/Sumcheck/Interaction/SingleRound.lean`
+- `ArkLib/ProofSystem/Sumcheck/Interaction/General.lean`
+
+This is the strongest evidence that the core is useful. A practical definition
+of "core landed" is:
+
+```text
+the interaction/oracle machinery is generic enough that Sumcheck can be
+expressed as an ordinary client, without bespoke composition plumbing.
+```
+
+The remaining Sumcheck proof gaps should be separated into:
+
+- API-critical gaps: if a missing lemma blocks composition or statement shape;
+- proof-hardening gaps: if the protocol is usable but correctness/security
+  theorems remain unfinished.
+
+### Layer 3: BCS Representation
+
+These files are central to Quang's verifier-representation blocker:
+
+- `ArkLib/Interaction/BCS/HybridSpec.lean`
+- `ArkLib/Interaction/BCS/HybridDecoration.lean`
+- `ArkLib/Interaction/BCS/HybridReduction.lean`
+- `ArkLib/Interaction/BCS/Verifier.lean`
+- `ArkLib/Interaction/Oracle/BCS.lean`
+
+The core design decision is `HybridSpec`: public `branch` nodes may shape the
+tree, hidden oracle `pass` nodes may not. `PublicQueryVerifier` then splits the
+verifier into challenger, public query selection, and final decision.
+
+For the first landing, BCS does not need to be security-complete. It does need
+to be coherent enough that the `HybridSpec` representation is clearly the path
+for BCS-compatible verifier structure.
+
+### Layer 4: Security And Reification
+
+These modules are important but not all needed to prove that the interaction
+core has landed:
+
+- `ArkLib/Interaction/Security.lean`
+- `ArkLib/Interaction/Oracle/Security.lean`
+- `ArkLib/Interaction/OracleSecurity.lean`
+- `ArkLib/Interaction/OracleReification.lean`
+- `ArkLib/Interaction/Boundary/*`
+
+Treat this as theorem debt unless a specific Sumcheck composition result needs
+one of these APIs. They are valuable, but they are also a natural source of
+large proof obligations.
+
+### Layer 5: Optional Protocol Frontends
+
+The FRI interaction frontend is currently a second client:
+
+- `ArkLib/ProofSystem/Fri/Interaction/*`
+
+This is useful as stress testing, but it is probably not required for the first
+core-rebuild landing. It can be:
+
+- cut from a reduced PR;
+- left as prototype if it does not expand review scope;
+- kept only if maintainers want a second client to validate the framework.
+
+### Layer 6: Documentation And Blueprint
+
+Blueprint and broad design docs are helpful, but they should not become the
+merge blocker unless they describe public APIs or changed workflows. For a
+reduced PR, prefer one accurate wiki/design note over broad blueprint expansion.
+
+## Documentation Triage
+
+There are many branch-local docs. They are not equally useful for deciding what
+to land.
+
+Use this page as the branch triage entrypoint. Treat the other docs as follows:
+
+| Document                                | Status for this branch                           | Keep / prune guidance                                                                                           |
+| ---                                     | ---                                              | ---                                                                                                             |
+| `docs/wiki/interaction-core-rebuild.md` | Operational triage                               | Keep as the current landing guide.                                                                              |
+| `PORTING.md`                            | Useful branch-status log, but partly stale       | Mine for facts, then fold the still-current checklist items into this page or a shorter migration guide.        |
+| `INTERACTION_BOUNDARIES.md`             | Real design reference for `Interaction.Boundary` | Keep if boundary APIs remain in scope; otherwise mark as follow-up design.                                      |
+| `INTERACTION_PROTOCOL_ROADMAP.md`       | Long-term Interaction split-out roadmap          | Not needed for the PR landing decision; move to long-term roadmap/archive if it distracts reviewers.            |
+| `INTERACTION_CONCURRENT_SPEC.md`        | Future concurrency design reference              | Scope creep for this PR unless concurrent modules are being landed now. Archive or move out of the review path. |
+| `INTERACTION_BRACHA_VERIFICATION.md`    | Benchmark/literature note                        | Useful research context, not a merge blocker. Archive or keep outside the branch-critical docs.                 |
+| Blueprint interaction chapters          | Public exposition                                | Keep only if the PR intentionally updates blueprint content; otherwise defer.                                   |
+
+Suggested consolidation path:
+
+1. Make this page the only required reader-facing branch triage doc.
+2. Shorten `PORTING.md` to a historical changelog or delete it after extracting
+   still-current checklist items.
+3. Keep `INTERACTION_BOUNDARIES.md` only if `ArkLib/Interaction/Boundary/*`
+   stays in the reduced landing scope.
+4. Move broad research/roadmap notes out of the immediate PR review path.
+5. Avoid adding more root-level `INTERACTION_*.md` files for this branch.
+
+## Core Versus Scope Creep
+
+### Core
+
+These are necessary for the branch's stated architectural value:
+
+- interaction-native reduction definitions;
+- oracle protocol spec/decorations;
+- oracle execution/continuation/composition primitives;
+- Sumcheck interaction frontend;
+- minimal CompPoly wrappers required by Sumcheck;
+- the BCS verifier representation decision, even if phase 2 remains incomplete.
+
+### Probably Necessary Soon
+
+These are not all needed for the first merge, but they should remain aligned
+with the core APIs:
+
+- BCS `HybridSpec` and `PublicQueryVerifier`;
+- phase-1 BCS prover wrapping;
+- small BCS toy tests or examples;
+- enough security statement scaffolding that future theorems will not require
+  reshaping the core types.
+
+### Likely Deferrable
+
+These are good follow-up PR candidates:
+
+- full BCS phase-2 implementation;
+- BCS security theorem;
+- full Fiat-Shamir transform/security;
+- FRI interaction frontend;
+- boundary/reification theorem closure unless used by Sumcheck;
+- broad blueprint rewrites;
+- polishing all old/prototype warning surfaces outside the new warning budget.
+
+### Watch For Scope Creep
+
+Be skeptical when a task requires:
+
+- finishing FRI before Sumcheck composition has landed;
+- proving generic security theorems before the representation is accepted;
+- requiring full BCS opening/security before the public-query verifier shape is
+  validated;
+- updating generated site or blueprint outputs when only Lean APIs changed;
+- enforcing style or warning budgets on unrelated old protocol files.
+
+## Validation Triage
+
+Use `./scripts/validate.sh` as the routine check, but interpret failures by
+category.
+
+Hard blockers:
+
+- `lake build` fails;
+- `ArkLib/Data/` non-sorry warnings introduced by this branch;
+- `ArkLib/Interaction/` non-sorry warnings introduced by this branch;
+- tracked import drift;
+- broken docs links introduced by this branch.
+
+Usually not design blockers:
+
+- existing `sorry` warnings;
+- warnings outside `ArkLib/Data/` and `ArkLib/Interaction/`;
+- untracked unrelated Lean files that need to be staged or ignored before
+  import generation;
+- optional docs/site/blueprint builds when those sources were not touched.
+
+Current local validation status:
+
+```text
+lake build: passes
+Data warning budget: passes
+Interaction warning budget: passes
+docs integrity: passes
+validate.sh: stops at check-imports because untracked LogUpGKR Lean files exist
+```
+
+Do not stage unrelated untracked Lean files merely to make this branch's
+validation pass unless they are intentionally part of the branch.
+
+## Reading Order For Review
+
+To understand what is actually core, read in this order:
+
+1. `ArkLib/Interaction/Reduction.lean`
+2. `ArkLib/Interaction/Oracle/Spec.lean`
+3. `ArkLib/Interaction/Oracle/Core.lean`
+4. `ArkLib/Interaction/Oracle/Continuation.lean`
+5. `ArkLib/ProofSystem/Sumcheck/Interaction/Defs.lean`
+6. `ArkLib/ProofSystem/Sumcheck/Interaction/Oracle.lean`
+7. `ArkLib/ProofSystem/Sumcheck/Interaction/SingleRound.lean`
+8. `ArkLib/ProofSystem/Sumcheck/Interaction/General.lean`
+9. `ArkLib/Interaction/BCS/HybridSpec.lean`
+10. `ArkLib/Interaction/BCS/Verifier.lean`
+
+Then read the rest only if the core path still seems coherent.
+
+## Reduced Landing Program
+
+Do not try to land the full architecture, BCS security, FRI frontend, Sumcheck
+frontend, and all proofs as one all-or-nothing PR. The branch is too broad for
+that to be an efficient review path.
+
+### Level 1: Land The Interaction Core
+
+Goal: merge the interaction/oracle framework with Sumcheck as the first
+acceptance test, while leaving full BCS security to follow-up PRs.
+
+Keep:
+
+- `ArkLib/Interaction/`
+- `ArkLib/Interaction/Oracle/`
+- `ArkLib/Interaction/Boundary/`
+- `ArkLib/ProofSystem/Sumcheck/Interaction/`
+- minimal `ArkLib/Data/CompPoly/` support needed by Sumcheck
+- docs/wiki updates explaining the new framework
+
+Consider cutting or clearly marking as prototype:
+
+- FRI interaction frontend
+- full BCS phase-2/security theorem surface
+- broad blueprint additions not needed for the landing story
+
+Must fix:
+
+- validation warning budget
+- import hygiene
+- stale generated imports
+- PR description, so reviewers know this lands the interaction/oracle scaffold,
+  not final BCS security
+
+### Level 2: Finish BCS Functional Correctness
+
+Goal: make the BCS transform mechanically usable.
+
+Implement the four phase-2 holes in `ArkLib/Interaction/BCS/Verifier.lean`:
+
+- `openingSpec`
+- `openingRoles`
+- `bcsPhase2Prover`
+- `bcsPhase2Verifier`
+
+Stress tests should start with small protocols:
+
+1. one committed oracle message and one query;
+2. two committed oracle messages with independent queries;
+3. mixed committed and non-committed oracle messages;
+4. a Sumcheck round polynomial as the committed oracle.
+
+### Level 3: Security And Proof Debt
+
+Goal: close the theorem-level debt after the representation and API have
+settled.
+
+Close:
+
+- claim-tree soundness in `ArkLib/Interaction/Security.lean`;
+- oracle execution map lemmas in `ArkLib/Interaction/Oracle/Execution.lean`;
+- reification-to-soundness bridge in `ArkLib/Interaction/OracleReification.lean`;
+- Sumcheck polynomial correctness lemmas;
+- blueprint and docs polish.
+
+## Recommended Next Move
+
+Expedite by landing a reduced PR whose success criterion is:
+
+```text
+the interaction/oracle core builds, Sumcheck exercises it, and the BCS verifier
+representation is coherent
+```
+
+Treat BCS phase 2 and security as follow-up proof-hardening PRs. The verifier
+representation should be kept as `HybridSpec` plus `PublicQueryVerifier`, with
+the invariant that committed oracle messages never determine protocol shape.

--- a/docs/wiki/interaction-core-rebuild.md
+++ b/docs/wiki/interaction-core-rebuild.md
@@ -142,9 +142,8 @@ judged by whether it is needed to demonstrate or protect that story.
 
 ## Current State
 
-On the local branch after the PR 2 cleanup captured with this note,
-the targeted core and Sumcheck builds pass, and the full branch should continue
-to be checked with `./scripts/validate.sh`, including:
+On the local branch after the local cleanup captured with this note,
+`./scripts/validate.sh` passes, including:
 
 - a successful `lake build`;
 - a clean `ArkLib/Data/` non-sorry warning budget;
@@ -153,10 +152,10 @@ to be checked with `./scripts/validate.sh`, including:
 - markdown/docs integrity checks.
 
 There are still expected `sorry` warnings. The active gaps in the new surface
-are concentrated in Sumcheck/CompPoly bridge lemmas, BCS Phase 2, and generic
+are concentrated in Sumcheck/CompPoly bridge lemmas and generic
 security/transport lemmas. The generic oracle execution/composition naturality
-lemmas and the single-round Sumcheck stateless/stateful execution bridge have
-been closed locally.
+lemmas that gate the Sumcheck bridge have been closed locally, and the
+`HybridSpec` BCS Phase 2 verifier scaffold now elaborates without `sorry`.
 
 The major proof-debt surfaces outside the PR 3 migration surface are:
 
@@ -165,7 +164,14 @@ The major proof-debt surfaces outside the PR 3 migration surface are:
 - Core soundness/boundary transport lemmas:
   `ArkLib/Interaction/Security.lean`.
 
-BCS Phase 2 opening checks remain PR 3 scope.
+BCS Phase 2 opening checks are now part of the local PR 3 surface.
+`ArkLib/Interaction/BCS/Verifier.lean` derives per-query
+`Commitment.Interaction.Opening` statements and witnesses from the BCS
+transcript and Phase 1 oracle witness, instantiates the corresponding opening
+prover strategies and verifier counterparts from `OpeningDeco`, assembles them
+into `fullBcsPhase2Prover` / `fullBcsPhase2Verifier`, and provides
+`checkedFullBcsPhase2Prover` / `checkedFullBcsPhase2Verifier`, where the
+verifier returns `some responses` exactly when every opening subproof accepts.
 
 The first non-Sumcheck component migrated onto the new interaction surface is
 `ArkLib/ProofSystem/Component/Interaction/DoNothing.lean`. It provides both a

--- a/docs/wiki/interaction-core-rebuild.md
+++ b/docs/wiki/interaction-core-rebuild.md
@@ -142,9 +142,9 @@ judged by whether it is needed to demonstrate or protect that story.
 
 ## Current State
 
-On the local branch after the PR 1 cleanup captured with this note,
-the targeted core example build passes, and the full branch should continue to
-be checked with `./scripts/validate.sh`, including:
+On the local branch after the PR 2 cleanup captured with this note,
+the targeted core and Sumcheck builds pass, and the full branch should continue
+to be checked with `./scripts/validate.sh`, including:
 
 - a successful `lake build`;
 - a clean `ArkLib/Data/` non-sorry warning budget;
@@ -155,7 +155,8 @@ be checked with `./scripts/validate.sh`, including:
 There are still expected `sorry` warnings. The active gaps in the new surface
 are concentrated in Sumcheck/CompPoly bridge lemmas, BCS Phase 2, and generic
 security/transport lemmas. The generic oracle execution/composition naturality
-lemmas that gate the Sumcheck bridge have been closed locally.
+lemmas and the single-round Sumcheck stateless/stateful execution bridge have
+been closed locally.
 
 The major proof-debt surfaces outside the PR 3 migration surface are:
 

--- a/docs/wiki/legacy-oracle-reduction.md
+++ b/docs/wiki/legacy-oracle-reduction.md
@@ -1,0 +1,45 @@
+# Legacy OracleReduction
+
+`ArkLib/Interaction/` is the canonical abstraction for new protocol work.
+Use it for new reductions, oracle protocol surfaces, BCS work, and security
+interfaces.
+
+`ArkLib/OracleReduction/` is retained as frozen legacy infrastructure. It still
+builds active protocol formalizations, but new code should not choose it as the
+default framework. Changes under this tree should be limited to build fixes,
+compatibility repairs, documentation, and migration support for moving clients
+to `Interaction`.
+
+## Retained Legacy Users
+
+The remaining `OracleReduction` imports are intentional until the corresponding
+protocols are migrated:
+
+- Binius ring-switching modules use legacy reductions, sequential composition,
+  and round-by-round security.
+- Old FRI and BatchedFri specs use legacy basic reductions, sequential
+  composition, LiftContext, and security definitions.
+- Spartan, Plonk, Stir, and Whir surfaces still depend on legacy security or
+  vector IOR modules.
+- Legacy component modules such as `DoNothing`, `NoInteraction`, `CheckClaim`,
+  `SendClaim`, `SendWitness`, `ReduceClaim`, and `RandomQuery` still use the old
+  round-by-round and LiftContext APIs.
+- Old Sumcheck specs remain on the legacy framework while
+  `ProofSystem/Sumcheck/Interaction` carries the interaction-native direction.
+- Commitment and data modules may still import `OracleInterface`, which
+  currently lives under `OracleReduction`.
+
+## Migration Policy
+
+Prefer `ArkLib.Interaction` and its submodules for any new formalization. When a
+legacy protocol needs new supporting work, add the interaction-native surface
+first when feasible, then bridge or migrate the old client in a focused follow-up.
+
+Do not delete or rename legacy modules as part of documentation-only cleanup.
+Actual removal of `ArkLib/OracleReduction/*` should happen only after retained
+protocols have moved off the old imports.
+
+Moving `OracleInterface` to a neutral location is future mechanical work. Until
+that relocation happens, imports of `ArkLib.OracleReduction.OracleInterface` from
+`Interaction`, `Data`, or commitment code are shared-interface references rather
+than endorsements of the legacy reduction framework.

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -53,6 +53,9 @@ If the task is specifically Lean warning cleanup, follow
 ./scripts/validate.sh --docs
 ```
 
+The wrapper builds the DocGen database and renders the API docs in safe core-root
+groups, avoiding full-core DocGen stack overflows or segfaults on some machines.
+
 For website or blueprint output, run:
 
 ```bash

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -22,19 +22,22 @@ home_page/            site assets and assembled website root
 
 ## Conceptual Layering
 
-- `ArkLib/Interaction/` is the new conceptual center, replacing `ArkLib/OracleReduction/`.
+- `ArkLib/Interaction/` is the canonical conceptual center for new protocol work, replacing
+  `ArkLib/OracleReduction/`.
 - `ArkLib/Interaction/BCS/` contains the generalized BCS transformation (hybrid decoration,
   spec transform, prover/verifier lifting, security theorems).
 - `ArkLib/Data/` and `ArkLib/ToMathlib/` support the core with reusable definitions and lemmas.
 - `ArkLib/CommitmentScheme/` and `ArkLib/ProofSystem/` build on top of those foundations.
 - When changing a protocol subtree, read the local subtree plus one layer of imports toward
-  `Data/` or `OracleReduction/` before making architectural edits.
+  `Data/`, `Interaction/`, or retained legacy `OracleReduction/` before making architectural
+  edits.
 
 ## Where To Start By Task
 
 - Extending foundational math or coding theory: start in `ArkLib/Data/`.
-- Changing core reduction or security abstractions: start in `ArkLib/Interaction/` (new) or
-  `ArkLib/OracleReduction/` (legacy).
+- Changing core reduction or security abstractions: start in `ArkLib/Interaction/`. Touch
+  `ArkLib/OracleReduction/` only for retained legacy clients; see
+  [`legacy-oracle-reduction.md`](legacy-oracle-reduction.md).
 - Working on the BCS transformation or hybrid oracle protocols: start in `ArkLib/Interaction/BCS/`.
 - Working on protocol statements or proofs: start in `ArkLib/ProofSystem/`.
 - Updating commitment interfaces or concrete schemes: start in `ArkLib/CommitmentScheme/`.

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -6,7 +6,21 @@ echo "Fetching Cache..."
 lake exe cache get
 
 echo "Building Project Documentation..."
-lake build ArkLib:docs
+# doc-gen4 can overflow the default shell stack or segfault when all core roots
+# are rendered in one process. Build the docInfo database through Lake, then
+# render the same docs in two safe root groups.
+ulimit -s unlimited
+DISABLE_EQUATIONS=1 lake build ArkLib:docInfo
+docgen=".lake/packages/doc-gen4/.lake/build/bin/doc-gen4"
+build_dir=".lake/build"
+DISABLE_EQUATIONS=1 "$docgen" fromDb \
+    --build "$build_dir" \
+    --manifest "$build_dir/doc-manifest-arklib-lake.json" \
+    "$build_dir/api-docs.db" ArkLib Init Std Lake
+DISABLE_EQUATIONS=1 "$docgen" fromDb \
+    --build "$build_dir" \
+    --manifest "$build_dir/doc-manifest-arklib-lean.json" \
+    "$build_dir/api-docs.db" ArkLib Init Std Lean
 
 # Build the Blueprint
 if [ -d "blueprint" ]; then

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -93,7 +93,21 @@ fi
 if (( run_docs )); then
   echo ""
   echo "# Building API docs"
-  DISABLE_EQUATIONS=1 lake build ArkLib:docs
+  # doc-gen4 can overflow the default shell stack or segfault when all core
+  # roots are rendered in one process. Build the docInfo database through Lake,
+  # then render the same docs in two safe root groups.
+  ulimit -s unlimited
+  DISABLE_EQUATIONS=1 lake build ArkLib:docInfo
+  docgen=".lake/packages/doc-gen4/.lake/build/bin/doc-gen4"
+  build_dir=".lake/build"
+  DISABLE_EQUATIONS=1 "$docgen" fromDb \
+    --build "$build_dir" \
+    --manifest "$build_dir/doc-manifest-arklib-lake.json" \
+    "$build_dir/api-docs.db" ArkLib Init Std Lake
+  DISABLE_EQUATIONS=1 "$docgen" fromDb \
+    --build "$build_dir" \
+    --manifest "$build_dir/doc-manifest-arklib-lean.json" \
+    "$build_dir/api-docs.db" ArkLib Init Std Lean
 fi
 
 if (( run_site )); then


### PR DESCRIPTION
## Summary
- removes the remaining local Sumcheck interaction CompPoly assumptions
- proves the Sumcheck-needed computable polynomial evaluation and degree bridges
- adds end-to-end interaction-native Sumcheck examples for public and stateful reductions

## Checks
- rg -n "axiom .*assumption|_assumption|\bsorry\b|admit" ArkLib/ProofSystem/Sumcheck/Interaction --glob '*.lean' is clean
- lake build ArkLib.ProofSystem.Sumcheck.Interaction.CompPoly passes
- lake build ArkLib.ProofSystem.Sumcheck.Interaction.Examples passes
- ./scripts/validate.sh passes

## Stack
PR 5 of 5. Intended review base is PR 4, but this account cannot push stack base branches into Verified-zkEVM/ArkLib, so the PR is opened from the fork against quang/core-rebuild.