### PR TITLE
Lint trailing spaces

### DIFF
--- a/.github/workflows/lint-whitespaces.yml
+++ b/.github/workflows/lint-whitespaces.yml
@@ -1,0 +1,19 @@
+name: Lint trailing whitespaces
+
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-whitespaces:
+    name: Lint trailing whitespaces
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint trailing whitespaces
+        run: bash ./scripts/lintWhitespace.sh

--- a/ArkLib/Data/CodingTheory/Basic/RelativeDistance.lean
+++ b/ArkLib/Data/CodingTheory/Basic/RelativeDistance.lean
@@ -361,23 +361,23 @@ theorem relDistFromCode_le_iff_distFromCode_le {C : Set (ι → F)} (u : ι → 
 
 theorem relDistFromCode_le_iff_distFromCode_toENNReal_le {C : Set (ι → F)} (u : ι → F) (δ : ℝ≥0) :
     δᵣ(u, C) ≤ δ ↔ (Δ₀(u, C) : ENNReal) ≤ δ * (Fintype.card ι : ℝ≥0) := by
-  rw [relDistFromCode_le_iff_distFromCode_le] 
-  constructor <;> intro h 
+  rw [relDistFromCode_le_iff_distFromCode_le]
+  constructor <;> intro h
   · simp_all only [ENNReal.coe_natCast]
-    convert ENNReal.ofReal_le_ofReal 
-      (Nat.floor_le (show 0 ≤ δ * (Fintype.card ι : ℝ≥0) by positivity)) |> 
+    convert ENNReal.ofReal_le_ofReal
+      (Nat.floor_le (show 0 ≤ δ * (Fintype.card ι : ℝ≥0) by positivity)) |>
         le_trans (ENNReal.ofReal_le_ofReal <| ?_) using 1
     any_goals exact Nat.cast (distFromCode u C |> ENat.toNat)
     · cases h : distFromCode u C <;> aesop
     · simp [ENNReal.ofReal_mul]
     · cases h' : distFromCode u C <;> aesop
   · contrapose! h
-    cases h' : distFromCode u C 
+    cases h' : distFromCode u C
     · simp_all only [ENat.coe_lt_top, ENNReal.coe_natCast, ENat.toENNReal_top]
       exact ENNReal.mul_lt_top (ENNReal.coe_lt_top) (ENNReal.natCast_lt_top _)
     · simp_all only [Nat.cast_lt, ENNReal.coe_natCast, ENat.toENNReal_coe]
       exact_mod_cast Nat.lt_of_floor_lt h
-        
+
 theorem relCloseToWord_iff_exists_possibleDisagreeCols
     {ι : Type*} [Fintype ι] [Nonempty ι] {F : Type*} [DecidableEq F] (u v : ι → F) (δ : ℝ≥0) :
     δᵣ(u, v) ≤ δ ↔ ∃ (D : Finset ι), D.card ≤ Nat.floor (δ * Fintype.card ι)

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -28,9 +28,9 @@ import ArkLib.ToMathlib.Polynomial.NatDegreeOfSum
     purported codeword using a random challenge.
 * `folding_preserves_distance`
   : lemma 4.9 from [ACFY24]. "Soundness" of the folding operation.
-    If a purported codeword `f` 
-    has distance `δ` to a given RS-code then, 
-    with high probability over the choice of folding randomness, 
+    If a purported codeword `f`
+    has distance `δ` to a given RS-code then,
+    with high probability over the choice of folding randomness,
     its folding also has distance `δ` to the "k-wise folded" RS-code.
 * `foldWord_codeword`
   : a bonus theorem not present in [ACFY24]. "Completeness" of the folding operation.
@@ -39,7 +39,7 @@ import ArkLib.ToMathlib.Polynomial.NatDegreeOfSum
 
 ## References
 
-* [Arnon, G., Chiesa, A., Fenzi, G., Yogev, E., 
+* [Arnon, G., Chiesa, A., Fenzi, G., Yogev, E.,
   *STIR: Reed–Solomon Proximity Testing with Fewer Queries*][ACFY24]
 -/
 
@@ -54,7 +54,7 @@ open Polynomial
 variable {F : Type} [Field F] [DecidableEq F]
 variable {n : ℕ}
 
-/-- Given a word `f`, `foldWordAux` is a polynomial `pₓ` 
+/-- Given a word `f`, `foldWordAux` is a polynomial `pₓ`
   of degree < 'k' such that `pₓ(domain i) = f i` for each `i`
   such that `domain i ^ k = x`. -/
 noncomputable def foldWordAux (domain : SmoothCosetFftDomain n F)
@@ -75,7 +75,7 @@ private lemma even_add_odd_eq_of_2_ne_0
 omit [DecidableEq F] in
 private lemma even_add_odd_eq_of_not_charp_2
   (x y z : F) (hz : z ≠ 0) (hchar : ¬CharP F 2) :
-  x = (x + y) / 2 + (x - y) / (2 * z) * z := 
+  x = (x + y) / 2 + (x - y) / (2 * z) * z :=
   even_add_odd_eq_of_2_ne_0 _ _ _ hz <| fun contra ↦ hchar <|
     ringChar.of_eq (CharP.ringChar_of_prime_eq_zero Nat.prime_two contra)
 
@@ -84,33 +84,33 @@ private lemma even_add_odd_eq_of_not_charp_2
 lemma foldWordAux_of_k_2
   [NeZero n]
   {i : Fin (2 ^ (n - 1))} :
-  foldWordAux domain f 2 (domain.subdomainNatReversed 1 i) = 
+  foldWordAux domain f 2 (domain.subdomainNatReversed 1 i) =
     let x : domain := CosetFftDomain.twoNthRoot (i := 1)
       ⟨domain.subdomainNatReversed 1 i, by simp⟩
     let i := domain.log x
     let i' := domain.log ⟨-x.1, by obtain ⟨x, hx⟩ := x; simpa using hx⟩
     C ((f i + f i') / 2) + Polynomial.X * C ((f i - f i') / (2 * x)) := by
-  unfold foldWordAux 
+  unfold foldWordAux
   have hn : n ≠ 0 := NeZero.ne _
   extract_lets y j j'
-  have h : 
-    ({i_1 | domain i_1 ^ 2 = (CosetFftDomain.subdomainNatReversed domain 1) i} : Finset _) = 
-    {j, j'} := by 
-    have h := CosetFftDomain.subdomainNatReversed_square_roots_explicit 
-      (ω := domain) (i := 0) (by omega) (y := y) 
+  have h :
+    ({i_1 | domain i_1 ^ 2 = (CosetFftDomain.subdomainNatReversed domain 1) i} : Finset _) =
+    {j, j'} := by
+    have h := CosetFftDomain.subdomainNatReversed_square_roots_explicit
+      (ω := domain) (i := 0) (by omega) (y := y)
       (x := (CosetFftDomain.subdomainNatReversed domain 1) i)
       (by simp) (by simp [y])
-    have hpre : Finset.preimage {y.1, -y.1} domain (by simp) = {j, j'} := by 
-      aesop (add unsafe (by apply CosetFftDomain.injective (ω := domain))) 
-    ext u 
+    have hpre : Finset.preimage {y.1, -y.1} domain (by simp) = {j, j'} := by
+      aesop (add unsafe (by apply CosetFftDomain.injective (ω := domain)))
+    ext u
     simp only [mem_filter, mem_univ, true_and, ←hpre, ←h, Nat.sub_zero, mem_preimage,
       CosetFftDomain.mem_coset_finset_iff_mem_coset_domain, iff_and_self]
     have := @CosetFftDomain.subdomainNatReversed_zero (ω := domain)
-    aesop 
+    aesop
   rw [h]
   have hcard : Finset.card {j, j'} = 2 := by
     rw [←h]
-    conv_rhs => 
+    conv_rhs =>
       rw [←pow_one 2,
           ←CosetFftDomain.subdomainNatReversed_roots_card (ω := domain) (i := 0)
               (x := (CosetFftDomain.subdomainNatReversed domain 1) i)
@@ -122,29 +122,29 @@ lemma foldWordAux_of_k_2
         rw [CosetFftDomain.subdomainNatReversed_zero]
         aesop)
       (fun _ _ _ _ h ↦ CosetFftDomain.injective h)
-      (fun b hb ↦ by 
-        obtain ⟨⟨j, hb⟩, hb'⟩ : 
-          b ∈ domain ∧ b ^ 2 = (CosetFftDomain.subdomainNatReversed domain 1) i := by 
+      (fun b hb ↦ by
+        obtain ⟨⟨j, hb⟩, hb'⟩ :
+          b ∈ domain ∧ b ^ 2 = (CosetFftDomain.subdomainNatReversed domain 1) i := by
           have := @CosetFftDomain.subdomainNatReversed_zero (ω := domain)
           aesop
         exact ⟨j, by simp [hb, hb'], by simp [hb]⟩)
   apply Polynomial.eq_of_eval_eq_degree (n := 2) (s := {y.1, -y.1})
-  · exact lt_of_lt_of_le 
-      (Lagrange.degree_interpolate_lt _ CosetFftDomain.injOn) 
+  · exact lt_of_lt_of_le
+      (Lagrange.degree_interpolate_lt _ CosetFftDomain.injOn)
       (by simp [hcard])
   · exact lt_of_le_of_lt (Polynomial.degree_add_le _ _) <| by
       simp only [X_mul_C, degree_mul, degree_X, WithBot.coe_ofNat, sup_lt_iff]
-      constructor 
+      constructor
       · exact lt_trans Polynomial.degree_C_lt (by simp)
-      · exact lt_of_lt_of_le 
+      · exact lt_of_lt_of_le
           (WithBot.add_lt_add_right (by simp) Polynomial.degree_C_lt) (by rfl)
-  · conv_rhs => 
-      rw [←hcard] 
+  · conv_rhs =>
+      rw [←hcard]
     exact Finset.card_le_card_of_injOn (f := domain)
       (fun x hx ↦ by aesop) CosetFftDomain.injOn
   · intro x hx
-    have hx : (x = domain j ∧ y.1 = domain j) ∨ 
-              (x = domain j' ∧ y.1 = -domain j') := by aesop 
+    have hx : (x = domain j ∧ y.1 = domain j) ∨
+              (x = domain j' ∧ y.1 = -domain j') := by aesop
     have hj := even_add_odd_eq_of_not_charp_2 (f j) (f j') (domain j) (by simp)
       (CosetFftDomain.subdomain_implies_char_ne_2 domain)
     have hj' := even_add_odd_eq_of_not_charp_2 (f j') (f j) (domain j') (by simp)
@@ -161,32 +161,32 @@ lemma foldWordAux_of_k_2
 
 private lemma roots_of_x_in_domain_eq
   (hk : k ≠ 0) :
-  ({i | domain i ^ k = x} : Finset (Fin (2 ^ n))) = 
-    Finset.preimage 
-      (nthRootsFinset k x) 
+  ({i | domain i ^ k = x} : Finset (Fin (2 ^ n))) =
+    Finset.preimage
+      (nthRootsFinset k x)
       domain
       (by simp) := by
-  ext i 
+  ext i
   simp only [mem_filter, mem_univ, true_and, mem_preimage]
   rw [Polynomial.mem_nthRootsFinset (by omega)]
 
 private lemma roots_of_x_in_domain_card
   (hk : k ≠ 0) :
-  Finset.card {i | domain i ^ k = x} ≤ 
-    Finset.card 
+  Finset.card {i | domain i ^ k = x} ≤
+    Finset.card
       (nthRootsFinset k x) := by
   rw [roots_of_x_in_domain_eq hk, Finset.card_preimage]
   exact Finset.card_le_card (by simp)
 
 private lemma roots_of_x_in_domain_le_k
   (hk : k ≠ 0) :
-  Finset.card {i | domain i ^ k = x} ≤ k := 
+  Finset.card {i | domain i ^ k = x} ≤ k :=
   le_trans (roots_of_x_in_domain_card hk) <| by
   simp only [nthRootsFinset, Multiset.toFinset, card_mk]
   exact le_trans
     (@Multiset.toFinset_card_le F (Classical.decEq F) _)
     (Polynomial.card_nthRoots _ _)
-    
+
 /-- The natDegree of the auxiliary polynomial `foldWordAux`
   is less than k. -/
 lemma foldWordAux_natDegree {k : ℕ} {x : F}
@@ -194,20 +194,20 @@ lemma foldWordAux_natDegree {k : ℕ} {x : F}
   (foldWordAux domain f k x).natDegree < k := by
   have hne := NeZero.ne (h := inst)
   by_cases heq: foldWordAux domain f k x = 0
-  · aesop 
-      (add safe (by omega)) 
+  · aesop
+      (add safe (by omega))
   · unfold foldWordAux at *
     apply lt_of_lt_of_le
     · rw [Polynomial.natDegree_lt_iff_degree_lt heq]
       exact Lagrange.degree_interpolate_lt _ (by simp)
     · exact roots_of_x_in_domain_le_k hne
 
-/-- Compute value of the folded word. 
+/-- Compute value of the folded word.
   Takes the auxiliary polynomial `foldWordAux` and evaluates it on `a`,
   the folding randomness. -/
 noncomputable def foldValue (domain : SmoothCosetFftDomain n F)
   (f : Word F (Fin (2 ^ n)))
-  (k : ℕ) (α : F) (x : F) : F := 
+  (k : ℕ) (α : F) (x : F) : F :=
   (foldWordAux domain f (2 ^ k) x).eval α
 
 lemma foldValue_def {α : F} {x : F} :
@@ -218,23 +218,23 @@ lemma foldValue_def' {α : F} {x : F} :
     (fun i => domain i) f).eval α := rfl
 
 @[simp]
-lemma foldValue_pow_x_k {i : Fin (2 ^ n)} : 
-  foldValue domain f k (domain i) ((domain i) ^ (2 ^ k)) = f i := 
+lemma foldValue_pow_x_k {i : Fin (2 ^ n)} :
+  foldValue domain f k (domain i) ((domain i) ^ (2 ^ k)) = f i :=
   Lagrange.eval_interpolate_at_node _ (by simp) (by simp)
-  
+
 @[simp]
 lemma foldValue_zero {k : ℕ} :
   foldValue domain 0 k = 0 := by aesop (add simp [foldValue, foldWordAux])
- 
+
 /-- An explicit formula for `foldValue` when `k = 1`. -/
 lemma foldValue_k_1 [NeZero n] {i : Fin (2 ^ (n - 1))} {α : F} :
-  foldValue domain f 1 α (domain.subdomainNatReversed 1 i) = 
+  foldValue domain f 1 α (domain.subdomainNatReversed 1 i) =
     let x : domain := CosetFftDomain.twoNthRoot (i := 1)
         ⟨domain.subdomainNatReversed 1 i, by simp⟩
     let i := domain.log x
     let i' := domain.log ⟨-x.1, by obtain ⟨x, hx⟩ := x; simpa using hx⟩
-    ((f i + f i') / 2) + α * ((f i - f i') / (2 * x)) := by 
-  aesop 
+    ((f i + f i') / 2) + α * ((f i - f i') / (2 * x)) := by
+  aesop
     (add simp [foldValue, foldWordAux_of_k_2])
     (add safe (by grind))
 
@@ -242,7 +242,7 @@ lemma foldValue_k_1 [NeZero n] {i : Fin (2 ^ (n - 1))} {α : F} :
   `a`, and returns a word over `Fin (2 ^ (n - k))`. -/
 noncomputable def foldWord (domain : SmoothCosetFftDomain n F)
   (f : Word F (Fin (2 ^ n))) (k : ℕ) (α : F) :
-  Word F (Fin (2 ^ (n - k))) := fun x ↦ 
+  Word F (Fin (2 ^ (n - k))) := fun x ↦
   foldValue domain f k α (domain.subdomainNatReversed k x)
 
 @[simp]
@@ -252,12 +252,12 @@ lemma foldWord_zero {k : ℕ} :
 /-- An explicit formula for `foldWord` when `k = 1` that
   does not use Lagrange interpolation. -/
 theorem foldWord_k_1 [NeZero n] {i : Fin (2 ^ (n - 1))} {α : F} :
-  foldWord domain f 1 α i = 
+  foldWord domain f 1 α i =
     let x : domain := CosetFftDomain.twoNthRoot (i := 1)
         ⟨domain.subdomainNatReversed 1 i, by simp⟩
     let i := domain.log x
     let i' := domain.log ⟨-x.1, by obtain ⟨x, hx⟩ := x; simpa using hx⟩
-    ((f i + f i') / 2) + α * ((f i - f i') / (2 * x)) := by 
+    ((f i + f i') / 2) + α * ((f i - f i') / (2 * x)) := by
   simp [foldWord, foldValue_k_1]
 
 omit [DecidableEq F] in
@@ -266,10 +266,10 @@ omit [DecidableEq F] in
 private lemma eval_comm {f : Polynomial (Polynomial F)} {a x : F} :
   (f.eval (Polynomial.C a)).eval x = (Polynomial.map (evalRingHom x) f).eval a := by
   simp only [Polynomial.eval_map]
-  have h_eval : Polynomial.eval (Polynomial.C a) f = 
+  have h_eval : Polynomial.eval (Polynomial.C a) f =
     ∑ i ∈ f.support, f.coeff i * (Polynomial.C a) ^ i := by
     aesop (add simp [Polynomial.eval_eq_sum])
-  simp [h_eval, Polynomial.eval_finset_sum, 
+  simp [h_eval, Polynomial.eval_finset_sum,
         Polynomial.eval₂_eq_sum, Polynomial.sum_def]
 
 private lemma roots_in_domain_card_eq_if_x_in_domain
@@ -284,9 +284,9 @@ private lemma roots_in_domain_card_eq_if_x_in_domain
     rw [←h]
   exact Finset.card_bij
     (fun x _ ↦ domain x)
-    (by 
+    (by
       aesop
-        (add simp [Nat.sub_zero, mem_filter, CosetFftDomain.mem_coset_finset_iff_mem_coset_domain]) 
+        (add simp [Nat.sub_zero, mem_filter, CosetFftDomain.mem_coset_finset_iff_mem_coset_domain])
         (add safe [(by rw [CosetFftDomain.subdomainNatReversed_zero])])
     )
     (fun _ _ _ _ h ↦ CosetFftDomain.injective h)
@@ -300,47 +300,47 @@ private lemma interpolate_eq_folding_poly_eval
   ((Lagrange.interpolate {i | domain i ^ 2 ^ k = x} fun i ↦ domain i)
     f) =
   (Polynomial.map (evalRingHom x)
-    (FoldingPolynomial.foldingPolynomial (Y ^ 2 ^ k) ((Lagrange.interpolate univ ⇑domain) f))) := 
-  by 
-  by_cases hf : f = 0 
+    (FoldingPolynomial.foldingPolynomial (Y ^ 2 ^ k) ((Lagrange.interpolate univ ⇑domain) f))) :=
+  by
+  by_cases hf : f = 0
   · simp [hf]
   · apply eq_of_eval_eq_degree (n := 2 ^ k)
         (s := Finset.image domain {i | domain i ^ 2 ^ k = x})
     · rw [Finset.card_image_of_injOn (by simp),
         roots_in_domain_card_eq_if_x_in_domain hk hx]
-    · simp only [mem_image, mem_filter, mem_univ, true_and] 
+    · simp only [mem_image, mem_filter, mem_univ, true_and]
       rintro u ⟨i, hu₁, hu₂⟩
       rw [←hu₂, ←foldValue_def', ←hu₁,
         FoldingPolynomial.eval_property_of_folding_polynomial_x_k]
-      aesop 
+      aesop
         (erase Lagrange.interpolate_apply)
         (add safe (by rw [Lagrange.eval_interpolate_at_node]))
         (add simp [FoldingPolynomial.eval_property_of_folding_polynomial_x_k])
     · exact lt_of_le_of_lt
         (Lagrange.degree_interpolate_le _ (by simp))
-        (by 
+        (by
           rw [roots_in_domain_card_eq_if_x_in_domain hk hx,
               show Nat.cast (2 ^ k - 1) = WithBot.some (2 ^ k - 1) by rfl,
               WithBot.coe_lt_coe]
           simp
         )
     · exact lt_of_le_of_lt Polynomial.degree_map_le <| by
-        have h := FoldingPolynomial.folding_polynomial_deg_y_bound_x_k 
+        have h := FoldingPolynomial.folding_polynomial_deg_y_bound_x_k
           (f := (Lagrange.interpolate univ ⇑domain) f)
           (k := 2 ^ k)
         simp only [Bivariate.natDegreeY] at h
         rw [Polynomial.natDegree_lt_iff_degree_lt (
           FoldingPolynomial.folding_polynomial_ne_zero_of_ne_zero <|
-            fun contra ↦ hf <| by 
+            fun contra ↦ hf <| by
               ext x
-              aesop 
+              aesop
                 (erase Lagrange.interpolate_apply)
                 (add safe (by rw [←Lagrange.eval_interpolate_at_node
                   (s := univ) (v := domain) f]))
         )] at h
         exact h
 
-/-- Perfect completeness of folding: folding a codeword is the same as 
+/-- Perfect completeness of folding: folding a codeword is the same as
   applying `polyFold` and then encoding.
 -/
 theorem foldWord_codeword {d : ℕ}
@@ -350,7 +350,7 @@ theorem foldWord_codeword {d : ℕ}
   :
   foldWord domain p k α
     = evalOnPoints (domain.subdomainNatReversed k)
-        (FoldingPolynomial.polyFold (ReedSolomon.codewordToPoly p) (2 ^ k) α) := by 
+        (FoldingPolynomial.polyFold (ReedSolomon.codewordToPoly p) (2 ^ k) α) := by
   ext x
   simp only [foldWord, foldValue, foldWordAux, evalOnPoints,
     Embedding.coeFn_mk, codewordToPoly, LinearMap.coe_mk, AddHom.coe_mk,
@@ -358,21 +358,21 @@ theorem foldWord_codeword {d : ℕ}
   rw [eval_comm, interpolate_eq_folding_poly_eval hk (by simp)]
 
 private noncomputable def foldWordAuxCoeff (domain : SmoothCosetFftDomain n F)
-  (f : Word F (Fin (2 ^ n))) (k : ℕ) (i : Fin k) (x : F) : F := 
+  (f : Word F (Fin (2 ^ n))) (k : ℕ) (i : Fin k) (x : F) : F :=
   (foldWordAux domain f k x).coeff i
 
 private lemma foldWordAux_coeff_eq_foldWordAuxCoeff_fin
   {i : Fin k} :
-  (foldWordAux domain f k x).coeff i =  
+  (foldWordAux domain f k x).coeff i =
     (foldWordAuxCoeff domain f k i x) := by simp [foldWordAux, foldWordAuxCoeff]
 
 private lemma foldWordAux_coeff_eq_foldWordAuxCoeff_nat
   [inst : NeZero k]
   {i : ℕ} :
-  (foldWordAux domain f k x).coeff i =  
-    if h : i < k 
+  (foldWordAux domain f k x).coeff i =
+    if h : i < k
     then (foldWordAuxCoeff domain f k ⟨i, h⟩ x)
-    else 0 := by 
+    else 0 := by
   by_cases h : i < k <;> simp only [h, ↓reduceDIte]
   · rw [←foldWordAux_coeff_eq_foldWordAuxCoeff_fin]
   · rw [Polynomial.coeff_eq_zero_of_natDegree_lt <|
@@ -380,12 +380,12 @@ private lemma foldWordAux_coeff_eq_foldWordAuxCoeff_nat
 
 private lemma foldWordAux_eq_sum_of_foldWordAuxCoeff
   [inst : NeZero k] :
-  foldWordAux domain f k x = 
+  foldWordAux domain f k x =
     ∑ j, Polynomial.C (foldWordAuxCoeff domain f k j x) * Y ^ j.val := by
   ext n
   simp only [finset_sum_coeff, coeff_C_mul, coeff_X_pow, mul_ite, mul_one, mul_zero]
   by_cases hlt : n < k
-  · aesop 
+  · aesop
       (add simp [foldWordAuxCoeff])
       (add safe [(by rw [Finset.sum_eq_single_of_mem ⟨n, hlt⟩])])
   · simp only [foldWordAux_coeff_eq_foldWordAuxCoeff_nat, hlt, ↓reduceDIte]
@@ -396,8 +396,8 @@ private lemma foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha
   {α : F} :
   foldValue domain f k α x =
     ∑ j, (foldWordAuxCoeff domain f (2 ^ k) j x) * α ^ j.val := by
-  aesop 
-    (add simp 
+  aesop
+    (add simp
       [foldValue,
         Polynomial.eval_finset_sum,
         foldWordAux_eq_sum_of_foldWordAuxCoeff])
@@ -410,7 +410,7 @@ private noncomputable def indicatedPolynomial
 
 section IndicatedPolynomial
 
-variable {s' : Finset F} 
+variable {s' : Finset F}
 
 private instance card_ne_zero (hs' : s'.Nonempty) : NeZero (Finset.card s') where
   out := by aesop
@@ -420,30 +420,30 @@ private lemma indicated_polynomial_degree_x_lt (hs' : s'.Nonempty) :
   simp only [Bivariate.degreeX, indicatedPolynomial, finset_sum_coeff, coeff_C_mul, coeff_map]
   rw [Finset.sup_lt_iff (by simp [hs'])]
   intro b hb
-  exact natDegree_sum_lt_of_forall_lt (inst := card_ne_zero hs') _ _ <| 
+  exact natDegree_sum_lt_of_forall_lt (inst := card_ne_zero hs') _ _ <|
     fun i hi ↦ lt_of_le_of_lt natDegree_mul_le <| by
-      aesop 
+      aesop
         (add simp [singleton_indicator_natDegree_lt_of_mem])
-  
+
 private lemma indicated_polynomial_degree_y_lt
   [inst : NeZero k] :
   Bivariate.natDegreeY (indicatedPolynomial domain f k s') < k := by
   simp only [Bivariate.natDegreeY, indicatedPolynomial]
-  exact natDegree_sum_lt_of_forall_lt _ _ <| fun i hi ↦ 
+  exact natDegree_sum_lt_of_forall_lt _ _ <| fun i hi ↦
     lt_of_le_of_lt natDegree_mul_le <| by
-      aesop 
+      aesop
         (add simp [foldWordAux_natDegree])
         (add safe forward [inst.out])
         (add safe (by omega))
-        
+
 private lemma indicated_polynomial_eq_foldAux
   {α : F} (hx : x ∈ s') :
-  ((indicatedPolynomial domain f k s').eval (Polynomial.C α)).eval x = 
+  ((indicatedPolynomial domain f k s').eval (Polynomial.C α)).eval x =
     (foldWordAux domain f k x).eval α := by
-  aesop 
+  aesop
     (add simp [indicatedPolynomial, eval_finset_sum])
-    (add safe 
-      [(by rw [singleton_indicator_eval_eq_zero_of_mem_sdiff]), 
+    (add safe
+      [(by rw [singleton_indicator_eval_eq_zero_of_mem_sdiff]),
         (by rw [Finset.sum_eq_ite x])])
 
 private lemma indicated_polynomial_eval_eq_combination_of_correlated
@@ -451,34 +451,34 @@ private lemma indicated_polynomial_eval_eq_combination_of_correlated
   {α : F}
   (hu : ∀ i x, x ∈ s' → (u i).eval x = (foldWordAuxCoeff domain f (2 ^ k) i x))
   (hx : x ∈ s') :
-  ((indicatedPolynomial domain f (2 ^ k) s').eval (Polynomial.C α)).eval x = 
+  ((indicatedPolynomial domain f (2 ^ k) s').eval (Polynomial.C α)).eval x =
     ∑ i, (u i).eval x * α ^ i.val := by
-  aesop 
+  aesop
     (add safe (by rw [←foldValue_def]))
-    (add simp 
-      [indicated_polynomial_eq_foldAux, 
-        foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha])  
-  
+    (add simp
+      [indicated_polynomial_eq_foldAux,
+        foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha])
+
 private lemma indicated_polynomial_eq_combination_of_correlated
   (hs' : s'.Nonempty)
   {u : Fin (2 ^ k) → Polynomial F}
   {α : F}
   (hu : ∀ i x, x ∈ s' → (u i).eval x = (foldWordAuxCoeff domain f (2 ^ k) i x))
   (hu_deg : ∀ i, (u i).natDegree < s'.card) :
-  ((indicatedPolynomial domain f (2 ^ k) s').eval (Polynomial.C α)) = 
+  ((indicatedPolynomial domain f (2 ^ k) s').eval (Polynomial.C α)) =
     ∑ i, (u i) * Polynomial.C (α ^ i.val) := by
   apply Polynomial.eq_of_eval_eq_natDegree (s := s') (n := #s')
-    <;> try rfl  
-  · simp only [indicatedPolynomial, 
+    <;> try rfl
+  · simp only [indicatedPolynomial,
       eval_finset_sum, eval_mul, eval_C, eval_map_apply]
-    exact natDegree_sum_lt_of_forall_lt (inst := card_ne_zero hs') _ _ <| 
-      fun i _ ↦ lt_of_le_of_lt natDegree_mul_le <| by 
-        aesop 
+    exact natDegree_sum_lt_of_forall_lt (inst := card_ne_zero hs') _ _ <|
+      fun i _ ↦ lt_of_le_of_lt natDegree_mul_le <| by
+        aesop
           (add simp [singleton_indicator_natDegree_lt_of_mem])
-  · exact natDegree_sum_lt_of_forall_lt (inst := card_ne_zero hs') _ _ <| 
-      fun i _ ↦ lt_of_le_of_lt natDegree_mul_le <| by simp [hu_deg] 
-  · aesop 
-      (add safe forward 
+  · exact natDegree_sum_lt_of_forall_lt (inst := card_ne_zero hs') _ _ <|
+      fun i _ ↦ lt_of_le_of_lt natDegree_mul_le <| by simp [hu_deg]
+  · aesop
+      (add safe forward
         [indicated_polynomial_eval_eq_combination_of_correlated])
       (add simp [eval_finset_sum])
 
@@ -493,63 +493,63 @@ private lemma indicated_polynomial_eq_foldAux'
   (h_card : 2 ^ k ≤ Fintype.card F) :
   (Polynomial.map
     (Polynomial.evalRingHom x)
-    (indicatedPolynomial domain f (2 ^ k) s')) = 
+    (indicatedPolynomial domain f (2 ^ k) s')) =
     foldWordAux domain f (2 ^ k) x := by
   apply Polynomial.eq_of_eval_eq_natDegree (s := Finset.univ) (n := (2 ^ k))
     <;> try tauto
-  · aesop 
+  · aesop
      (add safe [(by rw [←eval_comm]),
-      (by rw 
-        [indicated_polynomial_eq_combination_of_correlated, 
-          ←foldValue_def, 
+      (by rw
+        [indicated_polynomial_eq_combination_of_correlated,
+          ←foldValue_def,
           foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha])])
-     (add simp [eval_finset_sum])  
-  · simp only 
+     (add simp [eval_finset_sum])
+  · simp only
       [indicatedPolynomial, Polynomial.map_sum,
         Polynomial.map_mul, map_C, coe_evalRingHom]
-    exact natDegree_sum_lt_of_forall_lt _ _ <| fun i hi ↦ 
-      lt_of_le_of_lt natDegree_mul_le <| by 
-        aesop 
+    exact natDegree_sum_lt_of_forall_lt _ _ <| fun i hi ↦
+      lt_of_le_of_lt natDegree_mul_le <| by
+        aesop
           (add simp [Polynomial.map_map])
           (add safe [foldWordAux_natDegree])
   · exact foldWordAux_natDegree
 
-private lemma foldWordAux_poly_sum {a : F} : 
-  ((foldWordAux domain f (2 ^ k) a).sum fun e a ↦ Polynomial.C a * Polynomial.X ^ e) = 
+private lemma foldWordAux_poly_sum {a : F} :
+  ((foldWordAux domain f (2 ^ k) a).sum fun e a ↦ Polynomial.C a * Polynomial.X ^ e) =
   foldWordAux domain f (2 ^ k) a := by
-  aesop (add safe 
+  aesop (add safe
     [(by rw [←Polynomial.sum_monomial_eq]),
      (by rw [Polynomial.sum])])
 
 private lemma indicated_polynomial_comp_x_k_natDegree
   (hs' : s'.Nonempty) :
-  ((Polynomial.map (Polynomial.compRingHom (Polynomial.X ^ (2 ^ k))) <| 
+  ((Polynomial.map (Polynomial.compRingHom (Polynomial.X ^ (2 ^ k))) <|
     indicatedPolynomial domain f (2 ^ k) s').eval Polynomial.X).natDegree < (2 ^ k) * s'.card := by
   by_cases h_card : 1 < s'.card
-  · simp only [indicatedPolynomial, 
+  · simp only [indicatedPolynomial,
       Polynomial.eval_map, eval₂_finset_sum,
       eval₂_mul, eval₂_C, coe_compRingHom]
-    exact natDegree_sum_lt_of_forall_lt 
-      (inst := instNeZeroNatHMul (hm := card_ne_zero hs')) _ _ <| 
+    exact natDegree_sum_lt_of_forall_lt
+      (inst := instNeZeroNatHMul (hm := card_ne_zero hs')) _ _ <|
       fun i hi ↦ lt_of_le_of_lt natDegree_mul_le <| by
-      simp only [natDegree_comp, natDegree_pow, natDegree_X, mul_one, eval₂_map, 
+      simp only [natDegree_comp, natDegree_pow, natDegree_X, mul_one, eval₂_map,
         eval₂, RingHom.coe_comp, coe_compRingHom, comp_apply, C_comp, foldWordAux_poly_sum]
-      have h_ind := 
+      have h_ind :=
         Nat.le_sub_one_of_lt (singleton_indicator_natDegree_lt_of_mem hi)
-      exact lt_of_le_of_lt 
+      exact lt_of_le_of_lt
         (Nat.add_le_add_right (Nat.mul_le_mul_right _ h_ind) _) <|
-          lt_of_lt_of_le 
+          lt_of_lt_of_le
             (Nat.add_lt_add_left foldWordAux_natDegree _) <| by
             rw [Nat.mul_comm, ←Nat.mul_add_one]
             grind +ring
-  · have h_card : #s' = 1 := by grind 
-    aesop 
+  · have h_card : #s' = 1 := by grind
+    aesop
       (add unsafe [(by rw [Polynomial.eval_map, Polynomial.eval₂_map, eval₂])])
-      (add simp [Finset.card_eq_one, indicatedPolynomial, 
-        singletonIndicator, indicator, 
+      (add simp [Finset.card_eq_one, indicatedPolynomial,
+        singletonIndicator, indicator,
         foldWordAux_poly_sum])
       (add safe [foldWordAux_natDegree])
-    
+
 end IndicatedPolynomial
 
 omit [DecidableEq F] in
@@ -564,26 +564,26 @@ private lemma eval_comp_x_pow_map_eq {f : Polynomial (Polynomial F)} {x : F}
                (Polynomial.map
                 (Polynomial.evalRingHom (x ^ k))
                 f)) := by
-  induction f using Polynomial.induction_on 
+  induction f using Polynomial.induction_on
   · aesop
   · aesop
   · simp_all [pow_succ]
 
 private noncomputable def hammingDistComplementBound
-  {n : ℕ} (k : ℕ) (domain : SmoothCosetFftDomain n F) (s : Finset F) : ℕ := 
-  Finset.card { i ∈ 
-    Finset.product 
-      Finset.univ 
-      (Finset.preimage s (domain.subdomainNatReversed k) (by simp)) | 
+  {n : ℕ} (k : ℕ) (domain : SmoothCosetFftDomain n F) (s : Finset F) : ℕ :=
+  Finset.card { i ∈
+    Finset.product
+      Finset.univ
+      (Finset.preimage s (domain.subdomainNatReversed k) (by simp)) |
     (domain i.1) ^ (2 ^ k) = domain.subdomainNatReversed k i.2 }
 
 private noncomputable def hammingDistBound
-  {n : ℕ} (k : ℕ) (domain : SmoothCosetFftDomain n F) (s : Finset F) : ℕ := 
-  Fintype.card (Fin (2 ^ n)) - hammingDistComplementBound k domain s 
+  {n : ℕ} (k : ℕ) (domain : SmoothCosetFftDomain n F) (s : Finset F) : ℕ :=
+  Fintype.card (Fin (2 ^ n)) - hammingDistComplementBound k domain s
 
 @[simp]
 private lemma contradictory_hamming_dist_zero :
-  hammingDistBound k domain ∅ = 2 ^ n := by 
+  hammingDistBound k domain ∅ = 2 ^ n := by
   simp [hammingDistBound, hammingDistComplementBound]
 
 @[simp]
@@ -594,16 +594,16 @@ private lemma contradictory_hamming_dist_formula {s : Finset F}
   (h_d : d ≤ 2 ^ n) :
   hammingDistBound k domain s =
     2 ^ n - 2 ^ k * (Finset.card s) := by
-    unfold hammingDistBound hammingDistComplementBound 
-    simp only [Fintype.card_fin, product_eq_sprod] 
+    unfold hammingDistBound hammingDistComplementBound
+    simp only [Fintype.card_fin, product_eq_sprod]
     congr
-    rw [show @filter _ _ _ _ = 
-        (Finset.preimage s (domain.subdomainNatReversed k) (by simp)).biUnion 
-          (fun i ↦ {j | domain j.1 ^ 2 ^ k = domain.subdomainNatReversed k i ∧ j.2 = i} ) by aesop, 
+    rw [show @filter _ _ _ _ =
+        (Finset.preimage s (domain.subdomainNatReversed k) (by simp)).biUnion
+          (fun i ↦ {j | domain j.1 ^ 2 ^ k = domain.subdomainNatReversed k i ∧ j.2 = i} ) by aesop,
         Finset.card_biUnion (fun x hx y hy hxy a ha₁ ha₂ ↦ by
           by_contra contra
-          obtain ⟨c, hc⟩ : ∃ c, c ∈ a := by 
-            aesop 
+          obtain ⟨c, hc⟩ : ∃ c, c ∈ a := by
+            aesop
               (add simp [le_eq_subset])
               (add safe (by grind))
           specialize (ha₁ hc)
@@ -615,11 +615,11 @@ private lemma contradictory_hamming_dist_formula {s : Finset F}
       congr
       rfl
       ext u
-      rw [show (Finset.card _) = #{j | domain j ^ 2 ^ k = 
-        (CosetFftDomain.subdomainNatReversed domain k) u} by 
+      rw [show (Finset.card _) = #{j | domain j ^ 2 ^ k =
+        (CosetFftDomain.subdomainNatReversed domain k) u} by
         aesop (add safe (by apply Finset.card_bij (fun a _ ↦ a.1)))
       ]
-    rw [Finset.sum_bij (t := s) 
+    rw [Finset.sum_bij (t := s)
       (g := fun x ↦ Finset.card {j | domain j ^ (2 ^ k) = x})
       (i := fun i _ ↦ domain.subdomainNatReversed k i)
       (by aesop)
@@ -627,25 +627,25 @@ private lemma contradictory_hamming_dist_formula {s : Finset F}
       (by {
         intro b hb
         obtain ⟨a, ha⟩ : ∃ i, b = (CosetFftDomain.subdomainNatReversed domain k) i := by
-          rw [←CosetFftDomain.mem_coset_def, 
+          rw [←CosetFftDomain.mem_coset_def,
             ←CosetFftDomain.mem_coset_finset_iff_mem_coset_domain]
           exact h_s hb
         exists a
         aesop
-      }) 
+      })
       (by simp)]
-    rw [Finset.sum_bij (t := s) 
-      (g := fun i ↦ 2 ^ k) (fun i _ ↦ i) 
+    rw [Finset.sum_bij (t := s)
+      (g := fun i ↦ 2 ^ k) (fun i _ ↦ i)
       (by aesop)
       (by aesop)
-      (by aesop) 
+      (by aesop)
       (fun a ha ↦ by
         rw [roots_in_domain_card_eq_if_x_in_domain
           (by {
-            rw [←Nat.pow_le_pow_iff_right (a := 2) (by simp)] 
+            rw [←Nat.pow_le_pow_iff_right (a := 2) (by simp)]
             omega
         }) (by {
-          rw [←CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] 
+          rw [←CosetFftDomain.mem_coset_finset_iff_mem_coset_domain]
           exact h_s ha
         })]
       )]
@@ -663,12 +663,12 @@ private lemma correlated_agreement_implies_contradictory_hamm_dist
   (h_k_card : (2 ^ k) ≤ Fintype.card F)
   (h_u_deg : ∀ i, (u i).natDegree < d / (2 ^ k)) :
   ∃ f' : Polynomial F,
-    f'.natDegree < d ∧ 
-      hammingDist f (fun x => f'.eval (domain x)) ≤ 
+    f'.natDegree < d ∧
+      hammingDist f (fun x => f'.eval (domain x)) ≤
         hammingDistBound k domain s := by
   by_cases h_empty : s = ∅
   · exists (C <| f 0)
-    aesop 
+    aesop
       (add safe (by grind))
       (add unsafe (by rw [←Finset.compl_filter, Finset.card_compl]))
       (add simp [hammingDist, Finset.card_sdiff])
@@ -676,13 +676,13 @@ private lemma correlated_agreement_implies_contradictory_hamm_dist
     have h_nonempty : s.Nonempty := by grind
     have h_s'_card : s'.card = min s.card (d / (2 ^ k)) := by simp [s']
     have h_s'_non_empty : s'.Nonempty := by
-      simp_all only [card_pick_subset, ne_eq, 
+      simp_all only [card_pick_subset, ne_eq,
         Nat.div_eq_zero_iff, Nat.pow_eq_zero, OfNat.ofNat_ne_zero, false_and,
         false_or, not_lt, nonempty_pick_subset_of_nonempty_of_ne, s']
-    exists ((Polynomial.map (Polynomial.compRingHom (Polynomial.X ^ (2 ^ k))) <| 
+    exists ((Polynomial.map (Polynomial.compRingHom (Polynomial.X ^ (2 ^ k))) <|
       indicatedPolynomial domain f (2 ^ k) s').eval Polynomial.X)
     constructor
-    · exact lt_of_lt_of_le 
+    · exact lt_of_lt_of_le
         (indicated_polynomial_comp_x_k_natDegree h_s'_non_empty)
         (le_trans
           (Nat.mul_le_mul_left (m := d / (2 ^ k)) _ (by omega))
@@ -690,22 +690,22 @@ private lemma correlated_agreement_implies_contradictory_hamm_dist
     · simp only [hammingDist, ne_eq, hammingDistBound, Fintype.card_fin]
       rw [←Finset.compl_filter, Finset.card_compl, Fintype.card_fin]
       apply Nat.sub_le_sub_left
-      apply Finset.card_le_card_of_injOn Prod.fst 
+      apply Finset.card_le_card_of_injOn Prod.fst
         (f_inj := fun _ _ _ _ h ↦ by
-          aesop 
+          aesop
             (add unsafe [(by apply CosetFftDomain.injective (ω := domain.subdomainNatReversed k))])
 )
       rintro ⟨a₁, a₂⟩ ha
       simp_all only [product_eq_sprod, coe_filter, mem_product, mem_univ, mem_preimage, true_and,
-        Set.mem_setOf_eq] 
+        Set.mem_setOf_eq]
       rcases ha with ⟨h_a_s, h_eq⟩
       rw [eval_comp_x_pow_map_eq, h_eq]
       by_cases h_s'_s : s' = s
       · rw [h_s'_s,
-            ←eval_comm, 
+            ←eval_comm,
             indicated_polynomial_eq_foldAux (by simp [h_a_s]),
-            ←h_eq, 
-            ←foldValue_def, 
+            ←h_eq,
+            ←foldValue_def,
             foldValue_pow_x_k]
       · rw [indicated_polynomial_eq_foldAux' (u := u) (by aesop)] <;> try assumption
         · rw [←foldValue_def, ←h_eq, foldValue_pow_x_k]
@@ -713,8 +713,8 @@ private lemma correlated_agreement_implies_contradictory_hamm_dist
           have hx := (pick_subset_subset : s' ⊆ s) hx
           rw [h_u _ _ hx]
         · intro i
-          exact lt_of_lt_of_le 
-            (h_u_deg i) 
+          exact lt_of_lt_of_le
+            (h_u_deg i)
             (by rw [pick_subset_card_eq_of_ne h_s'_s])
 
 set_option linter.unusedFintypeInType false in -- false alert
@@ -735,12 +735,12 @@ private lemma dist_from_code_bound_of_correlated_agreement
   simp only [distFromCode, SetLike.mem_coe]
   exact sInf_le_of_le
     (b := ↑(hammingDistBound k domain s))
-    (h := by 
-      aesop 
-        (add safe 
+    (h := by
+      aesop
+        (add safe
           (by rw [contradictory_hamming_dist_formula]))
     ) <| by
-    obtain ⟨f', h_f'_deg, hdist⟩ := 
+    obtain ⟨f', h_f'_deg, hdist⟩ :=
       correlated_agreement_implies_contradictory_hamm_dist h_s h_u h_k_d (by {
     exact le_trans h_k_d <| by
       exact le_trans h_d <| by
@@ -756,15 +756,15 @@ private lemma folded_rate_div_eq_helper {d : ℕ}
   obtain ⟨m, rfl⟩ := hkd
   simp +zetaDelta only [ne_eq, Nat.pow_eq_zero, OfNat.ofNat_ne_zero, false_and, not_false_eq_true,
     mul_div_cancel_left₀, Nat.cast_mul, Nat.cast_pow, Nat.cast_ofNat] at *
-  rw [←Nat.add_sub_cancel' hkn, 
-      pow_add, 
-      mul_div_mul_left _ _ (by positivity)] 
+  rw [←Nat.add_sub_cancel' hkn,
+      pow_add,
+      mul_div_mul_left _ _ (by positivity)]
   norm_num
 
 omit [DecidableEq F] in
 /-- The rate of the folded RS-code is the same. -/
-lemma folded_rate_eq {d : ℕ} (hkn : k ≤ n) (hkd : 2 ^ k ∣ d) : 
-  LinearCode.rate 
+lemma folded_rate_eq {d : ℕ} (hkn : k ≤ n) (hkd : 2 ^ k ∣ d) :
+  LinearCode.rate
       (ReedSolomon.code (domain.subdomainNatReversed k : Fin (2 ^ (n - k)) ↪ F) (d / (2 ^ k))) =
     LinearCode.rate (ReedSolomon.code (domain : Fin (2 ^ n) ↪ F) d) := by
   simp only [rateOfLinearCode_eq_min_div, Fintype.card_fin, min_def, Nat.cast_ite, Nat.cast_pow,
@@ -780,23 +780,23 @@ lemma folded_rate_eq {d : ℕ} (hkn : k ≤ n) (hkd : 2 ^ k ∣ d) :
   · simp only [hif, ↓reduceIte, ne_eq, pow_eq_zero_iff', OfNat.ofNat_ne_zero, false_and,
     not_false_eq_true, div_self]
     have hif := Nat.div_le_div_right (c := 2 ^ k) (Nat.le_of_lt (not_le.mp hif))
-    rw [show 2 ^ n / 2 ^ k = 2 ^ (n - k) by 
-      aesop (add safe 
-        [(by rw [Nat.div_eq_iff]), 
-          (by rw [←pow_add]), 
+    rw [show 2 ^ n / 2 ^ k = 2 ^ (n - k) by
+      aesop (add safe
+        [(by rw [Nat.div_eq_iff]),
+          (by rw [←pow_add]),
           (by grind)])
     ] at hif
     rcases (Nat.lt_or_eq_of_le hif) with hif | hif
-    · aesop (add safe (by omega)) 
-    · aesop 
+    · aesop (add safe (by omega))
+    · aesop
         (add safe forward [div_eq_one_iff_eq])
         (add safe [(by norm_cast)])
 
 omit [DecidableEq F] in
 /-- The square root of the rate of the folded RS-code is the same. -/
-lemma folded_sqrtRate_eq {d : ℕ} (hkn : k ≤ n) (hkd : 2 ^ k ∣ d) : 
-  ReedSolomon.sqrtRate 
-     (d / (2 ^ k)) 
+lemma folded_sqrtRate_eq {d : ℕ} (hkn : k ≤ n) (hkd : 2 ^ k ∣ d) :
+  ReedSolomon.sqrtRate
+     (d / (2 ^ k))
      (domain.subdomainNatReversed k : Fin (2 ^ (n - k)) ↪ F) =
     ReedSolomon.sqrtRate d (domain : Fin (2 ^ n) ↪ F) := by
   aesop (add simp [ReedSolomon.sqrtRate, folded_rate_eq])
@@ -830,36 +830,36 @@ theorem folding_preserves_distance
   (δ_gt_0 : 0 < δ) -- this one is not used but should be.
   (δ_lt : δ < min (δᵣ(f, ReedSolomon.code (domain : Fin (2 ^ n) ↪ F) d))
     (1 - (ReedSolomon.sqrtRate d (domain : Fin (2 ^ n) ↪ F)))) :
-    Pr_{ let r ←$ᵖ F}[δᵣ(foldWord domain f k r, 
-      ReedSolomon.code (domain.subdomainNatReversed k : Fin (2 ^ (n - k)) ↪ F) 
+    Pr_{ let r ←$ᵖ F}[δᵣ(foldWord domain f k r,
+      ReedSolomon.code (domain.subdomainNatReversed k : Fin (2 ^ (n - k)) ↪ F)
       (d / (2 ^ k))) ≤ δ] ≤
-        ((2 ^ k) - 1) * ProximityGap.errorBound δ (d / (2 ^ k)) 
+        ((2 ^ k) - 1) * ProximityGap.errorBound δ (d / (2 ^ k))
         (domain.subdomainNatReversed k : Fin (2 ^ (n - k)) ↪ F) := by
     have h_k_d : 2 ^ k ≤ d := by exact Nat.le_of_dvd (by omega) k_div_d
     have h_k_le_n : k ≤ n := by
       rw [←Nat.pow_le_pow_iff_right (a := 2) (by simp)]
       omega
-    have bound_tighter : 
-      (↑δ) ≤ 1 - ReedSolomon.sqrtRate (d / (2 ^ k)) 
-        (domain.subdomainNatReversed k : Fin (2 ^ (n - k)) ↪ F) := 
+    have bound_tighter :
+      (↑δ) ≤ 1 - ReedSolomon.sqrtRate (d / (2 ^ k))
+        (domain.subdomainNatReversed k : Fin (2 ^ (n - k)) ↪ F) :=
       le_of_lt <| by
-        aesop 
+        aesop
           (add safe [(by rw [folded_sqrtRate_eq])])
           (add safe [(by grind)])
           (add safe (by norm_cast at *))
     have correlated_agreement :=
-      @correlatedAgreement_affine_curves (Fin (2 ^ (n - k))) _ _ F _ _ _ 
-        (2 ^ k - 1) (d / (2 ^ k)) 
-        (domain := domain.subdomainNatReversed k) (δ := δ) 
+      @correlatedAgreement_affine_curves (Fin (2 ^ (n - k))) _ _ F _ _ _
+        (2 ^ k - 1) (d / (2 ^ k))
+        (domain := domain.subdomainNatReversed k) (δ := δ)
         (hδ := bound_tighter)
     unfold foldWord δ_ε_correlatedAgreementCurves at *
     by_contra contra
-    simp only [not_le, foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha, bind_pure_comp, Functor.map, 
+    simp only [not_le, foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha, bind_pure_comp, Functor.map,
       PMF.bind_apply,
-      PMF.uniformOfFintype_apply, 
+      PMF.uniformOfFintype_apply,
       comp_apply, PMF.pure_apply, eq_iff_iff, true_iff,
       mul_ite, mul_one, mul_zero, tsum_fintype] at contra correlated_agreement
-    let cast (x : Fin (2 ^ k - 1 + 1)) : Fin (2 ^ k) := 
+    let cast (x : Fin (2 ^ k - 1 + 1)) : Fin (2 ^ k) :=
       Fin.cast (by rw [Nat.sub_add_cancel (by omega)]) x
     let cast' (x : Fin (2 ^ k)) : Fin (2 ^ k - 1 + 1) :=
       Fin.cast (by rw [Nat.sub_add_cancel (by omega)]) x
@@ -867,20 +867,20 @@ theorem folding_preserves_distance
       rw [bijective_iff_has_inverse]
       exists cast'
       simp [LeftInverse, RightInverse, cast, cast']
-    specialize correlated_agreement 
-      (Matrix.of (fun i j ↦ foldWordAuxCoeff domain f (2 ^ k) 
-        (cast i) 
+    specialize correlated_agreement
+      (Matrix.of (fun i j ↦ foldWordAuxCoeff domain f (2 ^ k)
+        (cast i)
         (domain.subdomainNatReversed k j)))
-    have correlated_curve_eq_sum_of_foldWord_coeffs {a : F} : 
-      ∑ i : Fin (2 ^ k - 1 + 1), a ^ (↑i : ℕ) • 
-        Matrix.of (fun i j ↦ 
+    have correlated_curve_eq_sum_of_foldWord_coeffs {a : F} :
+      ∑ i : Fin (2 ^ k - 1 + 1), a ^ (↑i : ℕ) •
+        Matrix.of (fun i j ↦
           foldWordAuxCoeff domain f (2 ^ k) (cast i) (domain.subdomainNatReversed k j)) i =
-      (fun x ↦ 
-        ∑ j, foldWordAuxCoeff domain f (2 ^ k) j 
+      (fun x ↦
+        ∑ j, foldWordAuxCoeff domain f (2 ^ k) j
           (domain.subdomainNatReversed k x) * a ^ (↑j : ℕ)) := by
       ext x
       simp only [sum_apply]
-      exact Fintype.sum_bijective cast bijective_cast _ _ <| 
+      exact Fintype.sum_bijective cast bijective_cast _ _ <|
         fun i ↦ by simp [cast, mul_comm]
     specialize correlated_agreement (by {
       conv_lhs =>
@@ -888,7 +888,7 @@ theorem folding_preserves_distance
         ext a
         rw [correlated_curve_eq_sum_of_foldWord_coeffs]
       norm_cast at contra
-    }) 
+    })
     simp only [jointAgreement, Fintype.card_fin, Nat.cast_pow, Nat.cast_ofNat, ge_iff_le,
       SetLike.mem_coe, Matrix.of_apply] at correlated_agreement
     obtain ⟨S, h_card, v, h'⟩ := correlated_agreement
@@ -899,10 +899,10 @@ theorem folding_preserves_distance
     let u : Fin (2 ^ k - 1 + 1) → Polynomial F :=
       fun i => Classical.choose (h_rs i)
     have contradiction := dist_from_code_bound_of_correlated_agreement (domain := domain) (f := f)
-      (s := Finset.image 
+      (s := Finset.image
         (domain.subdomainNatReversed k) S)
       (fun x hx ↦ by
-        rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] 
+        rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain]
         simp only [mem_image] at hx
         obtain ⟨x', _, hx'⟩ := hx
         aesop
@@ -923,15 +923,15 @@ theorem folding_preserves_distance
         And.left <| Classical.choose_spec (h_rs (cast' i)))
     rw [Finset.card_image_of_injective _ (by simp)] at contradiction
     have contradiction : (Δ₀(f, code (domain : Fin (2 ^ n) ↪ F) d) : ENNReal)
-      ≤ (↑(2 ^ n) : ℚ≥0) * δ := 
+      ≤ (↑(2 ^ n) : ℚ≥0) * δ :=
       le_trans (ENat.toENNReal_le.mpr contradiction) <| by
-        apply le_trans 
+        apply le_trans
           (b := (2 ^ n : ENNReal) - 2 ^ k * (1 - ↑δ) * 2 ^ (n - k))
         · rw [ENat.toENNReal_sub,
               show ENat.toENNReal (2 ^ n) = (2 ^ n : ENNReal) by simp,
               ENNReal.sub_le_sub_iff_left (h' := by simp)
                 (h := swap (le_trans (b := 2 ^ n * 1)) (by simp) <| by
-                  rw [mul_comm, 
+                  rw [mul_comm,
                       ←mul_assoc,
                       ←pow_add,
                       Nat.sub_add_cancel h_k_le_n,
@@ -944,7 +944,7 @@ theorem folding_preserves_distance
             have h_card := ENNReal.coe_le_coe_of_le h_card
             exact (swap le_trans h_card) (by norm_cast)
           · norm_cast
-        · rw [mul_comm, 
+        · rw [mul_comm,
               ←mul_assoc,
               ←pow_add,
               Nat.sub_add_cancel h_k_le_n]
@@ -965,8 +965,8 @@ theorem folding_preserves_distance
         rw [mul_comm]
         norm_cast
     simp only [lt_inf_iff] at δ_lt
-    simpa using lt_of_lt_of_le δ_lt.1 contradiction 
+    simpa using lt_of_lt_of_le δ_lt.1 contradiction
 
 end
-    
+
 end ProximityGap

--- a/ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean
+++ b/ArkLib/Data/CodingTheory/ReedSolomon/FftDomain.lean
@@ -220,7 +220,7 @@ lemma mem_finset_iff_mem_domain {ω : FftDomain ι F} {x : F} :
 omit [DecidableEq ι] in
 @[simp high]
 lemma mem_domain_finset_self {ω : FftDomain ι F} {i : ι} :
-  ω i ∈ ω.toFinset := by 
+  ω i ∈ ω.toFinset := by
   rw [mem_finset_iff_mem_domain]
   simp
 
@@ -378,7 +378,7 @@ lemma domain_add_eq_mul_domain {ω : FftDomain ι F}
 
 lemma mul_mem_domain_of_mem {ω : FftDomain ι F}
   {x₁ x₂ : F} (hx₁ : x₁ ∈ ω) (hx₂ : x₂ ∈ ω) :
-  x₁ * x₂ ∈ ω := by 
+  x₁ * x₂ ∈ ω := by
   rw [mem_domain_iff_exists] at *
   obtain ⟨⟨i₁, hi₁⟩, ⟨i₂, hi₂⟩⟩ := hx₁, hx₂
   exists (i₁ + i₂)
@@ -461,7 +461,7 @@ lemma neg_mem_domain_iff_mem {n} [nz : NeZero n] {ω : SmoothFftDomain n F}
   {x : F} :
   -x ∈ ω ↔ x ∈ ω := by
   constructor <;> intro h
-  · rw [show x = -(-x) by simp] 
+  · rw [show x = -(-x) by simp]
     exact neg_mem_domain_of_mem h
   · exact neg_mem_domain_of_mem h
 
@@ -600,7 +600,7 @@ lemma mem_coset_finset_iff_mem_coset_domain {ω : CosetFftDomain ι F}
 omit [DecidableEq ι] in
 @[simp high]
 lemma mem_coset_finset_self {ω : CosetFftDomain ι F} {i : ι} :
-  ω i ∈ ω.toFinset := by 
+  ω i ∈ ω.toFinset := by
   rw [mem_coset_finset_iff_mem_coset_domain]
   simp
 
@@ -676,7 +676,7 @@ lemma coset_domain_add_eq_mul_domain {ω : CosetFftDomain ι F}
   ω (i₁ + i₂) = (ω.x)⁻¹ * ω i₁ * ω i₂ := by cases ω with
   | mk x ω =>
     aesop
-      (add simp 
+      (add simp
         [eval_coset_fft_domain_eq_eval_x_mul_domain,
           FftDomain.domain_add_eq_mul_domain])
       (add safe (by ring_nf))
@@ -725,52 +725,52 @@ abbrev SmoothCosetFftDomain (n : ℕ) (F : Type) [Field F] : Type :=
 namespace FftDomain
 
 private def logAux {n : ℕ} (ω : SmoothFftDomain n F)
-  (x : ω) (fuel : ℕ) : Fin (2 ^ n) := 
+  (x : ω) (fuel : ℕ) : Fin (2 ^ n) :=
   match fuel with
   | 0 => default
-  | fuel + 1 => 
+  | fuel + 1 =>
     if h : fuel < 2 ^ n then
       if ω ⟨fuel, h⟩ = x then ⟨fuel, h⟩ else logAux ω x fuel
     else logAux ω x fuel
 
 /-- Finds a preimage of `x` under the mapping `ω`. -/
-def log {n : ℕ} (ω : SmoothFftDomain n F) (x : ω) : Fin (2 ^ n) := 
+def log {n : ℕ} (ω : SmoothFftDomain n F) (x : ω) : Fin (2 ^ n) :=
   logAux ω x (2 ^ n)
 
 @[simp]
 lemma log_right_inverse' {n : ℕ} {ω : SmoothFftDomain n F} {x : ω} :
-  ω (ω.log x) = x := by 
+  ω (ω.log x) = x := by
   have h_log : ∃ i : Fin (2 ^ n), ω i = x := by
     exact Finset.mem_image.mp x.2 |> fun ⟨i, _, hi⟩ ↦ ⟨i, hi⟩
   obtain ⟨i, hi⟩ := h_log
-  have h_log_aux : 
-    ∀ (fuel : ℕ) (i : Fin (2 ^ n)), 
+  have h_log_aux :
+    ∀ (fuel : ℕ) (i : Fin (2 ^ n)),
       i.val < fuel → ω i = x → ω (FftDomain.logAux ω x fuel) = x := by
     intro fuel i hi hx
-    induction fuel generalizing i with 
-    | zero => simp_all 
-    | succ fuel ih => 
+    induction fuel generalizing i with
+    | zero => simp_all
+    | succ fuel ih =>
       simp [FftDomain.logAux]
       grind
   exact h_log_aux _ _ (Fin.is_lt i) hi
 
-lemma log_right_inverse {n : ℕ} {ω : SmoothFftDomain n F} : 
+lemma log_right_inverse {n : ℕ} {ω : SmoothFftDomain n F} :
   Function.RightInverse ω.log (fun x ↦ ⟨ω x, by simp⟩) := fun x ↦ by simp
 
-lemma log_left_inverse {n : ℕ} {ω : SmoothFftDomain n F} : 
-  Function.LeftInverse ω.log (fun x ↦ ⟨ω x, by simp⟩) := 
+lemma log_left_inverse {n : ℕ} {ω : SmoothFftDomain n F} :
+  Function.LeftInverse ω.log (fun x ↦ ⟨ω x, by simp⟩) :=
     fun x ↦ injective (ω := ω) (by simp)
 
 @[simp]
 lemma log_injective {n : ℕ} {ω : SmoothFftDomain n F} :
-  Function.Injective (log ω) := 
-  Function.LeftInverse.injective 
+  Function.Injective (log ω) :=
+  Function.LeftInverse.injective
     (Function.RightInverse.leftInverse log_right_inverse)
-    
+
 @[simp]
 lemma log_injOn {n : ℕ} {ω : SmoothFftDomain n F} {s : Set ω.toFinset} :
   Set.InjOn (log ω) s := fun _ _ _ _ h ↦ log_injective h
-  
+
 private def subdomain_embed {n : ℕ} (i : Fin n.succ) (k : Fin (2 ^ (i : ℕ))) :
   Fin (2 ^ n) :=
   ⟨2 ^ (n - i) * k.val, match i, k with
@@ -901,8 +901,8 @@ lemma subdomain_le_finset {n} {ω : SmoothFftDomain n F}
   obtain ⟨k, hk⟩ : ∃ k : Fin (2 ^ (i : ℕ)), ω (subdomain_embed i k) = x := by
     unfold subdomain at hx
     aesop
-  obtain ⟨l, hl⟩ : ∃ l : Fin (2 ^ (j : ℕ)), 
-    subdomain_embed i k = subdomain_embed j l := 
+  obtain ⟨l, hl⟩ : ∃ l : Fin (2 ^ (j : ℕ)),
+    subdomain_embed i k = subdomain_embed j l :=
     subdomain_embed_of_le i j hij k
   aesop
 
@@ -1107,7 +1107,7 @@ lemma subdomain_subdomain_eq_subdomain {n} {ω : SmoothFftDomain n F}
 
 omit [DecidableEq F] in
 lemma subdomain_implies_char_ne_2 {n} [NeZero n] (ω : SmoothFftDomain n F) :
-  ¬CharP F 2 := fun hchar ↦ by 
+  ¬CharP F 2 := fun hchar ↦ by
   have hn : n ≠ 0 := NeZero.ne _
   set k : Fin (2 ^ n) := ⟨2 ^ (n - 1), pow_lt_pow_right₀ (by decide) (by omega)⟩
   have hk_ne_zero : k ≠ 0 := by simp [Fin.ext_iff, k]
@@ -1118,7 +1118,7 @@ lemma subdomain_implies_char_ne_2 {n} [NeZero n] (ω : SmoothFftDomain n F) :
     simp only [Fin.val_add, Fin.coe_ofNat_eq_mod, Nat.zero_mod, k]
     rcases n with _ | n <;> simp_all
     ring_nf
-    simp 
+    simp
   have h_sq : (ω k) ^ 2 = 1 := by
     rw [sq, ←domain_add_eq_mul_domain, h_kk, domain_zero_eq_one]
   have h_eq : ω k = 1 ∨ ω k = -1 := sq_eq_one_iff.mp h_sq
@@ -1247,11 +1247,11 @@ def twoNthRootAux (n i : ℕ) (ω : SmoothFftDomain n F)
   (x : F) (fuel : ℕ) : ω :=
   match fuel with
   | 0 => default
-  | fuel + 1 => 
+  | fuel + 1 =>
     if h : fuel < 2 ^ n then
-      if (ω ⟨fuel, h⟩) ^ 2 ^ i = x  
+      if (ω ⟨fuel, h⟩) ^ 2 ^ i = x
       then ⟨ω ⟨fuel, h⟩, by simp⟩
-      else twoNthRootAux n i ω x fuel 
+      else twoNthRootAux n i ω x fuel
     else default
 
 /-- Finds a `2 ^ n`th root of `x`. -/
@@ -1266,9 +1266,9 @@ private lemma twoNthRootAux_correct {n i : ℕ} {ω : SmoothFftDomain n F}
   obtain ⟨j, hj₁, hj₂⟩ := hexists
   induction fuel generalizing j with
   | zero => contradiction
-  | succ fuel ih => 
-    aesop 
-      (add simp [twoNthRootAux]) 
+  | succ fuel ih =>
+    aesop
+      (add simp [twoNthRootAux])
       (add safe (by grind))
 
 lemma twoNthRoot_correct {n i : ℕ} {ω : SmoothFftDomain n F}
@@ -1300,7 +1300,7 @@ lemma neg_mem_domain_of_mem {n} [nz : NeZero n] {ω : SmoothCosetFftDomain n F}
   -x ∈ ω := by
   rw [CosetFftDomain.mem_coset_domain] at *
   obtain ⟨y, hy₁, hy₂⟩ := h
-  exists (-y) 
+  exists (-y)
   aesop
 
 omit [DecidableEq F] in
@@ -1309,7 +1309,7 @@ lemma neg_mem_domain_iff_mem {n} [nz : NeZero n] {ω : SmoothCosetFftDomain n F}
   {x : F} :
   -x ∈ ω ↔ x ∈ ω := by
   constructor <;> intro h
-  · rw [show x = -(-x) by simp] 
+  · rw [show x = -(-x) by simp]
     exact neg_mem_domain_of_mem h
   · exact neg_mem_domain_of_mem h
 
@@ -1320,48 +1320,48 @@ lemma size_of_smooth_coset_domain_eq_pow_of_2 {n : ℕ} {ω : SmoothCosetFftDoma
     (add simp [CosetFftDomain.toFinset, Finset.card_image_of_injective, CosetFftDomain.injective])
 
 private def logAux {n : ℕ} (ω : SmoothCosetFftDomain n F)
-  (x : ω) (fuel : ℕ) : Fin (2 ^ n) := 
+  (x : ω) (fuel : ℕ) : Fin (2 ^ n) :=
   match fuel with
   | 0 => default
-  | fuel + 1 => 
+  | fuel + 1 =>
     if h : fuel < 2 ^ n then
       if ω ⟨fuel, h⟩ = x then ⟨fuel, h⟩ else logAux ω x fuel
     else logAux ω x fuel
 
 /-- Finds a preimage of `x` under the mapping `ω`. -/
-def log {n : ℕ} (ω : SmoothCosetFftDomain n F) (x : ω) : Fin (2 ^ n) := 
+def log {n : ℕ} (ω : SmoothCosetFftDomain n F) (x : ω) : Fin (2 ^ n) :=
   logAux ω x (2 ^ n)
 
 @[simp]
 lemma log_right_inverse' {n : ℕ} {ω : SmoothCosetFftDomain n F} {x : ω} :
-  ω (ω.log x) = x := by 
+  ω (ω.log x) = x := by
   have h_log : ∃ i : Fin (2 ^ n), ω i = x := by
     exact Finset.mem_image.mp x.2 |> fun ⟨i, _, hi⟩ ↦ ⟨i, hi⟩
   obtain ⟨i, hi⟩ := h_log
-  have h_log_aux : 
-    ∀ (fuel : ℕ) (i : Fin (2 ^ n)), 
+  have h_log_aux :
+    ∀ (fuel : ℕ) (i : Fin (2 ^ n)),
       i.val < fuel → ω i = x → ω (CosetFftDomain.logAux ω x fuel) = x := by
     intro fuel i hi hx
-    induction fuel generalizing i with 
-    | zero => simp_all 
-    | succ fuel ih => 
+    induction fuel generalizing i with
+    | zero => simp_all
+    | succ fuel ih =>
       simp [CosetFftDomain.logAux]
       grind
   exact h_log_aux _ _ (Fin.is_lt i) hi
 
-lemma log_right_inverse {n : ℕ} {ω : SmoothCosetFftDomain n F} : 
+lemma log_right_inverse {n : ℕ} {ω : SmoothCosetFftDomain n F} :
   Function.RightInverse ω.log (fun x ↦ ⟨ω x, by simp⟩) := fun x ↦ by simp
 
-lemma log_left_inverse {n : ℕ} {ω : SmoothCosetFftDomain n F} : 
-  Function.LeftInverse ω.log (fun x ↦ ⟨ω x, by simp⟩) := 
+lemma log_left_inverse {n : ℕ} {ω : SmoothCosetFftDomain n F} :
+  Function.LeftInverse ω.log (fun x ↦ ⟨ω x, by simp⟩) :=
     fun x ↦ injective (ω := ω) (by simp)
 
 @[simp]
 lemma log_injective {n : ℕ} {ω : SmoothCosetFftDomain n F} :
-  Function.Injective (log ω) := 
-  Function.LeftInverse.injective 
+  Function.Injective (log ω) :=
+  Function.LeftInverse.injective
     (Function.RightInverse.leftInverse log_right_inverse)
-    
+
 @[simp]
 lemma log_injOn {n : ℕ} {ω : SmoothCosetFftDomain n F} {s : Set ω.toFinset} :
   Set.InjOn (log ω) s := fun _ _ _ _ h ↦ log_injective h
@@ -1569,7 +1569,7 @@ private lemma y_ne_neg_y_of_mem_coset {n} [NeZero n]
   {y : F} (hy_mem : y ∈ ω) : y ≠ -y := by
   have h_char := CosetFftDomain.subdomain_implies_char_ne_2 ω
   contrapose! h_char
-  have h_char : (2 : F) = 0 := mul_left_cancel₀ (a := y) 
+  have h_char : (2 : F) = 0 := mul_left_cancel₀ (a := y)
       (fun contra ↦ by simp [contra] at hy_mem)
       (by linear_combination h_char)
   constructor
@@ -1607,11 +1607,11 @@ lemma subdomain_square_roots_explicit {n} [NeZero n] {ω : SmoothCosetFftDomain 
   {i : Fin n.succ} (hi : 0 < i) {x : F} {y : F}
   (hx : x ∈ (ω.subdomain (i - 1)))
   (hy : y ^ 2 = x) :
-  {y ∈ (ω.subdomain i).toFinset | y ^ 2 = x} = {y, -y} := by 
+  {y ∈ (ω.subdomain i).toFinset | y ^ 2 = x} = {y, -y} := by
   apply Finset.Subset.antisymm
   · intro z hz
     simp_all only [Nat.succ_eq_add_one, Finset.mem_filter,
-      mem_coset_finset_iff_mem_coset_domain, Finset.mem_insert, Finset.mem_singleton] 
+      mem_coset_finset_iff_mem_coset_domain, Finset.mem_insert, Finset.mem_singleton]
     exact eq_or_eq_neg_of_sq_eq_sq _ _ <| by rw [hz.2, hy]
   · have hy_mem : y ∈ subdomain ω i := sq_root_mem_subdomain hi hx hy
     simp_all only [Nat.succ_eq_add_one, Finset.subset_iff, Finset.mem_insert,
@@ -1879,15 +1879,15 @@ lemma subdomainNatReversed_mem_of_eq {n m k} {ω : SmoothCosetFftDomain n F}
 lemma subdomainNatReversed_square_roots_explicit {n} [NeZero n] {ω : SmoothCosetFftDomain n F}
   {i : ℕ} (hi : i < n) {x : F} {y : F}
   (hx : x ∈ (ω.subdomainNatReversed (i + 1))) (hy : y ^ 2 = x) :
-  {y ∈ (ω.subdomainNatReversed i).toFinset | y ^ 2 = x} = {y, -y} := by 
+  {y ∈ (ω.subdomainNatReversed i).toFinset | y ^ 2 = x} = {y, -y} := by
   unfold subdomainNatReversed at *
   have hn : (n + 1 - 1 % (n + 1) + (n - i)) % (n + 1) =
     (n - i - 1) % (n + 1) :=
     Nat.mod_eq_mod_iff.mpr ⟨0, ⟨1, by rw [Nat.mod_eq_of_lt (by omega)]; grind⟩⟩
-  rw [←subdomain_square_roots_explicit 
-        (ω := ω) (i := ⟨n - i, by omega⟩) (x := x) 
-        (by aesop (add simp [Fin.lt_def])) (by 
-          convert hx <;> 
+  rw [←subdomain_square_roots_explicit
+        (ω := ω) (i := ⟨n - i, by omega⟩) (x := x)
+        (by aesop (add simp [Fin.lt_def])) (by
+          convert hx <;>
             aesop
               (add simp [Nat.sub_add_eq, Fin.val_sub])
               (add safe (by grind))) hy]
@@ -1898,11 +1898,11 @@ def twoNthRootAux (n i : ℕ) (ω : SmoothCosetFftDomain n F)
   (x : F) (fuel : ℕ) : ω :=
   match fuel with
   | 0 => default
-  | fuel + 1 => 
+  | fuel + 1 =>
     if h : fuel < 2 ^ n then
-      if (ω ⟨fuel, h⟩) ^ 2 ^ i = x  
+      if (ω ⟨fuel, h⟩) ^ 2 ^ i = x
       then ⟨ω ⟨fuel, h⟩, by simp⟩
-      else twoNthRootAux n i ω x fuel 
+      else twoNthRootAux n i ω x fuel
     else default
 
 /-- Finds a `2 ^ n`th root of `x`. -/
@@ -1917,9 +1917,9 @@ private lemma twoNthRootAux_correct {n i : ℕ} {ω : SmoothCosetFftDomain n F}
   obtain ⟨j, hj₁, hj₂⟩ := hexists
   induction fuel generalizing j with
   | zero => contradiction
-  | succ fuel ih => 
-    aesop 
-      (add simp [twoNthRootAux]) 
+  | succ fuel ih =>
+    aesop
+      (add simp [twoNthRootAux])
       (add safe (by grind))
 
 lemma twoNthRoot_correct {n i : ℕ} {ω : SmoothCosetFftDomain n F}
@@ -1941,11 +1941,11 @@ lemma twoNthRoot_correct_one {n : ℕ} {ω : SmoothCosetFftDomain n F}
   [nz : NeZero n]
   {x : ω.subdomainNatReversed 1} :
   (twoNthRoot x).val ^ 2 = x := by
-  have hi : 1 ≤ n := by 
+  have hi : 1 ≤ n := by
     have hn : n ≠ 0 := NeZero.ne _
     omega
   conv_lhs =>
-    rhs 
+    rhs
     rw [←pow_one 2]
   rw [twoNthRoot_correct hi]
 

--- a/ArkLib/Data/CodingTheory/ReedSolomon/Multilinear.lean
+++ b/ArkLib/Data/CodingTheory/ReedSolomon/Multilinear.lean
@@ -9,8 +9,8 @@ import ArkLib.Data.MvPolynomial.Multilinear
 import ArkLib.Data.MvPolynomial.LinearMvExtension
 
 /-! This module provides an equivalent representation
-  of RS-codes in terms of multilinear polynomials 
-  as can be found in [ACFY24]. 
+  of RS-codes in terms of multilinear polynomials
+  as can be found in [ACFY24].
 
 ## References
 
@@ -20,7 +20,7 @@ import ArkLib.Data.MvPolynomial.LinearMvExtension
 
 namespace ReedSolomon
 
-open MvPolynomial LinearMvExtension 
+open MvPolynomial LinearMvExtension
 
 variable {F : Type*} [Field F] {ι : Type*} (domain : ι ↪ F)
 
@@ -28,24 +28,24 @@ variable {F : Type*} [Field F] {ι : Type*} (domain : ι ↪ F)
   such that `f` is evaluation of `powAlgHom g` on points from the eval domain. -/
 lemma mem_rs_code_iff_exists_mle
   {f : ι → F} {deg : ℕ} :
-  f ∈ code domain (2 ^ deg) ↔ 
+  f ∈ code domain (2 ^ deg) ↔
     ∃ g : F⦃≤ 1⦄[X (Fin deg)], f = evalOnPoints domain (powAlgHom g.1) := by
   constructor <;> intro h
   · rw [mem_code_iff_exists_polynomial] at h
     obtain ⟨g, hdeg, h⟩ := h
-    let poly := linearMvExtension (m := deg) ⟨g, by  
+    let poly := linearMvExtension (m := deg) ⟨g, by
       aesop (add simp [Polynomial.mem_degreeLT])
     ⟩
-    exists ⟨poly, by aesop (add simp [mem_restrictDegree_iff_degreeOf_le, 
+    exists ⟨poly, by aesop (add simp [mem_restrictDegree_iff_degreeOf_le,
                                        linearMvExtension_degreeOf_lt])⟩
     aesop (add simp powAlgHom_is_right_inverse_to_linearMvExtension)
-  · obtain ⟨g, h⟩ := h 
+  · obtain ⟨g, h⟩ := h
     exact mem_code_of_polynomial_of_natDegree_lt_of_eval
       (powAlgHom g.1)
       (lt_of_le_of_lt powAlgHom_of_restrict_degree_natDegree (by grind))
       (by aesop)
 
-/-- To prove a word `f` is in an RS-code, it is enough to 
+/-- To prove a word `f` is in an RS-code, it is enough to
   provide a multilinear polynomial `g` whose `powAlgHom g` coincides
   with the word `f` on the evaluation domain. -/
 lemma mem_rs_code_of_mle_of_eval

--- a/ArkLib/Data/Finset/PickSubset.lean
+++ b/ArkLib/Data/Finset/PickSubset.lean
@@ -12,7 +12,7 @@ import Mathlib.Tactic.Cases
 import Mathlib.Tactic.LinearCombination'
 
 /-!
-  This module provides tools for picking a 
+  This module provides tools for picking a
   subset from a finset. I.e., obtain a subset
   of a given finite set of a certain cardinality.
 -/
@@ -28,10 +28,10 @@ variable {α : Type*} [DecidableEq α]
 -/
 noncomputable def pickSubset (s : Finset α) (n : ℕ) : Finset α :=
   match n with
-  | .zero => ∅ 
-  | .succ n => 
+  | .zero => ∅
+  | .succ n =>
     let subset_n := pickSubset s n
-    if h : (s \ subset_n).Nonempty 
+    if h : (s \ subset_n).Nonempty
     then {Classical.choose (Finset.Nonempty.exists_mem h)} ∪ subset_n
     else subset_n
 
@@ -43,7 +43,7 @@ lemma pick_subset_zero {s : Finset α} :
 /-- Picking from an empty set always yields an empty set. -/
 @[simp]
 lemma pick_subset_empty {n : ℕ} :
-  pickSubset (∅ : Finset α) n = ∅ := by 
+  pickSubset (∅ : Finset α) n = ∅ := by
   induction n with
   | zero => rfl
   | succ n ih => simp [pickSubset, ih]
@@ -53,9 +53,9 @@ lemma pick_subset_subset {s : Finset α} {n : ℕ} :
   pickSubset s n ⊆ s := by
   induction n with
   | zero => simp
-  | succ n ih => 
-    by_cases h : (s \ s.pickSubset n).Nonempty 
-      <;> try 
+  | succ n ih =>
+    by_cases h : (s \ s.pickSubset n).Nonempty
+      <;> try
         (simp only [pickSubset, h, ↓reduceDIte, ih, singleton_union])
     rw [Finset.insert_subset_iff]
     have h_choose := Classical.choose_spec (Finset.Nonempty.exists_mem h)
@@ -64,33 +64,33 @@ lemma pick_subset_subset {s : Finset α} {n : ℕ} :
 /-- The cardinality of picked subset is `min s.card n`. -/
 @[simp]
 lemma card_pick_subset {s : Finset α} {n : ℕ} :
-  (pickSubset s n).card = min s.card n := by 
+  (pickSubset s n).card = min s.card n := by
   induction n generalizing s with
   | zero => simp [Finset.pickSubset]
   | succ n ih =>
     simp_all only [pickSubset, singleton_union]
     split_ifs with h
     · rw [Finset.card_insert_of_notMem]
-      · have := Finset.eq_of_subset_of_card_le 
+      · have := Finset.eq_of_subset_of_card_le
           (Finset.pick_subset_subset : s.pickSubset n ⊆ s)
-        aesop 
+        aesop
           (add safe (by omega))
           (add simp [min_def])
       · exact Classical.choose_spec h |> fun h' ↦ by aesop
     · simp_all only [nonempty_iff_ne_empty, ne_eq, sdiff_eq_empty_iff_subset, Decidable.not_not]
-      have := Finset.card_le_card h 
+      have := Finset.card_le_card h
       aesop (add safe (by omega))
 
 @[simp]
 lemma card_pick_subset_le {s : Finset α} {n : ℕ} :
-  (pickSubset s n).card ≤ n := by simp 
+  (pickSubset s n).card ≤ n := by simp
 
 /-- Picking non-zero elements from a non-empty set is not empty. -/
 @[simp]
 lemma nonempty_pick_subset_of_nonempty_of_ne {s : Finset α} {n : ℕ}
   (h : s.Nonempty)
   (hn : n ≠ 0) :
-  (pickSubset s n).Nonempty := by 
+  (pickSubset s n).Nonempty := by
   have h_card : (pickSubset s n).card ≠ 0 := by
     aesop
   rw [Finset.nonempty_iff_ne_empty]
@@ -111,15 +111,15 @@ lemma pick_subset_eq_of_card_pick_subset_lt {s : Finset α} {n : ℕ}
   pickSubset s n = s := by
   rw [←Finset.eq_iff_card_le_of_subset pick_subset_subset]
   aesop (add safe (by omega))
-  
+
 /-- `pickSubset` is of cardinality `n` if it is a proper subset of `s`. -/
 lemma pick_subset_card_eq_of_ne {s : Finset α} {n : ℕ}
   (h : pickSubset s n ≠ s) :
   (pickSubset s n).card = n := by
   by_contra contra
-  exact h ∘ pick_subset_eq_of_card_pick_subset_lt <| 
-    lt_of_le_of_ne (by simp) contra 
-  
+  exact h ∘ pick_subset_eq_of_card_pick_subset_lt <|
+    lt_of_le_of_ne (by simp) contra
+
 end PickSubset
 
 end Finset

--- a/ArkLib/Data/MvPolynomial/LinearMvExtension.lean
+++ b/ArkLib/Data/MvPolynomial/LinearMvExtension.lean
@@ -42,19 +42,19 @@ def linearMvExtension (p : Polynomial.degreeLT F (2 ^ m)) : MvPolynomial (Fin m)
   p.val.sum fun i a ↦ monomial (bitExpo i) a
 
 @[simp]
-lemma linearMvExtension_add_comm {p q : Polynomial.degreeLT F (2 ^ m)} : 
+lemma linearMvExtension_add_comm {p q : Polynomial.degreeLT F (2 ^ m)} :
   linearMvExtension (p + q) = linearMvExtension p + linearMvExtension q := by
   simp [linearMvExtension, Polynomial.sum_add_index]
 
 @[simp]
-lemma linearMvExtension_smul_comm {c : F} {p : Polynomial.degreeLT F (2 ^ m)} : 
+lemma linearMvExtension_smul_comm {c : F} {p : Polynomial.degreeLT F (2 ^ m)} :
   linearMvExtension (c • p) = c • linearMvExtension p := by
   simp only [linearMvExtension, SetLike.val_smul]
   rw [Polynomial.sum_smul_index _ _ _ (by simp)]
-  aesop 
-    (add simp 
+  aesop
+    (add simp
       [smul_monomial,
-        Polynomial.sum, 
+        Polynomial.sum,
         Finset.smul_sum])
 
 lemma bitExpo_apply (i : ℕ) (j : Fin m) :
@@ -64,14 +64,14 @@ lemma bitExpo_apply (i : ℕ) (j : Fin m) :
 lemma bitExpo_le_one (i : ℕ) (j : Fin m) :
   (bitExpo i : Fin m →₀ ℕ) j ≤ 1 := by aesop (add simp [bitExpo_apply])
 
-lemma linearMvExtension_degreeOf_lt {p : Polynomial.degreeLT F (2 ^ m)} {i : Fin m} : 
+lemma linearMvExtension_degreeOf_lt {p : Polynomial.degreeLT F (2 ^ m)} {i : Fin m} :
   MvPolynomial.degreeOf i (linearMvExtension p) ≤ 1 := by
-  have h_monomial_degrees {x} (hx : x ∈ p.val.support) : 
+  have h_monomial_degrees {x} (hx : x ∈ p.val.support) :
       (degreeOf i (monomial (bitExpo x) (p.val.coeff x))) ≤ 1 := by
     aesop (add simp [degreeOf_eq_sup, bitExpo_le_one])
-  have h_sum_degrees : 
-    (degreeOf i (p.val.sum fun i a ↦ monomial (bitExpo i) a)) ≤ 
-      (Finset.sup p.val.support 
+  have h_sum_degrees :
+    (degreeOf i (p.val.sum fun i a ↦ monomial (bitExpo i) a)) ≤
+      (Finset.sup p.val.support
         (fun x ↦ degreeOf i (monomial (bitExpo x) (p.val.coeff x)))) := by
     convert MvPolynomial.degreeOf_sum_le _ _ _
   exact h_sum_degrees.trans (Finset.sup_le @h_monomial_degrees)
@@ -79,7 +79,7 @@ lemma linearMvExtension_degreeOf_lt {p : Polynomial.degreeLT F (2 ^ m)} {i : Fin
 
 /-- The linear map that maps univariate polynomials of degree < 2ᵐ onto
     degree wise linear m-variate polynomials, sending
-    `aᵢ Xⁱ ↦ aᵢ ∏ⱼ Xⱼ^(bitⱼ(i))`, where `bitⱼ(i)` is the j-th binary digit of `(i mod 2ᵐ)`. 
+    `aᵢ Xⁱ ↦ aᵢ ∏ⱼ Xⱼ^(bitⱼ(i))`, where `bitⱼ(i)` is the j-th binary digit of `(i mod 2ᵐ)`.
     This is a linear map version. -/
 def linearMvExtensionLMap :
     Polynomial.degreeLT F (2^m) →ₗ[F] MvPolynomial (Fin m) F where
@@ -113,7 +113,7 @@ def powAlgHom :
 lemma powAlgHom_of_restrict_degree_natDegree {p : MvPolynomial.restrictDegree (Fin m) F 1} :
   (powAlgHom p.1).natDegree ≤ (2 ^ m - 1) := by
   have h_monomial_deg : ∀ d ∈ p.val.support, (∑ j : Fin m, d j * 2 ^ j.val) ≤ 2 ^ m - 1 := by
-    have h_deg {d} (hd : d ∈ p.val.support) : 
+    have h_deg {d} (hd : d ∈ p.val.support) :
       (∑ j : Fin m, d j * 2 ^ j.val) ≤ ∑ j : Fin m, 2 ^ j.val := by
       have h_deg {j : Fin m} : d j ≤ 1 := by
         have := p.2
@@ -123,21 +123,21 @@ lemma powAlgHom_of_restrict_degree_natDegree {p : MvPolynomial.restrictDegree (F
         exact this d (by aesop) j
       exact Finset.sum_le_sum fun i _ ↦ mul_le_of_le_one_left (Nat.zero_le _) h_deg
     convert (fun d hd ↦ h_deg (d := d) hd) using 3
-    exact Nat.sub_eq_of_eq_add 
-      (by exact Nat.recOn m (by norm_num) fun n ih ↦ 
+    exact Nat.sub_eq_of_eq_add
+      (by exact Nat.recOn m (by norm_num) fun n ih ↦
         by simp [Fin.sum_univ_castSucc, pow_succ'] at *; linarith)
-  exact le_trans (Polynomial.natDegree_sum_le _ _) <| Finset.sup_le <| fun d hd ↦ by 
+  exact le_trans (Polynomial.natDegree_sum_le _ _) <| Finset.sup_le <| fun d hd ↦ by
     specialize h_monomial_deg d hd
     simp_all only [Finsupp.mem_support_iff, ne_eq, Polynomial.algebraMap_eq, Finsupp.prod_pow,
-      Function.comp_apply, Polynomial.natDegree_le_iff_coeff_eq_zero, Polynomial.coeff_C_mul] 
+      Function.comp_apply, Polynomial.natDegree_le_iff_coeff_eq_zero, Polynomial.coeff_C_mul]
     simp_all only [←pow_mul', Finset.prod_pow_eq_pow_sum, Polynomial.coeff_X_pow, mul_ite, mul_one,
       mul_zero, ite_eq_right_iff, imp_false]
     exact fun N hN ↦ ne_of_gt (lt_of_le_of_lt h_monomial_deg hN)
 
 lemma powAlgHom_natDegree {p : MvPolynomial (Fin m) F} :
   (powAlgHom p).natDegree ≤ p.totalDegree * (2 ^ m - 1) := by
-  have h_deg {d} (hd : d ∈ p.support) : 
-    (powAlgHom (MvPolynomial.monomial d (p.coeff d))).natDegree ≤ 
+  have h_deg {d} (hd : d ∈ p.support) :
+    (powAlgHom (MvPolynomial.monomial d (p.coeff d))).natDegree ≤
         d.sum (fun i k => 2^i.val * k) := by
     simp only [
       powAlgHom,
@@ -149,23 +149,23 @@ lemma powAlgHom_natDegree {p : MvPolynomial (Fin m) F} :
       exact le_trans (Polynomial.natDegree_prod_le _ _) <| by
         simp only [←pow_mul, Finsupp.sum]
         exact Finset.sum_le_sum fun i _ ↦ Polynomial.natDegree_X_pow_le _
-  have h_le {d} (hd : d ∈ p.support) : 
+  have h_le {d} (hd : d ∈ p.support) :
     (powAlgHom (MvPolynomial.monomial d (p.coeff d))).natDegree ≤ p.totalDegree * (2^m - 1) := by
-    have h_sum : d.sum (fun i k ↦ 2^i.val * k) ≤ 
+    have h_sum : d.sum (fun i k ↦ 2^i.val * k) ≤
       p.totalDegree * (2^m - 1) := by
-      have h_sum : d.sum (fun i k ↦ 2^i.val * k) ≤ 
+      have h_sum : d.sum (fun i k ↦ 2^i.val * k) ≤
         d.sum (fun _ k => k) * (2^m - 1) := by
         rw [Finsupp.sum, Finsupp.sum, Finset.sum_mul _ _ _]
-        exact Finset.sum_le_sum fun i hi ↦ by 
-          rw [mul_comm] 
-          exact Nat.mul_le_mul_left _ 
+        exact Finset.sum_le_sum fun i hi ↦ by
+          rw [mul_comm]
+          exact Nat.mul_le_mul_left _
             (Nat.le_sub_one_of_lt (pow_lt_pow_right₀ (by decide) (Fin.is_lt i)))
-      exact h_sum.trans 
+      exact h_sum.trans
         (Nat.mul_le_mul_right _ (Finset.le_sup (f := fun s ↦ s.sum fun x k ↦ k) hd))
     exact le_trans (h_deg hd) h_sum
-  have h_sum_le : (powAlgHom p).natDegree ≤ 
+  have h_sum_le : (powAlgHom p).natDegree ≤
     Finset.sup p.support (fun d ↦ (powAlgHom (MvPolynomial.monomial d (p.coeff d))).natDegree) := by
-    have h_sum : powAlgHom p = 
+    have h_sum : powAlgHom p =
       ∑ d ∈ p.support, powAlgHom (MvPolynomial.monomial d (p.coeff d)) := by
       rw [MvPolynomial.as_sum p, map_sum]
       simp [MvPolynomial.support_sum_monomial_coeff]

--- a/ArkLib/Data/Polynomial/Indicator.lean
+++ b/ArkLib/Data/Polynomial/Indicator.lean
@@ -11,12 +11,12 @@ import Mathlib.Tactic.Cases
 import Mathlib.Tactic.LinearCombination'
 
 /-! This module is mostly needed from proving lemma 4.9
-  from [ACFY24] but we thought it might be useful for 
-  something else as well. 
+  from [ACFY24] but we thought it might be useful for
+  something else as well.
 
 ## References
 
-* [Arnon, G., Chiesa, A., Fenzi, G., Yogev, E., 
+* [Arnon, G., Chiesa, A., Fenzi, G., Yogev, E.,
   *STIR: Reed–Solomon Proximity Testing with Fewer Queries*][ACFY24]
 -/
 
@@ -24,20 +24,20 @@ namespace Polynomial
 
 section
 
-open Polynomial Polynomial.Bivariate 
+open Polynomial Polynomial.Bivariate
 
 variable {ι F : Type*} [Field F] [DecidableEq F]
 
 /-- The indicator polynomial is a univariate polynomial
-  `I(X)` of the minimal degree 
+  `I(X)` of the minimal degree
   that takes the value `1` on a given finset `pos`
   and the value `0` on `neg \ pos`. -/
 noncomputable def indicator (pos neg : Finset F) : F[X] :=
-  Lagrange.interpolate (pos ∪ neg) id 
-    (fun x ↦ if x ∈ pos then 1 else 0) 
+  Lagrange.interpolate (pos ∪ neg) id
+    (fun x ↦ if x ∈ pos then 1 else 0)
 
-/-- The indicator polynomial is a constant zero polynomial 
-  if the set `pos` is empty. 
+/-- The indicator polynomial is a constant zero polynomial
+  if the set `pos` is empty.
 
   Note, `indicator ∅ ∅ = 0` too! -/
 @[simp]
@@ -48,113 +48,113 @@ lemma indicator_eq_0_of_pos_empty {neg : Finset F} :
   if the set `neg` is empty while `pos` is not. -/
 lemma indicator_eq_1_of_neg_empty_empty_of_pos_nonempty
   {pos : Finset F}
-  (h_pos : pos.Nonempty) : 
-  indicator pos ∅ = 1 := by 
+  (h_pos : pos.Nonempty) :
+  indicator pos ∅ = 1 := by
   unfold indicator
   rw [Finset.nonempty_iff_ne_empty] at h_pos
   apply Polynomial.eq_of_degree_sub_lt_of_eval_finset_eq (pos ∪ ∅) _ _
   · apply lt_of_le_of_lt (Polynomial.degree_sub_le _ _) (max_lt _ _)
-    · convert Lagrange.degree_interpolate_lt _ _ 
+    · convert Lagrange.degree_interpolate_lt _ _
       aesop
     · simpa using Finset.card_pos.mpr (Finset.nonempty_of_ne_empty h_pos)
-  · have {x} {y} (hy : y ∈ pos.erase x) : 
-      (x - y)⁻¹ * (x - y) = 1 := 
+  · have {x} {y} (hy : y ∈ pos.erase x) :
+      (x - y)⁻¹ * (x - y) = 1 :=
         inv_mul_cancel₀ (sub_ne_zero_of_ne (by aesop))
-    aesop 
-      (add simp 
-        [Polynomial.eval_prod, 
+    aesop
+      (add simp
+        [Polynomial.eval_prod,
           Finset.prod_eq_zero_iff,
           Lagrange.basis,
-          Lagrange.basisDivisor, 
-          Finset.prod_eq_one]) 
-      (add safe [(by rw 
-        [Polynomial.eval_finset_sum, 
+          Lagrange.basisDivisor,
+          Finset.prod_eq_one])
+      (add safe [(by rw
+        [Polynomial.eval_finset_sum,
         Finset.sum_eq_single x])])
-    
-/-- If `pos` is non-empty then the indicator polynomial is the constant 
+
+/-- If `pos` is non-empty then the indicator polynomial is the constant
   zero polynomial. -/
 lemma indicator_ne_zero_of_pos_nonempty {pos neg : Finset F}
   (h : pos.Nonempty) :
-  indicator pos neg ≠ 0 := by 
+  indicator pos neg ≠ 0 := by
   unfold indicator
-  intro contra 
+  intro contra
   obtain ⟨x, hx⟩ := h
-  have := congr_arg (Polynomial.eval x) contra 
+  have := congr_arg (Polynomial.eval x) contra
   simp only [Lagrange.interpolate_apply, MonoidWithZeroHom.map_ite_one_zero, ite_mul, one_mul,
     zero_mul, Finset.sum_ite_mem, Finset.union_inter_cancel_left, eval_zero] at this
-  rw [Polynomial.eval_finset_sum, Finset.sum_eq_single x] at this 
-    <;> aesop 
-    (add simp 
-      [Lagrange.basis, 
-       sub_eq_zero, 
+  rw [Polynomial.eval_finset_sum, Finset.sum_eq_single x] at this
+    <;> aesop
+    (add simp
+      [Lagrange.basis,
+       sub_eq_zero,
        Finset.prod_eq_zero_iff,
        Finset.mem_erase_of_ne_of_mem,
        Finset.mem_union_left,
-       Lagrange.basisDivisor, 
+       Lagrange.basisDivisor,
        Polynomial.eval_prod])
     (add safe (by apply Finset.prod_eq_zero))
-    
+
 /-- Indicator evaluated on an element of `pos` is equal to 1. -/
 lemma indicator_eq_1_on_pos {pos neg : Finset F} {x : F}
   (h_pos : x ∈ pos) :
-  (indicator pos neg).eval x = 1 := by 
+  (indicator pos neg).eval x = 1 := by
   unfold indicator
-  have {x} {y} (hy : y ∈ (pos ∪ neg).erase x) : 
-    (x - y)⁻¹ * (x - y) = 1 := 
+  have {x} {y} (hy : y ∈ (pos ∪ neg).erase x) :
+    (x - y)⁻¹ * (x - y) = 1 :=
       inv_mul_cancel₀ (sub_ne_zero_of_ne (by aesop))
   rw [Polynomial.eval]
-  aesop 
-      (add simp 
-        [Polynomial.eval_prod, 
-          Polynomial.eval₂_finset_sum, 
+  aesop
+      (add simp
+        [Polynomial.eval_prod,
+          Polynomial.eval₂_finset_sum,
           Lagrange.basis,
           Finset.prod_eq_zero_iff,
           Lagrange.basis,
-          Lagrange.basisDivisor, 
-          Finset.prod_eq_one]) 
+          Lagrange.basisDivisor,
+          Finset.prod_eq_one])
       (add safe [(by rw [Finset.sum_eq_single x])])
 
 /-- The indicator polynomial is zero on `neg \ pos`. -/
 lemma indicator_eq_0_on_neg_sub_pos {pos neg : Finset F} {x : F}
   (h_pos : x ∈ neg \ pos) :
-  (indicator pos neg).eval x = 0 := by 
+  (indicator pos neg).eval x = 0 := by
   have h_basis_zero : ∀ y ∈ pos, Polynomial.eval x (Lagrange.basis (pos ∪ neg) id y) = 0 := by
-    aesop 
+    aesop
       (add simp [Finset.mem_sdiff, Lagrange.basis, id_eq, eval_prod])
       (add safe [(by rw [Finset.prod_eq_zero])])
   aesop (add simp [indicator, Polynomial.eval_finset_sum, Finset.sum_eq_zero])
 
-/-- The degree of the indicator polynomial 
+/-- The degree of the indicator polynomial
   is less than `#(pos ∪ neg)`. -/
 lemma indicator_degree_lt {pos neg : Finset F} :
   (indicator pos neg).degree < (pos ∪ neg).card := by
-  unfold indicator 
+  unfold indicator
   exact Lagrange.degree_interpolate_lt _ (by simp)
 
-/-- The natDegree of the indicator polynomial 
+/-- The natDegree of the indicator polynomial
   is less than `#(pos ∪ neg)` when `pos` is non-empty. -/
 lemma indicator_natDegree_lt_of_pos_nonempty {pos neg : Finset F}
   (h : pos.Nonempty) :
   (indicator pos neg).natDegree < (pos ∪ neg).card := by
-  rw [Polynomial.natDegree_lt_iff_degree_lt 
+  rw [Polynomial.natDegree_lt_iff_degree_lt
         (indicator_ne_zero_of_pos_nonempty h)]
   exact indicator_degree_lt
 
-/-- The natDegree of the indicator polynomial 
+/-- The natDegree of the indicator polynomial
   is less than `#(pos ∪ neg)` when `neg` is non-empty. -/
 lemma indicator_natDegree_lt_of_neg_nonempty {pos neg : Finset F}
   (h : neg.Nonempty) :
   (indicator pos neg).natDegree < (pos ∪ neg).card := by
   by_cases hpos : pos.Nonempty
   · exact indicator_natDegree_lt_of_pos_nonempty hpos
-  · aesop 
+  · aesop
 
 /-- If `pos` is a subset of `neg` then the degree of
   the indicator polynomial is less than `#neg`. -/
 lemma indicator_degree_lt_of_pos_subset_neg {pos neg : Finset F}
   (h : pos ⊆ neg)
   :
-  (indicator pos neg).degree < neg.card := 
+  (indicator pos neg).degree < neg.card :=
     lt_of_lt_of_le indicator_degree_lt <| by
     rw [←Finset.union_eq_right] at h
     simp [h]
@@ -165,7 +165,7 @@ lemma indicator_natDegree_lt_of_pos_nonempty_of_pos_subset_neg {pos neg : Finset
   (h_nonEmpty : pos.Nonempty)
   (h : pos ⊆ neg) :
   (indicator pos neg).natDegree < neg.card := by
-  rw [Polynomial.natDegree_lt_iff_degree_lt 
+  rw [Polynomial.natDegree_lt_iff_degree_lt
         (indicator_ne_zero_of_pos_nonempty h_nonEmpty)]
   exact indicator_degree_lt_of_pos_subset_neg h
 
@@ -185,7 +185,7 @@ section SingletonIndicator
 
 variable {x : F}
 
-/-- A special case of an indicator polynomial. 
+/-- A special case of an indicator polynomial.
   The subset `pos` is a singleton `{x}`. -/
 noncomputable def singletonIndicator (x : F) (S : Finset F) : F[X]
   := indicator {x} S

--- a/ArkLib/Data/Polynomial/SplitFold.lean
+++ b/ArkLib/Data/Polynomial/SplitFold.lean
@@ -25,7 +25,7 @@ This file defines n-way splitting and folding operations on polynomials.
 
 When `n = 2`, this recovers the even/odd splitting: `splitNth f 2 0` gives the even
 coefficients and `splitNth f 2 1` gives the odd coefficients (after appropriate
-reindexing). 
+reindexing).
 
 -/
 
@@ -254,7 +254,7 @@ lemma splitNth_degree_le {n : ℕ} {f : 𝔽[X]} [inst : NeZero n] :
 lemma folding_polynomial_eq_sum_splitNth {𝔽 : Type} [Field 𝔽]
   {f : Polynomial 𝔽} {n : ℕ}
   [inst : NeZero n] :
-  FoldingPolynomial.foldingPolynomial (X ^ n) f = 
+  FoldingPolynomial.foldingPolynomial (X ^ n) f =
     ∑ i, C (splitNth f n i) * (X ^ i.val) := by
   symm
   apply FoldingPolynomial.folding_polynomial_is_unique'
@@ -263,8 +263,8 @@ lemma folding_polynomial_eq_sum_splitNth {𝔽 : Type} [Field 𝔽]
       rw [splitNth_def (f := f) (inst := inst)]
     rw [
       Polynomial.map_sum,
-      Polynomial.eval_finset_sum] 
-    simp only [Polynomial.map_mul, map_C, coe_compRingHom, Polynomial.map_pow, map_X, 
+      Polynomial.eval_finset_sum]
+    simp only [Polynomial.map_mul, map_C, coe_compRingHom, Polynomial.map_pow, map_X,
     eval_mul, eval_C, eval_pow, eval_X]
     simp only [comp]
     conv =>
@@ -292,7 +292,7 @@ lemma folding_polynomial_eq_sum_splitNth {𝔽 : Type} [Field 𝔽]
     apply Polynomial.natDegree_sum_le_of_forall_le
     intro i _
     apply Nat.le_trans Polynomial.natDegree_mul_le
-    rcases i with ⟨i, hi⟩ 
+    rcases i with ⟨i, hi⟩
     simp
     omega
 
@@ -301,11 +301,11 @@ lemma folding_polynomial_eq_sum_splitNth {𝔽 : Type} [Field 𝔽]
 lemma polyFold_eq_sum_of_splitNth {𝔽 : Type} [Field 𝔽]
   {f : 𝔽[X]} {n : ℕ} {r : 𝔽}
   [inst : NeZero n] :
-  FoldingPolynomial.polyFold f n r = 
+  FoldingPolynomial.polyFold f n r =
     ∑ i, C (r ^ i.val) * splitNth f n i := by
   simp only [FoldingPolynomial.polyFold, folding_polynomial_eq_sum_splitNth, map_pow]
   rw [Polynomial.eval_finset_sum]
-  simp only [eval_mul, eval_C, eval_pow, eval_X] 
+  simp only [eval_mul, eval_C, eval_pow, eval_X]
   conv =>
     lhs
     rhs

--- a/ArkLib/ProofSystem/BatchedFri/Security.lean
+++ b/ArkLib/ProofSystem/BatchedFri/Security.lean
@@ -91,9 +91,9 @@ def cosetEnum (s₀ : evalDomainSigma s ω i) (k_le_n : ∑ j', (s j').1 ≤ n)
           apply Finset.sum_le_sum_of_subset
           simp
       }) (by omega) (by {
-        rcases s₀ with ⟨s₀, hs₀⟩ 
+        rcases s₀ with ⟨s₀, hs₀⟩
         simp only
-        simp only [evalDomainSigma] at hs₀ 
+        simp only [evalDomainSigma] at hs₀
         rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at hs₀
         exact hs₀
       }) r.2
@@ -143,7 +143,7 @@ noncomputable def fin_equiv_coset (s₀ : evalDomainSigma s ω ↑i)
       subst h
       simp only [Nat.succ_eq_add_one, finRangeTo.eq_1, Fin.ofNat_eq_cast, Fin.val_natCast,
         evalDomainSigma, CosetFftDomain.subdomainNatReversed, CosetFftDomain.subdomainNat] at hs₀
-      rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at hs₀ 
+      rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at hs₀
       have hs₀ := CosetFftDomain.zero_is_not_in_domain hs₀
       simp at hs₀
   · rintro ⟨⟨y, h'⟩, h⟩
@@ -224,9 +224,9 @@ noncomputable def f_succ'
       s₀.1 ^ (2 ^ (s i).1) = s₀'.1 := by
     rcases s₀' with ⟨s₀', hs₀'⟩
     simp only [Fin.val_natCast]
-    simp only [evalDomainSigma] at hs₀' 
+    simp only [evalDomainSigma] at hs₀'
     rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain] at hs₀'
-    rw [CosetFftDomain.subdomainNatReversed_mem_of_eq 
+    rw [CosetFftDomain.subdomainNatReversed_mem_of_eq
       (ω := ω)
       (k := (∑ j' ∈ finRangeTo (k + 1) ↑i, (s j').1 + (s i).1))
       (by {
@@ -243,7 +243,7 @@ noncomputable def f_succ'
         apply (swap le_trans) k_le_n
         apply Finset.sum_le_sum_of_subset (by simp)
       })
-      hs₀' 
+      hs₀'
     rcases h with ⟨y, ⟨h1, h2⟩⟩
     exists ⟨y, by {
       rw [CosetFftDomain.mem_coset_finset_iff_mem_coset_domain]
@@ -288,7 +288,7 @@ noncomputable def correlated_agreement_density {ι : Type} [Fintype ι]
   haveI : Fintype Fₛ.carrier := Set.Finite.fintype (Set.toFinite _)
   haveI : Fintype V.carrier := Set.Finite.fintype (Set.toFinite _)
   let Fc := Fₛ.carrier.toFinset
-  let Vc := V.carrier.toFinset  
+  let Vc := V.carrier.toFinset
   (Fc ∩ Vc).card / Fc.card
 
 open Polynomial

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -721,4 +721,4 @@ theorem combine_theorem
         simp only [pow_zero, one_mul] at hv
         exact hv
 
-end Combine\n
+end Combine

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -29,7 +29,7 @@ open BigOperators Finset NNReal Code
 namespace Combine
 variable {m : ℕ}
          {F : Type*} [Field F] [DecidableEq F]
-         {ι : Type*} 
+         {ι : Type*}
 
 /-- Fact 4.10
   Geometric series formula in a field, for a unit `r : F`. -/
@@ -37,10 +37,10 @@ lemma geometric_sum_units {r : Fˣ} {a : ℕ} :
   ∑ j ∈ range (a + 1), (r ^ j : F) =
     if r = 1 then (a + 1 : F)
     else (1 - r ^ (a + 1)) / (1 - r) := by
-  have h_geo_series : ∀ r : F, r ≠ 1 → ∑ j ∈ Finset.range (a + 1), r ^ j = 
-    (1 - r ^ (a + 1)) / (1 - r) := 
-    fun r hr ↦ by 
-      rw [←neg_div_neg_eq, geom_sum_eq hr] 
+  have h_geo_series : ∀ r : F, r ≠ 1 → ∑ j ∈ Finset.range (a + 1), r ^ j =
+    (1 - r ^ (a + 1)) / (1 - r) :=
+    fun r hr ↦ by
+      rw [←neg_div_neg_eq, geom_sum_eq hr]
       ring
   aesop
 
@@ -59,7 +59,7 @@ omit [DecidableEq F] in
 @[simp]
 lemma combine_dstar_zero
   {φ : ι ↪ F} {r : F} {fs : Fin m → ι → F} {degs : Fin m → ℕ} :
-  combine φ 0 r fs degs = 
+  combine φ 0 r fs degs =
     ∑ i, (r ^ i.val) • fs i := by aesop (add simp [combine, ri])
 
 private lemma geom_sum_cases (q : F) (n : ℕ) :
@@ -86,9 +86,9 @@ lemma combine_eq_cases {F ι : Type*} [Field F] [DecidableEq F]
       else ∑ i, (ri dstar degs r i) * (fs i x) *  (dstar - degs i + 1) := by
   funext x
   simp only [combine]
-  split_ifs 
-  · aesop 
-      (add simp [geom_sum_cases]) 
+  split_ifs
+  · aesop
+      (add simp [geom_sum_cases])
       (add safe (by ring))
   · simp_all
 
@@ -96,14 +96,14 @@ open Finset
 open BigOperators
 
 private def block_size (dstar : ℕ) (degs : Fin m → ℕ) (i : Fin m) := dstar - degs i + 1
-private def block_start (dstar : ℕ) (degs : Fin m → ℕ) (i : Fin m) := 
+private def block_start (dstar : ℕ) (degs : Fin m → ℕ) (i : Fin m) :=
   ∑ j ∈ univ.filter (· < i), block_size dstar degs j
 private def total_terms (dstar : ℕ) (degs : Fin m → ℕ) := ∑ i, block_size dstar degs i
 
 private lemma block_start_monotone
   {dstar : ℕ} {degs : Fin m → ℕ} {i j : Fin m} (h : i ≤ j) :
   block_start dstar degs i ≤ block_start dstar degs j := by
-  have h_subset : 
+  have h_subset :
     Finset.filter (· < i) Finset.univ ⊆ Finset.filter (· < j) Finset.univ := by
       grind
   exact Finset.sum_le_sum_of_subset h_subset
@@ -114,31 +114,31 @@ private lemma block_start_zero
 
 private lemma block_start_filter_nonempty
   {dstar : ℕ} {degs : Fin m.succ → ℕ} {l : ℕ} :
-  (univ.filter (fun j ↦ block_start dstar degs j ≤ l)).Nonempty := by 
+  (univ.filter (fun j ↦ block_start dstar degs j ≤ l)).Nonempty := by
   exists 0
   aesop (add simp [block_start])
 
 private lemma block_idx_eq_max
   {dstar : ℕ} {degs : Fin m → ℕ}
   {i : Fin m} {j : Fin (block_size dstar degs i)} :
-  Finset.max 
-    {x | block_start dstar degs x ≤ block_start dstar degs i + j} = i := 
+  Finset.max
+    {x | block_start dstar degs x ≤ block_start dstar degs i + j} = i :=
   Function.swap le_antisymm (by norm_num [Finset.le_max]) <| by
   norm_num [Finset.le_max]
   intro a ha
   contrapose! ha
   exact lt_of_lt_of_le (Nat.add_lt_add_left (Fin.is_lt j) _) <| by
     unfold block_start block_size
-    have h : (Finset.univ.filter fun j ↦ j < a) = 
-      Finset.univ.filter (fun j ↦ j < i) ∪ {i} ∪ Finset.univ.filter (fun j ↦ i < j ∧ j < a) := by 
-      grind 
-    rw [h, 
-        Finset.sum_union (by 
-          aesop 
+    have h : (Finset.univ.filter fun j ↦ j < a) =
+      Finset.univ.filter (fun j ↦ j < i) ∪ {i} ∪ Finset.univ.filter (fun j ↦ i < j ∧ j < a) := by
+      grind
+    rw [h,
+        Finset.sum_union (by
+          aesop
             (add simp [Finset.disjoint_left])
-            (add safe (by grind))), 
-        Finset.sum_union (by simp)] 
-    simp 
+            (add safe (by grind))),
+        Finset.sum_union (by simp)]
+    simp
 
 omit [DecidableEq F] in
 set_option maxHeartbeats 0 in
@@ -156,26 +156,26 @@ private lemma combine_eq_flat
       | some i =>
         let k := L - block_start dstar degs i
         ri dstar degs r i * fs i x * (φ x * r) ^ k := by
-  have h_sum_reorganized : ∀ x : ι, 
-    ∑ L ∈ Finset.range (total_terms dstar degs), 
+  have h_sum_reorganized : ∀ x : ι,
+    ∑ L ∈ Finset.range (total_terms dstar degs),
       (let i_opt := Finset.max (Finset.univ.filter (block_start dstar degs · ≤ L))
-      match i_opt with 
-      | Option.none => 0 
-      | Option.some i => 
+      match i_opt with
+      | Option.none => 0
+      | Option.some i =>
         let k := L - block_start dstar degs i
-        ri dstar degs r i * fs i x * ((φ x) * r) ^ k) = 
-          ∑ i : Fin m, ∑ L ∈ Finset.range (block_size dstar degs i), 
+        ri dstar degs r i * fs i x * ((φ x) * r) ^ k) =
+          ∑ i : Fin m, ∑ L ∈ Finset.range (block_size dstar degs i),
             ri dstar degs r i * fs i x * ((φ x) * r) ^ L := by
     intro x
-    have h_partition : Finset.range (total_terms dstar degs) = 
-      Finset.biUnion 
-        Finset.univ 
-        (fun i => 
-          Finset.Ico 
-            (block_start dstar degs i) 
+    have h_partition : Finset.range (total_terms dstar degs) =
+      Finset.biUnion
+        Finset.univ
+        (fun i =>
+          Finset.Ico
+            (block_start dstar degs i)
             (block_start dstar degs i + block_size dstar degs i)) := by
       ext L
-      simp only [total_terms, block_size, mem_range, block_start, 
+      simp only [total_terms, block_size, mem_range, block_start,
                   mem_biUnion, mem_univ, mem_Ico, true_and]
       constructor
       · induction m with
@@ -183,11 +183,11 @@ private lemma combine_eq_flat
         | succ m ih =>
           intro hL
           by_cases h : L < ∑ x : Fin m, (dstar - degs (Fin.castSucc x) + 1)
-          · obtain ⟨ a, ha₁, ha₂ ⟩ := ih 
-              (fun i x => fs i.castSucc x) 
-              (fun i => degs i.castSucc) 
+          · obtain ⟨ a, ha₁, ha₂ ⟩ := ih
+              (fun i x => fs i.castSucc x)
+              (fun i => degs i.castSucc)
               h
-            exists (Fin.castSucc a) 
+            exists (Fin.castSucc a)
             constructor
             · simp_all only [forall_const, Fin.sum_univ_castSucc]
               convert ha₁ using 1
@@ -195,18 +195,18 @@ private lemma combine_eq_flat
                 Nat.add_eq_left, ite_eq_right_iff, Nat.add_eq_zero_iff, one_ne_zero, and_false,
                 imp_false, not_lt]
               exact Fin.le_last _
-            · aesop 
-                (add simp [Fin.sum_univ_castSucc, Finset.sum_filter]) 
+            · aesop
+                (add simp [Fin.sum_univ_castSucc, Finset.sum_filter])
                 (add safe (by grind))
           · exists (Fin.last m)
             constructor
             · simp_all only [forall_const, Fin.sum_univ_castSucc, not_lt]
-              rw [Finset.sum_filter, Fin.sum_univ_castSucc] 
+              rw [Finset.sum_filter, Fin.sum_univ_castSucc]
               aesop
             · simp_all [Fin.sum_univ_castSucc, Finset.sum_filter]
       · rintro ⟨i, hi⟩
         exact lt_of_lt_of_le hi.2 <| by
-          rw [←Finset.sum_sdiff 
+          rw [←Finset.sum_sdiff
                 (Finset.subset_univ (Finset.filter (· < i) Finset.univ)),
               add_comm]
           simp only [add_le_add_iff_right, Order.add_one_le_iff]
@@ -217,22 +217,22 @@ private lemma combine_eq_flat
     rw [h_partition, Finset.sum_biUnion]
     · exact Finset.sum_congr rfl (by {
         intro i _
-        apply Finset.sum_bij (fun L hL => L - block_start dstar degs i) 
-        · simp only [mem_Ico, mem_range, and_imp] 
-          exact fun a ha₁ ha₂ => by 
-            rw [tsub_lt_iff_left ha₁] 
+        apply Finset.sum_bij (fun L hL => L - block_start dstar degs i)
+        · simp only [mem_Ico, mem_range, and_imp]
+          exact fun a ha₁ ha₂ => by
+            rw [tsub_lt_iff_left ha₁]
             exact ha₂
         · simp only [mem_Ico, and_imp]
           intros
           omega
-        · simp only [mem_range, mem_Ico, exists_prop] 
-          exact fun b hb => 
-            ⟨block_start dstar degs i + b, 
-              ⟨by linarith, by linarith⟩, 
+        · simp only [mem_range, mem_Ico, exists_prop]
+          exact fun b hb =>
+            ⟨block_start dstar degs i + b,
+              ⟨by linarith, by linarith⟩,
               by simp +decide⟩
-        · simp only [mem_Ico, and_imp] 
+        · simp only [mem_Ico, and_imp]
           intro a ha₁ ha₂
-          rw [show Finset.max 
+          rw [show Finset.max
               (Finset.filter (block_start dstar degs · ≤ a) Finset.univ) = ↑i from ?_]
           apply le_antisymm
           · simp only [Finset.max, Finset.sup_le_iff, mem_filter, mem_univ, true_and,
@@ -241,11 +241,11 @@ private lemma combine_eq_flat
             contrapose! hj₁
             apply lt_of_lt_of_le ha₂
             unfold block_start block_size
-            rw [show (Finset.univ.filter fun k => k < j) = 
-                  Finset.univ.filter (fun k => k < i) ∪ 
-                      {i} ∪ Finset.univ.filter (fun k => i < k ∧ k < j) from ?_, 
+            rw [show (Finset.univ.filter fun k => k < j) =
+                  Finset.univ.filter (fun k => k < i) ∪
+                      {i} ∪ Finset.univ.filter (fun k => i < k ∧ k < j) from ?_,
                 Finset.sum_union, Finset.sum_union] <;> norm_num
-            · exact Finset.disjoint_left.mpr fun x hx₁ hx₂ ↦ 
+            · exact Finset.disjoint_left.mpr fun x hx₁ hx₂ ↦
                 lt_asymm (Finset.mem_filter.mp hx₁ |>.2) (Finset.mem_filter.mp hx₂ |>.2.1)
             · grind
           · simp only [Finset.max, WithBot.bot_lt_coe, Finset.le_sup_iff, mem_filter, mem_univ,
@@ -253,48 +253,48 @@ private lemma combine_eq_flat
             exact ⟨i, ha₁, le_rfl⟩
       })
     · intro i _ j _ hij
-      have h_disjoint : 
-        block_start dstar degs j ≥ 
-          block_start dstar degs i + block_size dstar degs i ∨ 
-        block_start dstar degs i ≥ 
+      have h_disjoint :
+        block_start dstar degs j ≥
+          block_start dstar degs i + block_size dstar degs i ∨
+        block_start dstar degs i ≥
           block_start dstar degs j + block_size dstar degs j := by
-        cases lt_or_gt_of_ne hij 
+        cases lt_or_gt_of_ne hij
         · simp_all only [block_start, block_size, coe_univ, Set.mem_univ, ne_eq, ge_iff_le]
-          left 
-          apply 
-            (Function.swap le_trans <| 
-              Finset.sum_le_sum_of_subset 
-                (show Finset.filter (· < i) Finset.univ ∪ {i} ⊆ 
+          left
+          apply
+            (Function.swap le_trans <|
+              Finset.sum_le_sum_of_subset
+                (show Finset.filter (· < i) Finset.univ ∪ {i} ⊆
                   Finset.filter (· < j) Finset.univ from _))
           · rw [Finset.sum_union] <;> simp [*, Finset.sum_singleton]
           · simp only [union_singleton, subset_iff, mem_insert, mem_filter, mem_univ, true_and,
             forall_eq_or_imp, *]
             exact fun a ha ↦ lt_trans ha ‹_›
-        · simp_all only [block_start, block_size] 
-          rw [show (Finset.univ.filter fun x => x < i) = 
+        · simp_all only [block_start, block_size]
+          rw [show (Finset.univ.filter fun x => x < i) =
             Finset.univ.filter (· < j) ∪ {j} ∪
-              (Finset.univ.filter (· < i) \ 
-                (Finset.univ.filter (· < j) ∪ {j})) from ?_, 
-            Finset.sum_union, Finset.sum_union] 
-          · simp 
-          · simp 
+              (Finset.univ.filter (· < i) \
+                (Finset.univ.filter (· < j) ∪ {j})) from ?_,
+            Finset.sum_union, Finset.sum_union]
+          · simp
+          · simp
           · exact fun x hx₁ hx₂ a ha ↦ by
-              specialize hx₁ ha 
+              specialize hx₁ ha
               specialize hx₂ ha
               simp_all
           · simp only [union_singleton, union_sdiff_self_eq_union, insert_union, mem_union,
             mem_filter, mem_univ, lt_self_iff_false, and_false, and_self, or_true, insert_eq_of_mem,
             right_eq_union, *]
-            exact fun x hx ↦ Finset.mem_filter.mpr 
-              ⟨Finset.mem_univ _, lt_trans (Finset.mem_filter.mp hx |>.2) ‹_›⟩ 
-      cases h_disjoint 
-      · exact Finset.disjoint_left.mpr fun x hx₁ hx₂ ↦ by 
-          linarith [Finset.mem_Ico.mp hx₁, Finset.mem_Ico.mp hx₂] 
-      · exact Finset.disjoint_left.mpr fun x hx₁ hx₂ ↦ by 
+            exact fun x hx ↦ Finset.mem_filter.mpr
+              ⟨Finset.mem_univ _, lt_trans (Finset.mem_filter.mp hx |>.2) ‹_›⟩
+      cases h_disjoint
+      · exact Finset.disjoint_left.mpr fun x hx₁ hx₂ ↦ by
+          linarith [Finset.mem_Ico.mp hx₁, Finset.mem_Ico.mp hx₂]
+      · exact Finset.disjoint_left.mpr fun x hx₁ hx₂ ↦ by
           linarith [ Finset.mem_Ico.mp hx₁, Finset.mem_Ico.mp hx₂ ];
   ext x
   exact (by
-    convert h_sum_reorganized x |> Eq.symm using 2 
+    convert h_sum_reorganized x |> Eq.symm using 2
     simp [combine, Finset.mul_sum _ _ _]
     ring!)
 
@@ -304,8 +304,8 @@ private lemma combine_eq_flat'
   (fs : Fin m.succ → ι → F) (degs : Fin m.succ → ℕ) :
   combine φ dstar r fs degs = fun x ↦
     ∑ l : Fin (total_terms dstar degs),
-      let i := Finset.max' 
-          (univ.filter (block_start dstar degs · ≤ l)) 
+      let i := Finset.max'
+          (univ.filter (block_start dstar degs · ≤ l))
           block_start_filter_nonempty
       let k := l - block_start dstar degs i
       ri dstar degs r i * fs i x * (φ x * r) ^ k := by
@@ -313,7 +313,7 @@ private lemma combine_eq_flat'
   ext x
   rw [Finset.sum_fin_eq_sum_range]
   exact Finset.sum_equiv (Equiv.refl _) (by simp) <| fun i hi ↦ by
-    have h : Finset.max {j | block_start dstar degs j ≤ i} = 
+    have h : Finset.max {j | block_start dstar degs j ≤ i} =
       Finset.max' {j | block_start dstar degs j ≤ i} block_start_filter_nonempty := by
         aesop (add simp [Finset.max, Finset.max'])
     aesop
@@ -324,75 +324,75 @@ private lemma combine_eq_flat''
   (fs : Fin m.succ → ι → F) (degs : Fin m.succ → ℕ) :
   combine φ dstar r fs degs = fun x ↦
     ∑ l : Fin (total_terms dstar degs),
-      let i := Finset.max' 
-          (univ.filter (block_start dstar degs · ≤ l)) 
+      let i := Finset.max'
+          (univ.filter (block_start dstar degs · ≤ l))
           block_start_filter_nonempty
       let k := l - block_start dstar degs i
-      r ^ (i + ∑ j < i, (dstar - degs j)) * 
+      r ^ (i + ∑ j < i, (dstar - degs j)) *
         fs i x * (φ x * r) ^ k := by
   aesop (add safe combine_eq_flat')
-     
+
 omit [DecidableEq F] in
 private lemma combine_eq_flat'''
   (φ : ι ↪ F) (dstar : ℕ) (r : F)
   (fs : Fin m.succ → ι → F) (degs : Fin m.succ → ℕ) :
   combine φ dstar r fs degs = fun x ↦
     ∑ l : Fin (total_terms dstar degs),
-      (r ^ l.val) *      
-      (let i := Finset.max' 
-          (univ.filter (block_start dstar degs · ≤ l)) 
+      (r ^ l.val) *
+      (let i := Finset.max'
+          (univ.filter (block_start dstar degs · ≤ l))
           block_start_filter_nonempty
       let k := l - block_start dstar degs i
-      fs i x * (φ x) ^ k) := by 
-  have h_block : 
-    ∀ l : Fin (Combine.total_terms dstar degs), 
-      ∃ i : Fin m.succ, 
-        Combine.block_start dstar degs i ≤ l ∧ 
-          ∀ j : Fin m.succ, Combine.block_start dstar degs j ≤ l → j ≤ i := 
-        fun l ↦ by 
-        use (Finset.max' 
+      fs i x * (φ x) ^ k) := by
+  have h_block :
+    ∀ l : Fin (Combine.total_terms dstar degs),
+      ∃ i : Fin m.succ,
+        Combine.block_start dstar degs i ≤ l ∧
+          ∀ j : Fin m.succ, Combine.block_start dstar degs j ≤ l → j ≤ i :=
+        fun l ↦ by
+        use (Finset.max'
           (Finset.univ.filter (Combine.block_start dstar degs · ≤ l))
           ⟨0, by simp [block_start]⟩)
         constructor
-        · exact Finset.mem_filter.mp 
-            (Finset.max'_mem (Finset.univ.filter  
-              (Combine.block_start dstar degs · ≤ l)) _) |>.2 
+        · exact Finset.mem_filter.mp
+            (Finset.max'_mem (Finset.univ.filter
+              (Combine.block_start dstar degs · ≤ l)) _) |>.2
         · aesop (add safe Finset.le_max')
   convert Combine.combine_eq_flat'' φ dstar r fs degs using 1
   funext x
   exact Finset.sum_congr rfl <| fun l _ ↦ by
     obtain ⟨i, hi, hi'⟩ := h_block l
-    have hi_eq : (Finset.max' 
-      (filter (Combine.block_start dstar degs · ≤ l) Finset.univ) 
-      Combine.block_start_filter_nonempty) = i := 
-        le_antisymm 
-          (by simp_all [Finset.max']) 
+    have hi_eq : (Finset.max'
+      (filter (Combine.block_start dstar degs · ≤ l) Finset.univ)
+      Combine.block_start_filter_nonempty) = i :=
+        le_antisymm
+          (by simp_all [Finset.max'])
           (by aesop (add simp [Finset.max']))
     rw [hi_eq, ←Nat.add_sub_of_le hi]
     ring_nf
     simp only [block_start, Nat.succ_eq_add_one, block_size, sum_add_distrib, sum_const,
       smul_eq_mul, mul_comm, one_mul, add_tsub_cancel_left, mul_assoc, mul_left_comm,
       mul_eq_mul_left_iff]
-    rw [show filter _ _ = Finset.Iio i by aesop] 
+    rw [show filter _ _ = Finset.Iio i by aesop]
     aesop (add safe (by ring))
 
 omit [DecidableEq F] in
 private lemma combine_eq_flat_final
   (φ : ι ↪ F) (dstar : ℕ) (r : F) (fs : Fin m → ι → F) (degs : Fin m → ℕ) :
-  combine φ dstar r fs degs = 
+  combine φ dstar r fs degs =
     ∑ l : Fin (total_terms dstar degs),
       r ^ (l : ℕ) • fun (x : ι) ↦ (
         let i : WithBot (Fin m) := Finset.max (univ.filter (block_start dstar degs · ≤ l))
         i.elim (0 : F) fun i ↦
           let k := l - block_start dstar degs i
-          fs i x * (φ x) ^ k) := 
+          fs i x * (φ x) ^ k) :=
   match m with
   | 0 => by aesop (add simp Option.elim)
   | Nat.succ m => by
     have h {l : Fin (total_terms dstar degs)} :
-      Finset.max {j | block_start dstar degs j ≤ ↑l} = 
+      Finset.max {j | block_start dstar degs j ≤ ↑l} =
         Finset.max' {j | block_start dstar degs j ≤ ↑l}
-          block_start_filter_nonempty := by 
+          block_start_filter_nonempty := by
             aesop (add simp [Finset.max, Finset.max'])
     aesop (add simp [Option.elim, combine_eq_flat'''])
 
@@ -414,11 +414,11 @@ lemma degreeCor_eq {F : Type u_1} [Field F] [DecidableEq F] {ι : Type u_2} (φ 
     then f x * (1 - q^(dstar - degree + 1)) / (1 - q)
     else f x * (dstar - degree + 1) := by
   convert congr_arg _ (geom_sum_cases (φ x * r) (dstar - degree)) using 1
-  rw [Nat.cast_add, Nat.cast_sub hd, Nat.cast_one] 
+  rw [Nat.cast_add, Nat.cast_sub hd, Nat.cast_one]
   split_ifs <;> ring
 
 variable {F : Type} [Field F] [Fintype F] [DecidableEq F]
-         {ι : Type} [Fintype ι] 
+         {ι : Type} [Fintype ι]
 
 open scoped NNReal NNRat in
 private lemma glorious_lemma
@@ -427,8 +427,8 @@ private lemma glorious_lemma
   (hδLt : δ < (min (1 - NNReal.sqrt rho)
     (1 - rho - 1 / (↑m))))
   (hrho : rho = n / (↑m : ℚ≥0)) :
-  ↑rho + 1 / ↑(m) < 1 - δ := by 
-  all_goals first | infer_instance | simp_all +decide [lt_tsub_iff_left] 
+  ↑rho + 1 / ↑(m) < 1 - δ := by
+  all_goals first | infer_instance | simp_all +decide [lt_tsub_iff_left]
   ring_nf at *
   exact hδLt.2.trans_le' (by norm_cast)
 
@@ -436,11 +436,11 @@ private lemma even_more_glorious_lemma
   {n m : ℕ}
   {δ : ℝ≥0}
   (hm : 0 < m)
-  (h : ↑n / ↑(m) + (↑(m))⁻¹ < 1 - δ) : ↑(n + 1) < (1 - δ) * m := by 
+  (h : ↑n / ↑(m) + (↑(m))⁻¹ < 1 - δ) : ↑(n + 1) < (1 - δ) * m := by
  rw [← div_lt_iff₀ (by positivity)]
  convert h using 1
  push_cast
- ring   
+ ring
 
 set_option maxHeartbeats 0 in
 omit [DecidableEq F] [Fintype F] in
@@ -459,18 +459,18 @@ lemma master_lemma
   (hv_eval : ∀ i j, ∀ x ∈ S, (v i j).eval (φ x) = (φ x) ^ j.val * (fs i x))
   (i : Fin m)
   (j : Fin (block_size dstar degs i)) :
-  (v i j).degree < degs i + j := by 
+  (v i j).degree < degs i + j := by
   have hlt : dstar < Fintype.card ι := by
     by_contra contra
-    aesop 
+    aesop
       (add simp [ReedSolomon.rateOfLinearCode_eq_min_div, min_eq_right])
-  rcases j with ⟨j, hj⟩   
+  rcases j with ⟨j, hj⟩
   simp only [block_size] at hj
   simp only [gt_iff_lt]
   generalize hj': (dstar - degs i) - j = j'
   revert j
   induction j' with
-  | zero => 
+  | zero =>
     intro j hj hj'
     conv_rhs =>
       rw [show j = (dstar - degs i) by omega]
@@ -479,30 +479,30 @@ lemma master_lemma
         ←WithBot.coe_natCast, ←WithBot.coe_add, ←Nat.cast_add,
         Nat.add_sub_of_le (hdegs _)]
     exact hv_deg i ⟨j, hj⟩
-  | succ j' ih => 
-    intro j hj hj' 
+  | succ j' ih =>
+    intro j hj hj'
     have hj' : j = dstar - degs i - j' - 1 := by omega
     have h_fin : j + 1 < dstar - degs i + 1 := by omega
     specialize ih (j + 1) h_fin (by omega)
-    let q : Polynomial F := Polynomial.X * v i ⟨j, hj⟩ 
+    let q : Polynomial F := Polynomial.X * v i ⟨j, hj⟩
     have hq_deg : q.degree < dstar + 1 := by
       rw [WithBot.lt_def]
       by_cases hv: v i ⟨j, hj⟩ = 0
       · aesop
-      · right 
+      · right
         simp only [Polynomial.degree_mul, Polynomial.degree_X, q]
         rw [Polynomial.degree_eq_natDegree hv]
         exists (1 + (v i ⟨j ,hj⟩).natDegree)
-        aesop 
+        aesop
           (add unsafe (by rw [add_comm]))
           (add unsafe forward [Nat.add_lt_add_right])
           (add simp [Polynomial.natDegree_lt_iff_degree_lt])
     have hq_coincide :
       ∀ x ∈ S, q.eval (φ x) = (v i ⟨j + 1, h_fin⟩).eval (φ x) := by
-      aesop 
+      aesop
         (add simp [q])
         (add safe (by ring_nf))
-    have hq_coincide := 
+    have hq_coincide :=
       Polynomial.eq_of_eval_eq_degree
         (q := v i ⟨j + 1, h_fin⟩)
         hq_deg (lt_trans (hv_deg _ _) <| by
@@ -513,17 +513,17 @@ lemma master_lemma
         ) (Finset.image φ S) (by {
           simp only [Nat.cast_id, ge_iff_le, Order.add_one_le_iff]
           rw [Finset.card_image_of_injective _ (fun x y hxy ↦ by aesop)]
-          have h : ↑(rate (code φ dstar)) + 1 / ↑(Fintype.card ι) < 1 - δ := 
-            glorious_lemma 
-              (by simpa using hδLt)  
+          have h : ↑(rate (code φ dstar)) + 1 / ↑(Fintype.card ι) < 1 - δ :=
+            glorious_lemma
+              (by simpa using hδLt)
               (by {
                 simp only [rate]
                 rfl
               })
-          have h := 
-            le_trans 
+          have h :=
+            le_trans
               (le_of_lt <|
-                even_more_glorious_lemma (m := Fintype.card ι) 
+                even_more_glorious_lemma (m := Fintype.card ι)
                   (by simp) (by {
                     rw [ReedSolomon.rateOfLinearCode_eq_min_div,
                         min_eq_left (by omega)] at h
@@ -538,7 +538,7 @@ lemma master_lemma
     simp only [Polynomial.degree_mul, Polynomial.degree_X, WithBot.coe_add, WithBot.coe_one] at ih
     rw [←add_assoc, add_comm 1] at ih
     exact (WithBot.add_lt_add_iff_right (by simp)).mp ih
-        
+
 set_option maxHeartbeats 0 in
 open LinearCode Classical ProbabilityTheory ReedSolomon STIR in
 /-- Lemma 4.13
@@ -556,12 +556,12 @@ theorem combine_theorem
   (hProb : Pr_{ let r ← $ᵖ F}[δᵣ((combine φ dstar r fs degs), (code φ dstar)) ≤ δ] >
     (m * (dstar + 1) - ∑ i, degs i - 1) * ProximityGap.errorBound δ dstar φ) :
     ∃ S : Finset ι, S.card ≥ (1 - δ) * (Fintype.card ι) ∧
-      ∃ v : Fin m → ι → F, ∀ i, 
-        v i ∈ (code φ (degs i)) ∧ 
+      ∃ v : Fin m → ι → F, ∀ i,
+        v i ∈ (code φ (degs i)) ∧
           S ⊆ Finset.filter (fun j => v i j = fs i j) Finset.univ
     := by
   by_cases hempty : Fintype.card ι = 0
-  · exists ∅ 
+  · exists ∅
     simp only [card_empty, CharP.cast_eq_zero, hempty, mul_zero, ge_iff_le, Std.le_refl,
       empty_subset, and_true, true_and]
     rw [Fintype.card_eq_zero_iff] at hempty
@@ -572,31 +572,31 @@ theorem combine_theorem
     simp only [zero_mem, map_zero, true_and]
     ext j
     exact (False.elim <| hempty.1 j)
-  · generalize htotal: total_terms dstar degs = total 
+  · generalize htotal: total_terms dstar degs = total
     rw [Fintype.card_eq_zero_iff, not_isEmpty_iff] at hempty
     rcases total with _ | total
     · rcases m with _ | m
-      · aesop 
+      · aesop
           (add simp [total_terms, block_size])
-          (add safe (by exists Finset.univ)) 
+          (add safe (by exists Finset.univ))
       · aesop (add simp [total_terms, block_size])
-    · have proximity_gap := 
-        @ProximityGap.correlatedAgreement_affine_curves ι _ _ F _ _ _ 
+    · have proximity_gap :=
+        @ProximityGap.correlatedAgreement_affine_curves ι _ _ F _ _ _
           (total_terms dstar degs - 1) dstar φ δ (le_of_lt <| by
             aesop (add simp [lt_min_iff, ReedSolomon.sqrtRate]))
       simp only [ProximityGap.δ_ε_correlatedAgreementCurves] at proximity_gap
-      specialize proximity_gap 
+      specialize proximity_gap
           (fun l (x : ι) ↦ (
-            let i : WithBot (Fin m) := 
+            let i : WithBot (Fin m) :=
               Finset.max (univ.filter (block_start dstar degs · ≤ l))
             i.elim (0 : F) fun i ↦
               let k := l - block_start dstar degs i
-              fs i x * (φ x) ^ k                     
+              fs i x * (φ x) ^ k
           ))
           (by {
             simp only [bind_pure_comp, Functor.map, PMF.bind_apply,
-              PMF.uniformOfFintype_apply, 
-              tsum_fintype, Function.comp_apply, PMF.pure_apply, 
+              PMF.uniformOfFintype_apply,
+              tsum_fintype, Function.comp_apply, PMF.pure_apply,
               eq_iff_iff, true_iff, mul_ite, mul_one,
               mul_zero, gt_iff_lt] at hProb
             conv at hProb =>
@@ -605,24 +605,24 @@ theorem combine_theorem
               ext x
               rw [combine_eq_flat_final φ dstar x]
             simp only [bind_pure_comp, Functor.map, PMF.bind_apply,
-              PMF.uniformOfFintype_apply, 
-              tsum_fintype, Function.comp_apply, PMF.pure_apply, 
+              PMF.uniformOfFintype_apply,
+              tsum_fintype, Function.comp_apply, PMF.pure_apply,
               eq_iff_iff, true_iff, mul_ite, mul_one,
               mul_zero, gt_iff_lt]
             apply lt_of_le_of_lt
-              (b := ((↑m : ENNReal) * (↑dstar + 1) - ↑(∑ i, degs i) - 1) * 
+              (b := ((↑m : ENNReal) * (↑dstar + 1) - ↑(∑ i, degs i) - 1) *
                       ↑(ProximityGap.errorBound δ dstar φ))
-            · apply mul_le_mul_left 
-              rw [htotal, add_tsub_cancel_right, 
+            · apply mul_le_mul_left
+              rw [htotal, add_tsub_cancel_right,
                   Nat.cast_sum, mul_add, mul_one,
                   show (↑m : ENNReal) * ↑dstar
                     = ∑ x : Fin m, ↑dstar by simp,
                   show (↑m : ENNReal) = ∑ x : Fin m, 1 by simp,
-                  ←Finset.sum_add_distrib, 
-                  show ∑ x : Fin m, ((↑dstar : ENNReal) + 1) - ∑ x, ↑(degs x) 
-                    = ↑(∑ x : Fin m, (dstar + 1)) - ↑(∑ x, degs x) 
+                  ←Finset.sum_add_distrib,
+                  show ∑ x : Fin m, ((↑dstar : ENNReal) + 1) - ∑ x, ↑(degs x)
+                    = ↑(∑ x : Fin m, (dstar + 1)) - ↑(∑ x, degs x)
                       by simp; ring_nf,
-                  ←ENNReal.natCast_sub, 
+                  ←ENNReal.natCast_sub,
                   ←Finset.sum_tsub_distrib _ (fun x _ ↦
                     le_trans (hdegs x) (by omega))]
               conv =>
@@ -641,43 +641,43 @@ theorem combine_theorem
                 congr <;> try (rw [htotal]; omega)
                 refine (Fin.heq_fun_iff ?_).mpr ?_
                 · aesop (add safe (by omega))
-                · aesop 
+                · aesop
       })
       simp only [jointAgreement, ge_iff_le, SetLike.mem_coe] at proximity_gap
       have proximity_gap :
-        ∃ S : Finset ι, 
+        ∃ S : Finset ι,
           ↑(#S) ≥ (1 - δ) * ↑(Fintype.card ι)
             ∧ ∃ v : Π i : Fin m, (Fin (block_size dstar degs i) → Polynomial F),
-                ∀ i j, (v i j).degree < dstar ∧ 
+                ∀ i j, (v i j).degree < dstar ∧
                   ∀ x ∈ S, (v i j).eval (φ x) = (φ x) ^ j.val * (fs i x) := by
           obtain ⟨S, hcard, hagr⟩ := proximity_gap
           exists S
           obtain ⟨v, hagr⟩ := hagr
           simp only [ge_iff_le, hcard, true_and]
           simp only [code, Submodule.mem_map, forall_and] at hagr
-          rcases hagr with ⟨hagr1, hagr2⟩ 
-          let vaux (i : Fin m) (j : Fin (block_size dstar degs i)) : 
+          rcases hagr with ⟨hagr1, hagr2⟩
+          let vaux (i : Fin m) (j : Fin (block_size dstar degs i)) :
             Fin (total_terms dstar degs - 1 + 1) :=
             ⟨block_start dstar degs i + j.val,
             by {
             rw [htotal, add_tsub_cancel_right, ←htotal]
             simp only [block_start, block_size, total_terms]
-            rcases i with ⟨i, hi⟩ 
-            rcases j with ⟨j, hj⟩ 
+            rcases i with ⟨i, hi⟩
+            rcases j with ⟨j, hj⟩
             apply lt_of_lt_of_le
-            · apply Nat.add_lt_add_left (m := dstar - degs ⟨i, hi⟩ + 1) 
+            · apply Nat.add_lt_add_left (m := dstar - degs ⟨i, hi⟩ + 1)
                 (by aesop (add simp [block_size]) (add safe (by omega)))
-            · rw [Finset.sum_equiv 
-                (t := Finset.erase {x : Fin _ | x ≤ ⟨i, hi⟩} ⟨i, hi⟩) 
+            · rw [Finset.sum_equiv
+                (t := Finset.erase {x : Fin _ | x ≤ ⟨i, hi⟩} ⟨i, hi⟩)
                 (g := fun x => (dstar - degs x + 1))
                 (Equiv.refl _)
                 (by aesop (add safe (by omega)))
                 (by aesop), Finset.sum_erase_add _ _ (by simp)]
               exact Finset.sum_le_sum_of_subset (by simp)
-          }⟩ 
+          }⟩
           simp only [Polynomial.degreeLT, ge_iff_le, Submodule.mem_iInf, LinearMap.mem_ker,
             Polynomial.lcoeff_apply, evalOnPoints, LinearMap.coe_mk, AddHom.coe_mk] at hagr1
-          exists (fun i j => Classical.choose 
+          exists (fun i j => Classical.choose
             (hagr1 (vaux i j)))
           intro i j
           have h_spec := Classical.choose_spec (hagr1 (vaux i j))
@@ -692,9 +692,9 @@ theorem combine_theorem
             rw [hagr2, block_idx_eq_max]
             simp only [Option.elim]
             rw [add_tsub_cancel_left, mul_comm]
-      rcases proximity_gap with ⟨S, ⟨hS_card, ⟨v, hv⟩⟩⟩ 
+      rcases proximity_gap with ⟨S, ⟨hS_card, ⟨v, hv⟩⟩⟩
       have master_lemma :=
-        @master_lemma _ _ _ _ hempty  
+        @master_lemma _ _ _ _ hempty
           _ _ _ _ hdegs _
           hδLt _ (by aesop) (v := v) (fs := fs)
         (by aesop)
@@ -721,4 +721,4 @@ theorem combine_theorem
         simp only [pow_zero, one_mul] at hv
         exact hv
 
-end Combine
+end Combine\n

--- a/ArkLib/ToMathlib/Polynomial/EvalExt.lean
+++ b/ArkLib/ToMathlib/Polynomial/EvalExt.lean
@@ -2,7 +2,7 @@ import Mathlib.LinearAlgebra.Lagrange
 
 namespace Polynomial
 
-variable {𝔽 : Type*} [Field 𝔽] 
+variable {𝔽 : Type*} [Field 𝔽]
 
 lemma eq_of_eval_eq_degree {p q : 𝔽[X]} {n : ℕ}
       (hp : p.degree < .some n) (hq : q.degree < .some n) (s : Finset 𝔽) :

--- a/ArkLib/ToMathlib/Polynomial/NatDegreeOfSum.lean
+++ b/ArkLib/ToMathlib/Polynomial/NatDegreeOfSum.lean
@@ -7,7 +7,7 @@ theorem natDegree_sum_lt_of_forall_lt.{u_1, w}
   {n : ℕ} [inst : NeZero n] (f : ι → Polynomial S) (h : ∀ i ∈ s, (f i).natDegree < n) :
   (∑ i ∈ s, f i).natDegree < n := by
   rw [←Nat.le_pred_iff_lt (by aesop (add safe forward [inst.out]) (add safe (by omega)))]
-  exact natDegree_sum_le_of_forall_le _ _ <| fun i hi ↦ 
+  exact natDegree_sum_le_of_forall_le _ _ <| fun i hi ↦
     Nat.le_pred_of_lt (h _ hi)
 
 end Polynomial

--- a/scripts/lintWhitespace.sh
+++ b/scripts/lintWhitespace.sh
@@ -35,13 +35,8 @@ fix_spaces_inplace() {
     do 
         # Remove trailing `\t` and ` `.
         sed -i 's/[ \t]*$//' "$file"
-
-        # Check if the last line ends with a new line
-        # if not, append it. 
-        if [ "$(tail -c 1 "$file" | od -c | awk 'NR==1 {print $2}')" != "\n" ]; then
-            echo "\n" >> $file
-        fi
-
+        # Add trailing '\n' to the file
+        sed -i -e '$a\' "$file"
     done
 }
 

--- a/scripts/lintWhitespace.sh
+++ b/scripts/lintWhitespace.sh
@@ -3,23 +3,58 @@
 tmpfile=$(mktemp)
 issues_found=0
 
-find ArkLib -type f -name "*.lean" | while IFS= read -r file; do
-    # Check for trailing whitespace and print line number if found
-    while IFS=: read -r line_num line; do
-        echo "Trailing whitespace found in $file at line $line_num: $line"
-        echo 1 > "$tmpfile"
-    done < <(grep -n "[[:blank:]]$" "$file")
+validate_spaces () {
+    find ArkLib -type f -name "*.lean" | while IFS= read -r file; do
+        # Check for trailing whitespace and print line number if found
+        while IFS=: read -r line_num line; do
+            echo "Trailing whitespace found in $file at line $line_num: $line"
+            echo 1 > "$tmpfile"
+        done < <(grep -n "[[:blank:]]$" "$file")
 
-    # Check if the last line ends with a new line
-    if [ "$(tail -c 1 "$file" | od -c | awk 'NR==1 {print $2}')" != "\n" ]; then
-        echo "Last line does not end with a new line in: $file"
-        echo 1 > "$tmpfile"
+        # Check if the last line ends with a new line
+        if [ "$(tail -c 1 "$file" | od -c | awk 'NR==1 {print $2}')" != "\n" ]; then
+            echo "Last line does not end with a new line in: $file"
+            echo 1 > "$tmpfile"
+        fi
+    done
+
+    if [ -f "$tmpfile" ]; then
+        issues_found=$(<"$tmpfile")
     fi
+    rm -f "$tmpfile"
+
+    exit $issues_found
+}
+
+fix_spaces_inplace() {
+    for file in $(find ArkLib -type f -name "*.lean")
+    do 
+        # Remove trailing `\t` and ` `.
+        sed -i 's/[ \t]*$//' "$file"
+
+        # Check if the last line ends with a new line
+        # if not, append it. 
+        if [ "$(tail -c 1 "$file" | od -c | awk 'NR==1 {print $2}')" != "\n" ]; then
+            echo "\n" >> $file
+        fi
+
+    done
+}
+
+is_inplace=0
+
+while getopts ":i" option; do
+  case $option in
+    i)
+      is_inplace=1 ;;
+    *)
+      echo "Usage: $0 [-i]" 
+      exit 1
+      ;;
+  esac
 done
 
-if [ -f "$tmpfile" ]; then
-    issues_found=$(<"$tmpfile")
-fi
-rm -f "$tmpfile"
+if [ $is_inplace -eq 1 ]; then fix_spaces_inplace; else validate_spaces; fi
+    
 
-exit $issues_found
+

--- a/scripts/lintWhitespace.sh
+++ b/scripts/lintWhitespace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tmpfile=$(mktemp)
 issues_found=0

--- a/scripts/lintWhitespace.sh
+++ b/scripts/lintWhitespace.sh
@@ -23,6 +23,10 @@ validate_spaces () {
     fi
     rm -f "$tmpfile"
 
+    if [ $issues_found ]; then
+        echo "Run \`bash ./scripts/lintWhitespace.sh -i\` to fix whitespace issues."; 
+    fi
+
     exit $issues_found
 }
 


### PR DESCRIPTION
`lintWhitespace.sh` script is now capable of in-place fixing trailing whitespaces and end-of-lines at the end of files.

To avoid distracting trailing space changes in PR diffs I propose linting them in CI.