### PR TITLE
refactor(probability): consolidate Data/Probability/Instances into namespace Probability

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -254,6 +254,9 @@ import ArkLib.ProofSystem.Sumcheck.Domain
 import ArkLib.ProofSystem.Sumcheck.Impl.Basic
 import ArkLib.ProofSystem.Sumcheck.Spec.General
 import ArkLib.ProofSystem.Sumcheck.Spec.SingleRound
+import ArkLib.ProofSystem.Sumcheck.Structured
+import ArkLib.ProofSystem.Sumcheck.Structured.Prismalinear
+import ArkLib.ProofSystem.Sumcheck.Structured.SingleRound
 import ArkLib.ProofSystem.ToyProblem.ConstrainedCode
 import ArkLib.ProofSystem.ToyProblem.Definitions
 import ArkLib.ProofSystem.ToyProblem.Impl.FRS

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -19,6 +19,7 @@ namespace ProximityGap
 
 open NNReal Finset Function ProbabilityTheory ReedSolomon Code
 open scoped BigOperators LinearCode ProbabilityTheory
+open Probability
 
 section BCIKS20ProximityGapSection6
 

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ReedSolomonGap.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ReedSolomonGap.lean
@@ -15,6 +15,7 @@ namespace ProximityGap
 
 open NNReal Finset Function ProbabilityTheory Code
 open scoped BigOperators LinearCode ProbabilityTheory
+open Probability
 
 section CoreResults
 

--- a/ArkLib/Data/CodingTheory/ProximityGap/DG25/MainResults.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/DG25/MainResults.lean
@@ -18,6 +18,7 @@ noncomputable section
 open Code LinearCode InterleavedCode ReedSolomon ProximityGap ProbabilityTheory Filter
 open NNReal Finset Function Real
 open scoped BigOperators LinearCode ProbabilityTheory
+open Probability
 
 universe u v w k l
 variable {κ : Type k} {ι : Type l} [Fintype ι] [Nonempty ι] [DecidableEq ι] [DecidableEq κ]

--- a/ArkLib/Data/CodingTheory/ProximityGap/Errors.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Errors.lean
@@ -96,6 +96,7 @@ namespace ProximityGap
 
 open NNReal Code
 open scoped ProbabilityTheory BigOperators
+open Probability
 
 section
 

--- a/ArkLib/Data/CodingTheory/ProximityGap/MCAGenerator.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/MCAGenerator.lean
@@ -27,6 +27,7 @@ namespace LinearTransformations
 
 open NNReal ENNReal unitInterval LinearCode CoreDefinitions Matrix
 open scoped ProbabilityTheory
+open Probability
 
 variable {ι : Type} [Fintype ι]
          {F : Type} [Field F]

--- a/ArkLib/Data/Probability/Instances.lean
+++ b/ArkLib/Data/Probability/Instances.lean
@@ -40,6 +40,8 @@ instance [IsEmpty α] : IsEmpty (PMF α) := by
 --     · simp [hb]; sorry
 end
 
+namespace Probability
+
 section ProbabilityTools
 /-- Unrolls `Pr_{ let x ← D }[P x]` into a sum of the form
 `∑' x, Pr[x] * (if P x then 1 else 0)`. -/
@@ -117,7 +119,7 @@ theorem prob_uniform_eq_card_filter_div_card {F : Type} [Fintype F] [Nonempty F]
     rw [and_self_iff]
   rw [h_card_eq]
 
-lemma Fintype.card_fun_fin_one_eq {F : Type} [Fintype F] [Nonempty F] :
+lemma _root_.Fintype.card_fun_fin_one_eq {F : Type} [Fintype F] [Nonempty F] :
     Fintype.card (Fin 1 → F) = Fintype.card F := by
   rw [Fintype.card_fun]
   simp only [Fintype.card_unique, pow_one]
@@ -511,7 +513,7 @@ If every variable's degree in `P` is `< d`, then `P.totalDegree ≤ m * (d - 1)`
 (Mathlib-extension candidate; lives here while `prob_polynomial_identity_le` is the
 only consumer. Would belong in `Mathlib/Algebra/MvPolynomial/Degrees.lean` alongside
 `degreeOf_le_totalDegree`, which is the converse direction.) -/
