### PR TITLE
fix(oracle-reduction): close vacuity in straightline knowledge soundness

### DIFF
--- a/ArkLib/OracleReduction/Security/Basic.lean
+++ b/ArkLib/OracleReduction/Security/Basic.lean
@@ -267,10 +267,24 @@ class IsSound (langIn : Set StmtIn) (langOut : Set StmtOut)
   - there exists a straightline extractor `E`, such that
   - for all input statement `stmtIn`, witness `witIn`, and (malicious) prover `prover`,
   - if the execution with the honest verifier results in a pair `(stmtOut, witOut)`,
-  - and the extractor produces some `witIn'`,
 
-  then the probability that `(stmtIn, witIn')` is not valid and yet `(stmtOut, witOut)` is valid
-  is at most `knowledgeError`.
+  then the probability that `(stmtOut, witOut)` is valid and yet the extractor fails to produce
+  a witness `witIn'` such that `(stmtIn, witIn')` is valid is at most `knowledgeError`.
+
+  Implementation note: the extractor returns an `OptionT` computation, so it may fail. We run
+  this `OptionT` layer explicitly (via `.run`) and keep the resulting `Option WitIn` in the
+  game's output, so that extractor failure counts as a "bad" event (the adversary wins).
+
+  This is essential for the definition to be meaningful: if instead the extractor were bound
+  inside the surrounding `OptionT` computation, its failure would contribute to the failure
+  mass of the whole game, which `probEvent` excludes (it only measures `some` outputs). The
+  always-failing extractor `fun _ _ _ _ _ => failure` would then drive the game's event
+  probability to `0`, vacuously discharging knowledge soundness (at error `0`!) for any
+  verifier and any relations.
+
+  In contrast, failures of the reduction execution itself (e.g. the verifier aborting) are
+  still excluded from the event, matching the convention for (plain) soundness: a run in which
+  the verifier does not accept imposes no obligation on the extractor.
 -/
 def knowledgeSoundness (relIn : Set (StmtIn × WitIn)) (relOut : Set (StmtOut × WitOut))
     (verifier : Verifier oSpec StmtIn StmtOut pSpec) (knowledgeError : ℝ≥0) : Prop :=
@@ -283,10 +297,12 @@ def knowledgeSoundness (relIn : Set (StmtIn × WitIn)) (relOut : Set (StmtOut ×
     let exec := do
       let ⟨⟨⟨transcript, ⟨_, witOut⟩⟩, stmtOut⟩, proveQueryLog, verifyQueryLog⟩
         ← (Reduction.mk prover verifier).runWithLog stmtIn witIn
-      let extractedWitIn ← extractor stmtIn witOut transcript proveQueryLog.fst verifyQueryLog
-      return (stmtIn, extractedWitIn, stmtOut, witOut)
-    Pr[fun ⟨stmtIn, witIn, stmtOut, witOut⟩ =>
-        (stmtIn, witIn) ∉ relIn ∧ (stmtOut, witOut) ∈ relOut
+      let extractedWitIn? ←
+        liftM (extractor stmtIn witOut transcript proveQueryLog.fst verifyQueryLog).run
+      return (stmtIn, extractedWitIn?, stmtOut, witOut)
+    Pr[fun ⟨stmtIn, extractedWitIn?, stmtOut, witOut⟩ =>
+        (∀ extractedWitIn ∈ extractedWitIn?, (stmtIn, extractedWitIn) ∉ relIn) ∧
+          (stmtOut, witOut) ∈ relOut
       | OptionT.mk do (simulateQ pImpl exec.run).run' (← init)] ≤ knowledgeError
 
 /-- Type class for knowledge soundness for a verifier -/
@@ -552,10 +568,48 @@ def Extractor.Straightline.id : Extractor.Straightline oSpec StmtIn WitIn WitIn 
 @[simp]
 theorem Verifier.id_knowledgeSoundness {rel : Set (StmtIn × WitIn)} :
     (Verifier.id : Verifier oSpec _ _ _).knowledgeSoundness init impl rel rel 0 := by
-  sorry
-  -- Approach: Extractor.Straightline.id returns input witness.
-  -- Event (stmtIn, witIn) ∉ rel ∧ (stmtIn, witIn) ∈ rel is contradiction.
-  -- Same blocker: needs StateT.run'_bind/pure or manual support reasoning.
+  -- `Extractor.Straightline.id` returns the (adversarial) output witness. On the support of the
+  -- game, the identity verifier outputs the input statement, so the bad event requires both
+  -- `(stmtIn, witOut) ∉ rel` (extracted witness invalid) and `(stmtIn, witOut) ∈ rel`
+  -- (output pair valid): a contradiction.
+  refine ⟨Extractor.Straightline.id, fun stmtIn witIn prover => ?_⟩
+  simp only [ENNReal.coe_zero, le_zero_iff]
+  refine probEvent_eq_zero fun x hx => ?_
+  rw [OptionT.mem_support_iff, OptionT.run_mk] at hx
+  simp only [support_bind, Set.mem_iUnion] at hx
+  obtain ⟨s, _, hx⟩ := hx
+  simp only [Reduction.runWithLog, Verifier.run, Verifier.id, Extractor.Straightline.id,
+    OptionT.run_bind, OptionT.run_pure, Option.getM, Option.elimM,
+    simulateQ_bind, StateT.run'_bind', support_bind, Set.mem_iUnion] at hx
+  obtain ⟨⟨o, s'⟩, hi, hx2⟩ := hx
+  cases o with
+  | none =>
+    simp only [Option.elim, simulateQ_pure, StateT.run'_pure', support_pure,
+      Set.mem_singleton_iff] at hx2
+    exact (Option.some_ne_none x hx2).elim
+  | some x' =>
+    -- From `hx2`: `x = (stmtIn, some witOut, x'.1.2, witOut)`
+    simp only [Option.elim, simulateQ_pure, OptionT.run_pure, liftM_pure, pure_bind,
+      StateT.run'_pure', support_pure, Set.mem_singleton_iff] at hx2
+    -- From `hi`: the verifier is the identity, so `x'.1.2 = stmtIn`
+    rw [show (pure stmtIn : OptionT (OracleComp oSpec) StmtIn) =
+      (pure (some stmtIn) : OracleComp oSpec (Option StmtIn)) from rfl] at hi
+    simp only [Option.elim, simulateQ_pure, OptionT.run_pure, WriterT.run_pure, liftM_pure,
+      pure_bind, support_bind, Set.mem_iUnion, StateT.run_bind] at hi
+    obtain ⟨⟨o2, s2⟩, _, hi2⟩ := hi
+    cases o2 with
+    | none =>
+      simp only [simulateQ_pure, StateT.run_pure, support_pure,
+        Set.mem_singleton_iff, Prod.mk.injEq] at hi2
+      exact (Option.some_ne_none x' hi2.1).elim
+    | some pr =>
+      simp only [simulateQ_pure, StateT.run_pure, support_pure,
+        Set.mem_singleton_iff, Prod.mk.injEq, Option.some.injEq] at hi2
+      obtain ⟨rfl, -⟩ := hi2
+      simp only [Option.some.injEq] at hx2
+      subst hx2
+      rintro ⟨h1, h2⟩
+      exact h1 _ rfl h2
 
 /-- The identity / trivial reduction is perfectly complete. -/
 @[simp]

--- a/blueprint/src/oracle_reductions/defs.tex
+++ b/blueprint/src/oracle_reductions/defs.tex
@@ -543,9 +543,10 @@ special soundness (via rewinding). At the moment, we only care about non-rewindi
         \item there exists a straightline extractor $E$, such that
         \item for all input statement $x_{\text{in}}$, witness $w_{\text{in}}$, and (malicious) prover,
         \item if the execution with the honest verifier results in a pair $(x_{\text{out}}, w_{\text{out}})$,
-        \item and the extractor produces some $w'_{\text{in}}$,
     \end{itemize}
-    then the probability that $(x_{\text{in}}, w'_{\text{in}})$ is not valid for $R_{\text{in}}$ and yet $(x_{\text{out}}, w_{\text{out}})$ is valid for $R_{\text{out}}$ is at most $\epsilon$.
+    then the probability that $(x_{\text{out}}, w_{\text{out}})$ is valid for $R_{\text{out}}$ and yet the extractor fails to produce a witness $w'_{\text{in}}$ such that $(x_{\text{in}}, w'_{\text{in}})$ is valid for $R_{\text{in}}$ is at most $\epsilon$.
+
+    Note that the extractor failing outright (it is a partial computation) counts as a win for the adversary: whenever the prover convinces the verifier, the extractor is obliged to succeed and produce a valid witness. (Excluding extractor failure from the bad event would render the definition vacuous, as the always-failing extractor would satisfy it for any verifier.) In contrast, runs in which the protocol execution itself fails (e.g.\ the verifier aborts) impose no obligation on the extractor, matching the convention for plain soundness.
 
     A (straightline) extractor for knowledge soundness is a deterministic algorithm that takes in the output public context after executing the oracle reduction, the side information (i.e. log of oracle queries from the malicious prover) observed during execution, and outputs the witness for the input context.
 


### PR DESCRIPTION
`Verifier.knowledgeSoundness` was vacuously satisfiable: the straightline extractor returns `OptionT (OracleComp oSpec) WitIn`, and the knowledge game bound it inside the surrounding `OptionT` execution. In VCV-io semantics, `OptionT` failure contributes to the failure mass of the computation, which `probEvent` excludes (it only measures `some '' {x | p x}`). Hence the always-failing extractor `fun _ _ _ _ _ => failure` drove the game's bad-event probability to exactly 0, discharging knowledge soundness at error 0 for ANY verifier and ANY relations. (Verified by a Lean proof of `verifier.knowledgeSoundness init impl relIn relOut 0` for arbitrary `verifier`, `relIn`, `relOut`, depending only on the standard axioms; reproduced in the PR description.)

Fix: run the extractor's `OptionT` layer explicitly (`.run`) and keep the resulting `Option WitIn` in the game's output, changing the bad event to

  (∀ extractedWitIn ∈ extractedWitIn?, (stmtIn, extractedWitIn) ∉ relIn) ∧
    (stmtOut, witOut) ∈ relOut

so extractor failure now counts as an adversary win, matching the cryptographic definition (the extractor must succeed whenever the prover convinces the verifier). This keeps `Extractor.Straightline`'s type, the definition's signature, and the error type unchanged, so no downstream statement changes; failures of the protocol execution itself (verifier aborts) remain excluded, consistent with plain soundness. The rbr variant (`rbrKnowledgeSoundness`) uses a pure-function extractor and is unaffected.

Also prove the previously-sorried `Verifier.id_knowledgeSoundness` (via `Extractor.Straightline.id`), which both removes a sorry and witnesses that the strengthened definition remains satisfiable; as a result `OracleVerifier.id_knowledgeSoundness` is now sorry-free as well (both depend only on [propext, Classical.choice, Quot.sound]).

Blueprint prose for `def:knowledge_soundness` updated to match.

Known follow-up (out of scope): `Verifier.StateRestoration.knowledgeSoundness` has the same trap (its extractor's `OracleComp` may fail inside the game).