-lemma MvPolynomial.totalDegree_le_of_degreeOf_lt
+lemma _root_.MvPolynomial.totalDegree_le_of_degreeOf_lt
     {R : Type*} [CommSemiring R] {m d : ℕ}
     (P : MvPolynomial (Fin m) R)
     (h_indiv_deg : ∀ i, P.degreeOf i < d) :
@@ -559,7 +561,7 @@ Useful when `f` is an affine-linear surjection: every fiber is a translate of
 the kernel and hence has constant cardinality. The proximity-gap proofs use this
 to bridge the coefficient-parameterised sampling of an affine span to the
 uniform sampling of the affine-span finset. -/
-theorem PMF.map_uniformOfFintype_of_fiber_const
+theorem _root_.PMF.map_uniformOfFintype_of_fiber_const
     {α β : Type*} [Fintype α] [Nonempty α] [DecidableEq β]
     (f : α → β) {k : ℕ} (hk : 0 < k)
     (hfib : ∀ b ∈ Finset.univ.image f,
@@ -747,3 +749,5 @@ theorem prob_uniform_pi_mem_finset_le {ι : Type} [Fintype ι] [Nonempty ι]
   le_of_eq (prob_uniform_pi_mem_finset_eq A t)
 
 end UniformProductBound
+
+end Probability

--- a/ArkLib/ProofSystem/ToyProblem/ConstrainedCode.lean
+++ b/ArkLib/ProofSystem/ToyProblem/ConstrainedCode.lean
@@ -91,6 +91,7 @@ namespace ToyProblem
 
 open Code InterleavedCode ListDecodable ProximityGap
 open scoped NNReal ENNReal ProbabilityTheory
+open Probability
 
 set_option linter.unusedDecidableInType false
 set_option linter.unusedSectionVars false

--- a/ArkLib/ProofSystem/ToyProblem/Leaderboard.lean
+++ b/ArkLib/ProofSystem/ToyProblem/Leaderboard.lean
@@ -99,6 +99,7 @@ namespace ToyProblem
 
 open Code InterleavedCode ListDecodable ProximityGap
 open scoped NNReal ENNReal
+open Probability
 
 variable {ι F : Type} [Fintype ι] [Field F] [Fintype F] [DecidableEq F]
 variable {A : Type} [Fintype A] [DecidableEq A] [AddCommGroup A] [Module F A]

--- a/ArkLib/ProofSystem/ToyProblem/SoundnessBounds.lean
+++ b/ArkLib/ProofSystem/ToyProblem/SoundnessBounds.lean
@@ -77,6 +77,7 @@ namespace ToyProblem
 
 open Code InterleavedCode ListDecodable ProximityGap
 open scoped NNReal ENNReal ProbabilityTheory
+open Probability
 
 -- Generalising the codeword alphabet to an `F`-module `A` (folded RS: `A = Fin s → F`)
 -- leaves many lemmas using only a subset of `A`'s `Fintype`/`DecidableEq`/`Module`

--- a/ArkLib/ProofSystem/ToyProblem/Spec/General.lean
+++ b/ArkLib/ProofSystem/ToyProblem/Spec/General.lean
@@ -116,6 +116,7 @@ namespace Spec
 open OracleSpec OracleComp ProtocolSpec
 open Code InterleavedCode ListDecodable ProximityGap
 open scoped NNReal ENNReal ProbabilityTheory
+open Probability
 
 -- `[Fintype A]`/`[DecidableEq A]` are used inside the bodies of the code-theoretic
 -- terms (`epsMCA`, `interleavedCodeSet`, the `accepts` decidability) but do not

--- a/ArkLib/ProofSystem/ToyProblem/Spec/SimplifiedIOR.lean
+++ b/ArkLib/ProofSystem/ToyProblem/Spec/SimplifiedIOR.lean
@@ -63,6 +63,7 @@ namespace SimplifiedIOR
 open OracleSpec OracleComp ProtocolSpec
 open Code InterleavedCode ListDecodable ProximityGap
 open scoped NNReal ENNReal
+open Probability
 open ToyProblem.Spec (Statement OracleStatement Witness)
 
 -- The code-theoretic terms (`epsMCA`, `interleavedCodeSet`) use `[Fintype A]`/`[DecidableEq A]`

--- a/ArkLib/ProofSystem/Whir/MutualCorrAgreement.lean
+++ b/ArkLib/ProofSystem/Whir/MutualCorrAgreement.lean
@@ -35,6 +35,7 @@ Todo: should we aim to add tags?
 namespace MutualCorrAgreement
 
 open NNReal Generator ProbabilityTheory ReedSolomon
+open Probability
 
 variable {F : Type} [Field F] [Fintype F] [DecidableEq F]
           {ι parℓ : Type} [Fintype ι] [Nonempty ι] [Fintype parℓ] [Nonempty parℓ]

--- a/ArkLib/ToVCVio/OracleComp/RbrGame.lean
+++ b/ArkLib/ToVCVio/OracleComp/RbrGame.lean
@@ -41,6 +41,7 @@ upstream candidate only after the `Pr_{…}` notation itself moves.
 
 open OracleComp OracleSpec ProtocolSpec ProbabilityTheory
 open scoped ENNReal
+open Probability
 
 namespace ProtocolSpec
 


### PR DESCRIPTION
## What

Consolidates `ArkLib/Data/Probability/Instances.lean` into `namespace Probability`, so the file stops polluting the **root** namespace.

- **23 bare declarations** (`prob_tsum_form_*`, `prob_uniform_*`, `prob_split_*`, `do_two_uniform_sampling_eq_uniform_prod`, `Pr_le_Pr_of_implies`, `Pr_multi_let_equiv_single_let`, `Pr_add_split_by_complement`, `Pr_congr`, `Pr_map_eq`, `prob_schwartz_zippel_*`, `prob_polynomial_identity_le`, `prob_dotProduct_eq_zero_le`, …) moved into `namespace Probability`, matching the sibling `Data/Probability/Combinatorial.lean` (already `namespace Probability`).
- **3 Mathlib-extending declarations** kept at their dotted namespaces via `_root_.` prefixes, preserving dot-notation and upstreaming:
  - `Fintype.card_fun_fin_one_eq`
  - `MvPolynomial.totalDegree_le_of_degreeOf_lt` (flagged Mathlib-upstream candidate)
  - `PMF.map_uniformOfFintype_of_fiber_const`
- **12 consumer files** each gain a single `open Probability` after their existing `open` block, so call sites stay unqualified.

This is a **pure namespace move**: no renames, no proof changes — one `open` line per consumer.

## Why

`Instances.lean` was the last sizable contributor of root-namespace `prob_*`/`Pr_*` symbols. Those names are generic probability/PMF helpers (Schwartz–Zippel, uniform-sampling splits, monotonicity, pushforward, linear-form collision bounds) that have no business sitting at the global root — they collide-risk with anything else opened in a downstream file and obscure where a lemma comes from. Putting them under `Probability` (alongside `Combinatorial.lean`) gives the file a single, discoverable home and makes `open Probability` the explicit, greppable opt-in that every consumer now states.

This was identified as cleanliness item **"low" #9** in the ABF26 whole-PR extreme review.

## Verification

- Full build **green** (4165 jobs); `./scripts/validate.sh --lint` clean.
- The four ABF26 crown jewels remain **axiom-clean** (first-hand `#print axioms` → `[propext, Classical.choice, Quot.sound]`):
  `protocol62_knowledgeSound`, `protocol62_rbrKnowledgeSound`, `simplifiedIOR_knowledgeSound`, `oracleReduction_perfectCompleteness`.

## Notes

- **Stacks on #505** — base is `feat/abf26-plan` (9 of the 23 decls were added there). Cannot merge before #505; rebase onto `main` and retarget afterward.
- The second commit (`chore: regen ArkLib.lean …`) is **not** part of the refactor: it picks up the three `Sumcheck.Structured{,.Prismalinear,.SingleRound}` imports added in #516, which `feat/abf26-plan`'s `ArkLib.lean` had never been regenerated to include (`main` already has them). Without it `validate.sh`'s umbrella-import check is red on this base. It no-ops cleanly on rebase to `main`.
