### PR TITLE
Introduce blocks as in the WHIR paper

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -81,6 +81,7 @@ import ArkLib.Data.CodingTheory.ProximityGap.MCAGenerator
 import ArkLib.Data.CodingTheory.ProximityGap.ProximityGenerators
 import ArkLib.Data.CodingTheory.ReedSolomon
 import ArkLib.Data.CodingTheory.ReedSolomon.Multilinear
+import ArkLib.Data.Domain.CosetFftDomain.Block
 import ArkLib.Data.Domain.CosetFftDomain.Defs
 import ArkLib.Data.Domain.CosetFftDomain.Log
 import ArkLib.Data.Domain.CosetFftDomain.Mem

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -58,8 +58,8 @@ variable {F : Type} [Field F] [DecidableEq F]
 variable {n : ℕ}
 
 /-- Given a word `f`, `foldWordAux` is a polynomial `pₓ`
-  of degree < 'k' such that `pₓ(domain i) = f i` for each `i`
-  such that `domain i ^ k = x`. -/
+  of degree < '2 ^ k' such that `pₓ(domain i) = f i` for each `i`
+  such that `domain i ^ 2 ^ k = x`. -/
 noncomputable def foldWordAux (domain : SmoothCosetFftDomain n F)
   (f : Word F (Fin (2 ^ n))) (k : ℕ) (x : F) : Polynomial F :=
   Lagrange.interpolate (blockIdx domain k x)
@@ -87,7 +87,7 @@ private lemma even_add_odd_eq_of_not_charp_2
 lemma foldWordAux_of_k_2
   [NeZero n]
   {i : Fin (2 ^ (n - 1))} :
-  foldWordAux domain f 2 (domain.subdomain 1 i) =
+  foldWordAux domain f 1 (domain.subdomain 1 i) =
     let x : domain := CosetFftDomain.twoNthRoot (i := 1)
       ⟨domain.subdomain 1 i, by simp⟩
     let i := domain.log x
@@ -97,7 +97,7 @@ lemma foldWordAux_of_k_2
   have hn : n ≠ 0 := NeZero.ne _
   extract_lets y j j'
   have h :
-    ({i_1 | domain i_1 ^ 2 = (CosetFftDomain.subdomain domain 1) i} : Finset _) =
+    ({i_1 | domain i_1 ^ 2 ^ 1 = (CosetFftDomain.subdomain domain 1) i} : Finset _) =
     {j, j'} := by
     have h := square_roots_explicit
       (ω := domain) (i := 0) (by omega) (y := y)
@@ -106,8 +106,7 @@ lemma foldWordAux_of_k_2
     have hpre : Finset.preimage {y.1, -y.1} domain (by simp) = {j, j'} := by
       aesop (add unsafe (by apply CosetFftDomain.injective (ω := domain)))
     ext u
-    simp only [mem_filter, mem_univ, true_and, ←hpre, ←h, Nat.sub_zero, mem_preimage,
-       iff_and_self]
+    simp only [mem_filter, mem_univ, true_and, ←hpre, ←h, Nat.sub_zero, mem_preimage]
     have := @mem_subdomain_0_iff_mem (ω := domain)
     aesop
   rw [blockIdx, h]
@@ -164,10 +163,8 @@ lemma foldWordAux_of_k_2
 
 /-- The natDegree of the auxiliary polynomial `foldWordAux`
   is less than k. -/
-lemma foldWordAux_natDegree {k : ℕ} {x : F}
-  [inst : NeZero k] :
-  (foldWordAux domain f k x).natDegree < k := by
-  have hne := NeZero.ne (h := inst)
+lemma foldWordAux_natDegree {k : ℕ} {x : F} :
+  (foldWordAux domain f k x).natDegree < 2 ^ k := by
   by_cases heq: foldWordAux domain f k x = 0
   · aesop
       (add safe (by omega))
@@ -183,18 +180,18 @@ lemma foldWordAux_natDegree {k : ℕ} {x : F}
 noncomputable def foldValue (domain : SmoothCosetFftDomain n F)
   (f : Word F (Fin (2 ^ n)))
   (k : ℕ) (α : F) (x : F) : F :=
-  (foldWordAux domain f (2 ^ k) x).eval α
+  (foldWordAux domain f k x).eval α
 
 lemma foldValue_def {α : F} {x : F} :
-  foldValue domain f k α x = (foldWordAux domain f (2 ^ k) x).eval α := rfl
+  foldValue domain f k α x = (foldWordAux domain f k x).eval α := rfl
 
 lemma foldValue_def' {α : F} {x : F} :
-  foldValue domain f k α x = (Lagrange.interpolate (blockIdx domain (2 ^ k) x)
+  foldValue domain f k α x = (Lagrange.interpolate (blockIdx domain k x)
     (fun i ↦ domain i) f).eval α := rfl
 
 @[simp]
 lemma foldValue_pow_x_k {i : Fin (2 ^ n)} :
-  foldValue domain f k (domain i) ((domain i) ^ (2 ^ k)) = f i :=
+  foldValue domain f k (domain i) (domain i ^ 2 ^ k) = f i :=
   Lagrange.eval_interpolate_at_node _ (by simp) (by simp)
 
 @[simp]
@@ -250,7 +247,7 @@ private lemma eval_comm {f : Polynomial (Polynomial F)} {a x : F} :
 private lemma interpolate_eq_folding_poly_eval
   (hk : k ≤ n)
   (hx : x ∈ domain.subdomain k) :
-  ((Lagrange.interpolate (blockIdx domain (2 ^ k) x) fun i ↦ domain i)
+  ((Lagrange.interpolate (blockIdx domain k x) fun i ↦ domain i)
     f) =
   (Polynomial.map (evalRingHom x)
     (FoldingPolynomial.foldingPolynomial (Y ^ 2 ^ k) ((Lagrange.interpolate univ ⇑domain) f))) :=
@@ -258,7 +255,7 @@ private lemma interpolate_eq_folding_poly_eval
   by_cases hf : f = 0
   · simp [hf]
   · apply eq_of_eval_eq_degree (n := 2 ^ k)
-        (s := block domain (2 ^ k) x)
+        (s := block domain k x)
     · exact lt_of_lt_of_le (Lagrange.degree_interpolate_lt _ (by simp)) <| by
         aesop (add simp [card_block_of_mem_subdomain'])
     · exact lt_of_le_of_lt Polynomial.degree_map_le <| by
@@ -362,33 +359,29 @@ theorem foldWord_mem_code_of_mem_code {d : ℕ}
         simp [evalOnPoints]
 
 private noncomputable def foldWordAuxCoeff (domain : SmoothCosetFftDomain n F)
-  (f : Word F (Fin (2 ^ n))) (k : ℕ) (i : Fin k) (x : F) : F :=
+  (f : Word F (Fin (2 ^ n))) (k : ℕ) (i : Fin (2 ^ k)) (x : F) : F :=
   (foldWordAux domain f k x).coeff i
 
-private lemma foldWordAux_coeff_eq_foldWordAuxCoeff_fin
-  {i : Fin k} :
+private lemma foldWordAux_coeff_eq_foldWordAuxCoeff_fin {i : Fin (2 ^ k)} :
   (foldWordAux domain f k x).coeff i =
-    (foldWordAuxCoeff domain f k i x) := by simp [foldWordAux, foldWordAuxCoeff]
+    foldWordAuxCoeff domain f k i x := by simp [foldWordAux, foldWordAuxCoeff]
 
-private lemma foldWordAux_coeff_eq_foldWordAuxCoeff_nat
-  [inst : NeZero k]
-  {i : ℕ} :
+private lemma foldWordAux_coeff_eq_foldWordAuxCoeff_nat {i : ℕ} :
   (foldWordAux domain f k x).coeff i =
-    if h : i < k
-    then (foldWordAuxCoeff domain f k ⟨i, h⟩ x)
+    if h : i < 2 ^ k
+    then foldWordAuxCoeff domain f k ⟨i, h⟩ x
     else 0 := by
-  by_cases h : i < k <;> simp only [h, ↓reduceDIte]
+  by_cases h : i < 2 ^ k <;> simp only [h, ↓reduceDIte]
   · rw [←foldWordAux_coeff_eq_foldWordAuxCoeff_fin]
   · rw [Polynomial.coeff_eq_zero_of_natDegree_lt <|
             lt_of_lt_of_le foldWordAux_natDegree <| by simpa using h]
 
-private lemma foldWordAux_eq_sum_of_foldWordAuxCoeff
-  [inst : NeZero k] :
+private lemma foldWordAux_eq_sum_of_foldWordAuxCoeff :
   foldWordAux domain f k x =
     ∑ j, Polynomial.C (foldWordAuxCoeff domain f k j x) * Y ^ j.val := by
   ext n
   simp only [finsetSum_coeff, coeff_C_mul, coeff_X_pow, mul_ite, mul_one, mul_zero]
-  by_cases hlt : n < k
+  by_cases hlt : n < 2 ^ k
   · aesop
       (add simp [foldWordAuxCoeff])
       (add safe [(by rw [Finset.sum_eq_single_of_mem ⟨n, hlt⟩])])
@@ -399,7 +392,7 @@ private lemma foldWordAux_eq_sum_of_foldWordAuxCoeff
 private lemma foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha
   {α : F} :
   foldValue domain f k α x =
-    ∑ j, (foldWordAuxCoeff domain f (2 ^ k) j x) * α ^ j.val := by
+    ∑ j, (foldWordAuxCoeff domain f k j x) * α ^ j.val := by
   aesop
     (add simp
       [foldValue,
@@ -429,19 +422,16 @@ private lemma indicated_polynomial_degree_x_lt (hs' : s'.Nonempty) :
       aesop
         (add simp [singleton_indicator_natDegree_lt_of_mem])
 
-private lemma indicated_polynomial_degree_y_lt
-  [inst : NeZero k] :
-  Bivariate.natDegreeY (indicatedPolynomial domain f k s') < k := by
+private lemma indicated_polynomial_degree_y_lt :
+  Bivariate.natDegreeY (indicatedPolynomial domain f k s') < 2 ^ k := by
   simp only [Bivariate.natDegreeY, indicatedPolynomial]
   exact natDegree_sum_lt_of_forall_lt _ _ <| fun i hi ↦
     lt_of_le_of_lt natDegree_mul_le <| by
       aesop
         (add simp [foldWordAux_natDegree])
-        (add safe forward [inst.out])
         (add safe (by omega))
 
-private lemma indicated_polynomial_eq_foldAux
-  {α : F} (hx : x ∈ s') :
+private lemma indicated_polynomial_eq_foldAux {α : F} (hx : x ∈ s') :
   ((indicatedPolynomial domain f k s').eval (Polynomial.C α)).eval x =
     (foldWordAux domain f k x).eval α := by
   aesop
@@ -453,9 +443,9 @@ private lemma indicated_polynomial_eq_foldAux
 private lemma indicated_polynomial_eval_eq_combination_of_correlated
   {u : Fin (2 ^ k) → Polynomial F}
   {α : F}
-  (hu : ∀ i x, x ∈ s' → (u i).eval x = (foldWordAuxCoeff domain f (2 ^ k) i x))
+  (hu : ∀ i x, x ∈ s' → (u i).eval x = foldWordAuxCoeff domain f k i x)
   (hx : x ∈ s') :
-  ((indicatedPolynomial domain f (2 ^ k) s').eval (Polynomial.C α)).eval x =
+  ((indicatedPolynomial domain f k s').eval (Polynomial.C α)).eval x =
     ∑ i, (u i).eval x * α ^ i.val := by
   aesop
     (add safe (by rw [←foldValue_def]))
@@ -467,9 +457,9 @@ private lemma indicated_polynomial_eq_combination_of_correlated
   (hs' : s'.Nonempty)
   {u : Fin (2 ^ k) → Polynomial F}
   {α : F}
-  (hu : ∀ i x, x ∈ s' → (u i).eval x = (foldWordAuxCoeff domain f (2 ^ k) i x))
+  (hu : ∀ i x, x ∈ s' → (u i).eval x = (foldWordAuxCoeff domain f k i x))
   (hu_deg : ∀ i, (u i).natDegree < s'.card) :
-  ((indicatedPolynomial domain f (2 ^ k) s').eval (Polynomial.C α)) =
+  ((indicatedPolynomial domain f k s').eval (Polynomial.C α)) =
     ∑ i, (u i) * Polynomial.C (α ^ i.val) := by
   apply Polynomial.eq_of_eval_eq_natDegree (s := s') (n := #s')
     <;> try rfl
@@ -490,15 +480,15 @@ private lemma indicated_polynomial_eq_foldAux'
   [Fintype F]
   {s' : Finset F}
   {u : Fin (2 ^ k) → Polynomial F}
-  (hx : ∀ i, (u i).eval x = (foldWordAuxCoeff domain f (2 ^ k) i x))
-  (hu : ∀ i x, x ∈ s' → (u i).eval x = (foldWordAuxCoeff domain f (2 ^ k) i x))
+  (hx : ∀ i, (u i).eval x = (foldWordAuxCoeff domain f k i x))
+  (hu : ∀ i x, x ∈ s' → (u i).eval x = (foldWordAuxCoeff domain f k i x))
   (hu_deg : ∀ i, (u i).natDegree < s'.card)
   (h_s' : s'.Nonempty)
   (h_card : 2 ^ k ≤ Fintype.card F) :
   (Polynomial.map
     (Polynomial.evalRingHom x)
-    (indicatedPolynomial domain f (2 ^ k) s')) =
-    foldWordAux domain f (2 ^ k) x := by
+    (indicatedPolynomial domain f k s')) =
+    foldWordAux domain f k x := by
   apply Polynomial.eq_of_eval_eq_natDegree (s := Finset.univ) (n := (2 ^ k))
     <;> try tauto
   · aesop
@@ -519,16 +509,16 @@ private lemma indicated_polynomial_eq_foldAux'
   · exact foldWordAux_natDegree
 
 private lemma foldWordAux_poly_sum {a : F} :
-  ((foldWordAux domain f (2 ^ k) a).sum fun e a ↦ Polynomial.C a * Polynomial.X ^ e) =
-  foldWordAux domain f (2 ^ k) a := by
+  ((foldWordAux domain f k a).sum fun e a ↦ Polynomial.C a * Polynomial.X ^ e) =
+  foldWordAux domain f k a := by
   aesop (add safe
     [(by rw [←Polynomial.sum_monomial_eq]),
      (by rw [Polynomial.sum])])
 
 private lemma indicated_polynomial_comp_x_k_natDegree
   (hs' : s'.Nonempty) :
-  ((Polynomial.map (Polynomial.compRingHom (Polynomial.X ^ (2 ^ k))) <|
-    indicatedPolynomial domain f (2 ^ k) s').eval Polynomial.X).natDegree < (2 ^ k) * s'.card := by
+  ((Polynomial.map (Polynomial.compRingHom (Polynomial.X ^ 2 ^ k)) <|
+    indicatedPolynomial domain f k s').eval Polynomial.X).natDegree < (2 ^ k) * s'.card := by
   by_cases h_card : 1 < s'.card
   · simp only [indicatedPolynomial,
       Polynomial.eval_map, eval₂_finsetSum,
@@ -645,7 +635,7 @@ private lemma contradictory_hamming_dist_formula {s : Finset F}
       (by aesop)
       (fun a ha ↦ by
         rw [
-          show ({j | domain j ^ 2 ^ k = a} : Finset _) = blockIdx domain (2 ^ k) a by rfl,
+          show ({j | domain j ^ 2 ^ k = a} : Finset _) = blockIdx domain k a by rfl,
           card_blockIdx,
           card_block_of_mem_subdomain' (by {
             rw [←Nat.pow_le_pow_iff_right (a := 2) (by simp)]
@@ -663,7 +653,7 @@ private lemma correlated_agreement_implies_contradictory_hamm_dist
   (h_s : s ⊆ (domain.subdomain k).toFinset)
   {u : Fin (2 ^ k) → Polynomial F}
   (h_u : ∀ i, ∀ x ∈ s, (u i).eval x =
-    foldWordAuxCoeff domain f (2 ^ k) i x)
+    foldWordAuxCoeff domain f k i x)
   {d : ℕ}
   (h_d : 2 ^ k ≤ d)
   (h_k_card : (2 ^ k) ≤ Fintype.card F)
@@ -686,7 +676,7 @@ private lemma correlated_agreement_implies_contradictory_hamm_dist
         Nat.div_eq_zero_iff, Nat.pow_eq_zero, OfNat.ofNat_ne_zero, false_and,
         false_or, not_lt, nonempty_pick_subset_of_nonempty_of_ne, s']
     exists ((Polynomial.map (Polynomial.compRingHom (Polynomial.X ^ (2 ^ k))) <|
-      indicatedPolynomial domain f (2 ^ k) s').eval Polynomial.X)
+      indicatedPolynomial domain f k s').eval Polynomial.X)
     constructor
     · exact lt_of_lt_of_le
         (indicated_polynomial_comp_x_k_natDegree h_s'_non_empty)
@@ -730,7 +720,7 @@ private lemma dist_from_code_bound_of_correlated_agreement
   (h_s : s ⊆ (domain.subdomain k).toFinset)
   {u : Fin (2 ^ k) → Polynomial F}
   (h_u : ∀ i, ∀ x ∈ s, (u i).eval x =
-      foldWordAuxCoeff domain f (2 ^ k) i x)
+      foldWordAuxCoeff domain f k i x)
   {d : ℕ}
   (h_k_d : 2 ^ k ≤ d)
   (h_d : d ≤ 2 ^ n)
@@ -874,15 +864,15 @@ theorem folding_preserves_distance
       exists cast'
       simp [LeftInverse, RightInverse, cast, cast']
     specialize correlated_agreement
-      (Matrix.of (fun i j ↦ foldWordAuxCoeff domain f (2 ^ k)
+      (Matrix.of (fun i j ↦ foldWordAuxCoeff domain f k
         (cast i)
         (domain.subdomain k j)))
     have correlated_curve_eq_sum_of_foldWord_coeffs {a : F} :
       ∑ i : Fin (2 ^ k - 1 + 1), a ^ (↑i : ℕ) •
         Matrix.of (fun i j ↦
-          foldWordAuxCoeff domain f (2 ^ k) (cast i) (domain.subdomain k j)) i =
+          foldWordAuxCoeff domain f k (cast i) (domain.subdomain k j)) i =
       (fun x ↦
-        ∑ j, foldWordAuxCoeff domain f (2 ^ k) j
+        ∑ j, foldWordAuxCoeff domain f k j
           (domain.subdomain k x) * a ^ (↑j : ℕ)) := by
       ext x
       simp only [sum_apply]

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -247,28 +247,6 @@ private lemma eval_comm {f : Polynomial (Polynomial F)} {a x : F} :
   simp [h_eval, Polynomial.eval_finsetSum,
         Polynomial.eval₂_eq_sum, Polynomial.sum_def]
 
-private lemma roots_in_domain_card_eq_if_x_in_domain
-  (hk : k ≤ n)
-  (hx : x ∈ domain.subdomain k) :
-  Finset.card {i | domain i ^ 2 ^ k = x} = 2 ^ k := by
-  have h := card_block_of_mem_subdomain (ω := domain)
-          (j := k) (i := 0) (x := x)
-          (by simp [hk])
-          (by aesop (add simp [mem_subdomain_of_eq_vals]))
-  conv_rhs =>
-    rw [←h]
-  exact Finset.card_bij
-    (fun x _ ↦ domain x)
-    (by
-      aesop
-        (add simp [Nat.sub_zero, mem_filter])
-        (add safe [(by rw [mem_subdomain_0_iff_mem])])
-    )
-    (fun _ _ _ _ h ↦ CosetFftDomain.injective h)
-    (fun b ↦ by
-      have := @mem_subdomain_0_iff_mem
-      aesop (add simp [CosetFftDomainClass.mem_def]))
-
 private lemma interpolate_eq_folding_poly_eval
   (hk : k ≤ n)
   (hx : x ∈ domain.subdomain k) :
@@ -280,26 +258,9 @@ private lemma interpolate_eq_folding_poly_eval
   by_cases hf : f = 0
   · simp [hf]
   · apply eq_of_eval_eq_degree (n := 2 ^ k)
-        (s := Finset.image domain {i | domain i ^ 2 ^ k = x})
-    · rw [Finset.card_image_of_injOn (by simp),
-        roots_in_domain_card_eq_if_x_in_domain hk hx]
-    · simp only [mem_image, mem_filter, mem_univ, true_and]
-      rintro u ⟨i, hu₁, hu₂⟩
-      rw [←hu₂, ←foldValue_def', ←hu₁,
-        FoldingPolynomial.eval_property_of_folding_polynomial_x_k]
-      aesop
-        (erase Lagrange.interpolate_apply)
-        (add safe (by rw [Lagrange.eval_interpolate_at_node]))
-        (add simp [FoldingPolynomial.eval_property_of_folding_polynomial_x_k])
-    · exact lt_of_le_of_lt
-        (Lagrange.degree_interpolate_le _ (by simp))
-        (by
-          rw [card_blockIdx,
-              card_block_of_mem_subdomain' hk hx,
-              show Nat.cast (2 ^ k - 1) = WithBot.some (2 ^ k - 1) by rfl,
-              WithBot.coe_lt_coe]
-          simp
-        )
+        (s := block domain (2 ^ k) x)
+    · exact lt_of_lt_of_le (Lagrange.degree_interpolate_lt _ (by simp)) <| by
+        aesop (add simp [card_block_of_mem_subdomain'])
     · exact lt_of_le_of_lt Polynomial.degree_map_le <| by
         have h := FoldingPolynomial.folding_polynomial_deg_y_bound_x_k
           (f := (Lagrange.interpolate univ ⇑domain) f)
@@ -315,6 +276,15 @@ private lemma interpolate_eq_folding_poly_eval
                   (s := univ) (v := domain) f]))
         )] at h
         exact h
+    · aesop (add simp [card_block_of_mem_subdomain'])
+    · simp only [mem_block, and_imp]
+      rintro u ⟨i, hu₁⟩ hu₂
+      rw [←hu₂, ←foldValue_def', ←hu₁,
+        FoldingPolynomial.eval_property_of_folding_polynomial_x_k]
+      aesop
+        (erase Lagrange.interpolate_apply)
+        (add safe (by rw [Lagrange.eval_interpolate_at_node]))
+        (add simp [FoldingPolynomial.eval_property_of_folding_polynomial_x_k])
 
 /-- Perfect completeness of folding: folding a codeword is the same as
   applying `polyFold` and then encoding.
@@ -674,14 +644,16 @@ private lemma contradictory_hamming_dist_formula {s : Finset F}
       (by aesop)
       (by aesop)
       (fun a ha ↦ by
-        rw [roots_in_domain_card_eq_if_x_in_domain
-          (by {
+        rw [
+          show ({j | domain j ^ 2 ^ k = a} : Finset _) = blockIdx domain (2 ^ k) a by rfl,
+          card_blockIdx,
+          card_block_of_mem_subdomain' (by {
             rw [←Nat.pow_le_pow_iff_right (a := 2) (by simp)]
             omega
-        }) (by {
-          rw [←CosetFftDomainClass.mem_toFinset_iff_mem]
-          exact h_s ha
-        })]
+          }) (by {
+            rw [←CosetFftDomainClass.mem_toFinset_iff_mem]
+            exact h_s ha
+          })]
       )]
     aesop (add safe (by grind))
 

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -13,6 +13,7 @@ import ArkLib.Data.Polynomial.SplitFold
 import ArkLib.Data.CodingTheory.ProximityGap.Basic
 import ArkLib.Data.Finset.PickSubset
 import ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.Curves
+import ArkLib.Data.Domain.CosetFftDomain.Block
 import ArkLib.Data.Domain.CosetFftDomain.Subdomain
 import ArkLib.Data.Domain.CosetFftDomain.Log
 import ArkLib.Data.Polynomial.Indicator
@@ -61,8 +62,8 @@ variable {n : ℕ}
   such that `domain i ^ k = x`. -/
 noncomputable def foldWordAux (domain : SmoothCosetFftDomain n F)
   (f : Word F (Fin (2 ^ n))) (k : ℕ) (x : F) : Polynomial F :=
-  Lagrange.interpolate {i | domain i ^ k = x}
-    (fun i => domain i) f
+  Lagrange.interpolate (blockIdx domain k x)
+    (fun i ↦ domain i) f
 
 section
 
@@ -109,18 +110,18 @@ lemma foldWordAux_of_k_2
        iff_and_self]
     have := @mem_subdomain_0_iff_mem (ω := domain)
     aesop
-  rw [h]
+  rw [blockIdx, h]
   have hcard : Finset.card {j, j'} = 2 := by
     rw [←h]
     conv_rhs =>
       rw [←pow_one 2,
-          ←card_roots (ω := domain) (i := 0)
+          ←card_block_of_mem_subdomain (ω := domain) (i := 0)
               (x := (CosetFftDomain.subdomain domain 1) i)
               (by omega) (by simp)]
     exact Finset.card_bij
       (fun a _ ↦ domain a)
       (fun a ha ↦ by
-        simp only [pow_one, Nat.sub_zero, mem_filter, CosetFftDomainClass.mem_toFinset_iff_mem]
+        simp only [Nat.sub_zero, mem_block, pow_one]
         rw [mem_subdomain_0_iff_mem]
         simpa using ha)
       (fun _ _ _ _ h ↦ CosetFftDomain.injective h)
@@ -161,34 +162,6 @@ lemma foldWordAux_of_k_2
       simp
       grind
 
-private lemma roots_of_x_in_domain_eq
-  (hk : k ≠ 0) :
-  ({i | domain i ^ k = x} : Finset (Fin (2 ^ n))) =
-    Finset.preimage
-      (nthRootsFinset k x)
-      domain
-      (by simp) := by
-  ext i
-  simp only [mem_filter, mem_univ, true_and, mem_preimage]
-  rw [Polynomial.mem_nthRootsFinset (by omega)]
-
-private lemma roots_of_x_in_domain_card
-  (hk : k ≠ 0) :
-  Finset.card {i | domain i ^ k = x} ≤
-    Finset.card
-      (nthRootsFinset k x) := by
-  rw [roots_of_x_in_domain_eq hk, Finset.card_preimage]
-  exact Finset.card_le_card (by simp)
-
-private lemma roots_of_x_in_domain_le_k
-  (hk : k ≠ 0) :
-  Finset.card {i | domain i ^ k = x} ≤ k :=
-  le_trans (roots_of_x_in_domain_card hk) <| by
-  simp only [nthRootsFinset, Multiset.toFinset, card_mk]
-  exact le_trans
-    (@Multiset.toFinset_card_le F (Classical.decEq F) _)
-    (Polynomial.card_nthRoots _ _)
-
 /-- The natDegree of the auxiliary polynomial `foldWordAux`
   is less than k. -/
 lemma foldWordAux_natDegree {k : ℕ} {x : F}
@@ -202,7 +175,7 @@ lemma foldWordAux_natDegree {k : ℕ} {x : F}
     apply lt_of_lt_of_le
     · rw [Polynomial.natDegree_lt_iff_degree_lt heq]
       exact Lagrange.degree_interpolate_lt _ (by simp)
-    · exact roots_of_x_in_domain_le_k hne
+    · simp
 
 /-- Compute value of the folded word.
   Takes the auxiliary polynomial `foldWordAux` and evaluates it on `a`,
@@ -216,8 +189,8 @@ lemma foldValue_def {α : F} {x : F} :
   foldValue domain f k α x = (foldWordAux domain f (2 ^ k) x).eval α := rfl
 
 lemma foldValue_def' {α : F} {x : F} :
-  foldValue domain f k α x = (Lagrange.interpolate {i | domain i ^ (2 ^ k) = x}
-    (fun i => domain i) f).eval α := rfl
+  foldValue domain f k α x = (Lagrange.interpolate (blockIdx domain (2 ^ k) x)
+    (fun i ↦ domain i) f).eval α := rfl
 
 @[simp]
 lemma foldValue_pow_x_k {i : Fin (2 ^ n)} :
@@ -278,7 +251,7 @@ private lemma roots_in_domain_card_eq_if_x_in_domain
   (hk : k ≤ n)
   (hx : x ∈ domain.subdomain k) :
   Finset.card {i | domain i ^ 2 ^ k = x} = 2 ^ k := by
-  have h := card_roots (ω := domain)
+  have h := card_block_of_mem_subdomain (ω := domain)
           (j := k) (i := 0) (x := x)
           (by simp [hk])
           (by aesop (add simp [mem_subdomain_of_eq_vals]))
@@ -299,7 +272,7 @@ private lemma roots_in_domain_card_eq_if_x_in_domain
 private lemma interpolate_eq_folding_poly_eval
   (hk : k ≤ n)
   (hx : x ∈ domain.subdomain k) :
-  ((Lagrange.interpolate {i | domain i ^ 2 ^ k = x} fun i ↦ domain i)
+  ((Lagrange.interpolate (blockIdx domain (2 ^ k) x) fun i ↦ domain i)
     f) =
   (Polynomial.map (evalRingHom x)
     (FoldingPolynomial.foldingPolynomial (Y ^ 2 ^ k) ((Lagrange.interpolate univ ⇑domain) f))) :=
@@ -321,7 +294,8 @@ private lemma interpolate_eq_folding_poly_eval
     · exact lt_of_le_of_lt
         (Lagrange.degree_interpolate_le _ (by simp))
         (by
-          rw [roots_in_domain_card_eq_if_x_in_domain hk hx,
+          rw [card_blockIdx,
+              card_block_of_mem_subdomain' hk hx,
               show Nat.cast (2 ^ k - 1) = WithBot.some (2 ^ k - 1) by rfl,
               WithBot.coe_lt_coe]
           simp

--- a/ArkLib/Data/Domain/CosetFftDomain/Block.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Block.lean
@@ -66,6 +66,10 @@ lemma block_x_0 :
 lemma block_k_0 :
   block ω 0 x = if x = 1 then toFinset ω else ∅ := by aesop
 
+@[simp]
+lemma block_k_1 :
+  block ω 1 x = if x ∈ ω then {x} else ∅ := by aesop
+
 /-- An alternative definition of `block` in terms of
   `Polynomial.nthRootsFinset`. -/
 lemma block_eq_nthRootsFinset [NeZero k] :

--- a/ArkLib/Data/Domain/CosetFftDomain/Block.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Block.lean
@@ -103,6 +103,29 @@ lemma mem_blockIdx_self {i : ι} :
 lemma mem_blockIdx_iff_mem_block {i : ι} :
   i ∈ blockIdx ω k x ↔ ω i ∈ block ω k x := by simp [blockIdx]
 
+/-- There are no roots of `0` in any domain. -/
+@[simp]
+lemma blockIdx_x_0 :
+  blockIdx ω k 0 = ∅ := by aesop (add simp [mem_blockIdx_iff_mem_block])
+
+/-- If `x` is `1` then any element of a domain is its `0`th root.
+  In any other case, `x` does not have roots in the domain. -/
+@[simp]
+lemma blockIdx_k_0 :
+  blockIdx ω 0 x = if x = 1 then univ else ∅ := by aesop (add simp [mem_blockIdx_iff_mem_block])
+
+lemma blockIdx_k_1_of_eq {i : ι} (hi : ω i = x) :
+  blockIdx ω 1 x = {i} := by
+  ext j
+  have := CosetFftDomainClass.injective ω (a₁ := i) (a₂ := j)
+  aesop
+    (add simp [mem_blockIdx_iff_mem_block])
+
+lemma blockIdx_k_1_of_ne_mem (hx : x ∉ ω) :
+  blockIdx ω 1 x = ∅ := by
+  aesop
+    (add simp [mem_blockIdx_iff_mem_block])
+
 /-- `blockIdx` is the preimage of `block`. -/
 lemma blockIdx_eq_preimage_block :
   blockIdx ω k x =

--- a/ArkLib/Data/Domain/CosetFftDomain/Block.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Block.lean
@@ -44,41 +44,34 @@ open Finset Polynomial
 
 /-- The `k`th roots of `x` from the domain `ω`.
 
-  This is the definition 4.16 from [ACFY24]. Note, for simplicity of
-  the definition, we do not require `k` to be a power of two,
-  nor `x` to be from a subdomain. -/
+  This is the definition 4.16 from [ACFY24].
+  Note, we do not require `x` to be from a subdomain. -/
 def block (ω : D) (k : ℕ) (x : F) : Finset F :=
-  {y ∈ toFinset ω | y ^ k = x}
+  {y ∈ toFinset ω | y ^ 2 ^ k = x}
 
 /-- An equivalent definition of the membership to a block. -/
 @[simp]
 lemma mem_block :
-  y ∈ block ω k x ↔ y ∈ ω ∧ y ^ k = x := by simp [block]
+  y ∈ block ω k x ↔ y ∈ ω ∧ y ^ 2 ^ k = x := by simp [block]
 
 /-- There are no roots of `0` in any domain. -/
 @[simp]
 lemma block_x_0 :
   block ω k 0 = ∅ := by aesop
 
-/-- If `x` is `1` then any element of a domain is its `0`th root.
-  In any other case, `x` does not have roots in the domain. -/
-@[simp]
-lemma block_k_0 :
-  block ω 0 x = if x = 1 then toFinset ω else ∅ := by aesop
-
 @[simp]
 lemma block_k_1 :
-  block ω 1 x = if x ∈ ω then {x} else ∅ := by aesop
+  block ω 0 x = if x ∈ ω then {x} else ∅ := by aesop
 
 /-- An alternative definition of `block` in terms of
   `Polynomial.nthRootsFinset`. -/
-lemma block_eq_nthRootsFinset [NeZero k] :
-  block ω k x = nthRootsFinset k x ∩ toFinset ω := by aesop (add unsafe cases Nat)
+lemma block_eq_nthRootsFinset :
+  block ω k x = nthRootsFinset (2 ^ k) x ∩ toFinset ω := by aesop (add unsafe cases Nat)
 
 /-- The cardinality of a block does not exceed its degree. -/
 @[simp]
-lemma card_block_le [NeZero k] :
-  (block ω k x).card ≤ k := by
+lemma card_block_le :
+  (block ω k x).card ≤ 2 ^ k := by
   rw [block_eq_nthRootsFinset]
   exact le_trans (card_le_card inter_subset_left) <| by
     simp only [nthRootsFinset, Multiset.toFinset, card_mk]
@@ -88,17 +81,17 @@ lemma card_block_le [NeZero k] :
 
 /-- The set of indices of a block of `ω` at `x` of the degree `k`. -/
 def blockIdx (ω : D) (k : ℕ) (x : F) : Finset ι :=
-  {i | ω i ^ k = x}
+  {i | ω i ^ 2 ^ k = x}
 
 omit [AddCommGroup ι] [CosetFftDomainClass D ι F] in
 /-- The definition of membership to a `blockIdx`. -/
 lemma mem_blockIdx {i : ι} :
-  i ∈ blockIdx ω k x ↔ ω i ^ k = x := by simp [blockIdx]
+  i ∈ blockIdx ω k x ↔ ω i ^ 2 ^ k = x := by simp [blockIdx]
 
 omit [AddCommGroup ι] [CosetFftDomainClass D ι F] in
 @[simp]
 lemma mem_blockIdx_self {i : ι} :
-  i ∈ blockIdx ω k (ω i ^ k) := by simp [blockIdx]
+  i ∈ blockIdx ω k (ω i ^ 2 ^ k) := by simp [blockIdx]
 
 lemma mem_blockIdx_iff_mem_block {i : ι} :
   i ∈ blockIdx ω k x ↔ ω i ∈ block ω k x := by simp [blockIdx]
@@ -108,21 +101,15 @@ lemma mem_blockIdx_iff_mem_block {i : ι} :
 lemma blockIdx_x_0 :
   blockIdx ω k 0 = ∅ := by aesop (add simp [mem_blockIdx_iff_mem_block])
 
-/-- If `x` is `1` then any element of a domain is its `0`th root.
-  In any other case, `x` does not have roots in the domain. -/
-@[simp]
-lemma blockIdx_k_0 :
-  blockIdx ω 0 x = if x = 1 then univ else ∅ := by aesop (add simp [mem_blockIdx_iff_mem_block])
-
 lemma blockIdx_k_1_of_eq {i : ι} (hi : ω i = x) :
-  blockIdx ω 1 x = {i} := by
+  blockIdx ω 0 x = {i} := by
   ext j
   have := CosetFftDomainClass.injective ω (a₁ := i) (a₂ := j)
   aesop
     (add simp [mem_blockIdx_iff_mem_block])
 
 lemma blockIdx_k_1_of_ne_mem (hx : x ∉ ω) :
-  blockIdx ω 1 x = ∅ := by
+  blockIdx ω 0 x = ∅ := by
   aesop
     (add simp [mem_blockIdx_iff_mem_block])
 

--- a/ArkLib/Data/Domain/CosetFftDomain/Block.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Block.lean
@@ -7,8 +7,27 @@ Authors: Ilia Vlasov
 import Mathlib.Algebra.Polynomial.Roots
 
 import ArkLib.Data.Domain.CosetFftDomain.Ops
-import ArkLib.Data.Domain.CosetFftDomain.Log
 import ArkLib.Data.Domain.FftDomain.Ops
+
+/-! This module provides a definition of a block of a
+  coset FFT domain (definition 4.16 from [ACFY24]).
+
+## Main definitions
+
+- `block`: A block of a coset FFT domain at a point `x`.
+- `blockIdx`: The indices of the elements of a block of
+  a coset FFT domain at a point `x`.
+
+## Main results
+
+- `card_block_le`: The cardinality bound of a block.
+- `card_blockIdx`: The cardinality of `block` and `blockIdx` coincide.
+
+## References
+
+  * [Arnon, G., Chiesa, A., Fenzi, G., and Yogev, E., *WHIR: Reed–Solomon Proximity Testing
+      with Super-Fast Verification*][ACFY24]
+-/
 
 namespace Domain
 
@@ -23,26 +42,38 @@ variable {ω : D} {k : ℕ} {x y : F}
 
 open Finset Polynomial
 
+/-- The `k`th roots of `x` from the domain `ω`.
+
+  This is the definition 4.16 from [ACFY24]. Note, for simplicity of
+  the definition, we do not require `k` to be a power of two,
+  nor `x` to be from a subdomain. -/
 def block (ω : D) (k : ℕ) (x : F) : Finset F :=
   {y ∈ toFinset ω | y ^ k = x}
 
+/-- An equivalent definition of the membership to a block. -/
 @[simp]
 lemma mem_block :
   y ∈ block ω k x ↔ y ∈ ω ∧ y ^ k = x := by simp [block]
 
+/-- There are no roots of `0` in any domain. -/
 @[simp]
 lemma block_x_0 :
   block ω k 0 = ∅ := by aesop
 
+/-- If `x` is `1` then any element of a domain is its `0`th root.
+  In any other case, `x` does not have roots in the domain. -/
 @[simp]
 lemma block_k_0 :
   block ω 0 x = if x = 1 then toFinset ω else ∅ := by aesop
 
+/-- An alternative definition of `block` in terms of
+  `Polynomial.nthRootsFinset`. -/
 lemma block_eq_nthRootsFinset [NeZero k] :
   block ω k x = nthRootsFinset k x ∩ toFinset ω := by aesop (add unsafe cases Nat)
 
+/-- The cardinality of a block does not exceed its degree. -/
 @[simp]
-lemma block_card_le [NeZero k] :
+lemma card_block_le [NeZero k] :
   (block ω k x).card ≤ k := by
   rw [block_eq_nthRootsFinset]
   exact le_trans (card_le_card inter_subset_left) <| by
@@ -51,10 +82,12 @@ lemma block_card_le [NeZero k] :
       (@Multiset.toFinset_card_le F (Classical.decEq F) _)
       (card_nthRoots _ _)
 
+/-- The set of indices of a block of `ω` at `x` of the degree `k`. -/
 def blockIdx (ω : D) (k : ℕ) (x : F) : Finset ι :=
   {i | ω i ^ k = x}
 
 omit [AddCommGroup ι] [CosetFftDomainClass D ι F] in
+/-- The definition of membership to a `blockIdx`. -/
 lemma mem_blockIdx {i : ι} :
   i ∈ blockIdx ω k x ↔ ω i ^ k = x := by simp [blockIdx]
 
@@ -66,6 +99,7 @@ lemma mem_blockIdx_self {i : ι} :
 lemma mem_blockIdx_iff_mem_block {i : ι} :
   i ∈ blockIdx ω k x ↔ ω i ∈ block ω k x := by simp [blockIdx]
 
+/-- `blockIdx` is the preimage of `block`. -/
 lemma blockIdx_eq_preimage_block :
   blockIdx ω k x =
     preimage
@@ -73,6 +107,7 @@ lemma blockIdx_eq_preimage_block :
       (fun _ _ _ _ h ↦ CosetFftDomainClass.injective _ h) := by
   aesop (add simp [mem_blockIdx_iff_mem_block])
 
+/-- The cardinality of `blockIdx` is that of `block`. -/
 @[simp]
 lemma card_blockIdx :
   (blockIdx ω k x).card = (block ω k x).card := by

--- a/ArkLib/Data/Domain/CosetFftDomain/Block.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Block.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2024-2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ilia Vlasov
+-/
+
+import Mathlib.Algebra.Polynomial.Roots
+
+import ArkLib.Data.Domain.CosetFftDomain.Ops
+import ArkLib.Data.Domain.CosetFftDomain.Log
+import ArkLib.Data.Domain.FftDomain.Ops
+
+namespace Domain
+
+variable {ι : Type} [Fintype ι] [AddCommGroup ι]
+variable {F : Type} [Field F] [DecidableEq F]
+
+namespace CosetFftDomainClass
+
+variable {n : ℕ}
+variable {D : Type} [FunLike D ι F] [CosetFftDomainClass D ι F]
+variable {ω : D} {k : ℕ} {x y : F}
+
+open Finset Polynomial
+
+def block (ω : D) (k : ℕ) (x : F) : Finset F :=
+  {y ∈ toFinset ω | y ^ k = x}
+
+@[simp]
+lemma mem_block :
+  y ∈ block ω k x ↔ y ∈ ω ∧ y ^ k = x := by simp [block]
+
+@[simp]
+lemma block_x_0 :
+  block ω k 0 = ∅ := by aesop
+
+@[simp]
+lemma block_k_0 :
+  block ω 0 x = if x = 1 then toFinset ω else ∅ := by aesop
+
+lemma block_eq_nthRootsFinset [NeZero k] :
+  block ω k x = nthRootsFinset k x ∩ toFinset ω := by aesop (add unsafe cases Nat)
+
+@[simp]
+lemma block_card_le [NeZero k] :
+  (block ω k x).card ≤ k := by
+  rw [block_eq_nthRootsFinset]
+  exact le_trans (card_le_card inter_subset_left) <| by
+    simp only [nthRootsFinset, Multiset.toFinset, card_mk]
+    exact le_trans
+      (@Multiset.toFinset_card_le F (Classical.decEq F) _)
+      (card_nthRoots _ _)
+
+def blockIdx (ω : D) (k : ℕ) (x : F) : Finset ι :=
+  {i | ω i ^ k = x}
+
+omit [AddCommGroup ι] [CosetFftDomainClass D ι F] in
+lemma mem_blockIdx {i : ι} :
+  i ∈ blockIdx ω k x ↔ ω i ^ k = x := by simp [blockIdx]
+
+omit [AddCommGroup ι] [CosetFftDomainClass D ι F] in
+@[simp]
+lemma mem_blockIdx_self {i : ι} :
+  i ∈ blockIdx ω k (ω i ^ k) := by simp [blockIdx]
+
+lemma mem_blockIdx_iff_mem_block {i : ι} :
+  i ∈ blockIdx ω k x ↔ ω i ∈ block ω k x := by simp [blockIdx]
+
+lemma blockIdx_eq_preimage_block :
+  blockIdx ω k x =
+    preimage
+      (block ω k x) ω
+      (fun _ _ _ _ h ↦ CosetFftDomainClass.injective _ h) := by
+  aesop (add simp [mem_blockIdx_iff_mem_block])
+
+@[simp]
+lemma card_blockIdx :
+  (blockIdx ω k x).card = (block ω k x).card := by
+  aesop
+    (add simp [blockIdx_eq_preimage_block, card_preimage])
+    (add unsafe congrArg)
+
+end CosetFftDomainClass
+
+end Domain

--- a/ArkLib/Data/Domain/CosetFftDomain/Mem.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Mem.lean
@@ -99,9 +99,7 @@ lemma not_zero_mem :
   obtain ⟨i, contra⟩ := contra
   exact CosetFftDomainClass.ne_zero ω i (by simp_all)
 
-end CosetFftDomainClass
-
-/-- The finset of elements of a concrete coset FFT domain is inhabited.
+/-- The finset of elements of a coset FFT domain is inhabited.
 
   There always exists `ω 0`.
 -/
@@ -111,6 +109,13 @@ instance [Fintype ι] [DecidableEq F] {ω : CosetFftDomain ι F} : Inhabited ω.
 /-- A concrete coset FFT domain coerced to `Type` is inhabited. -/
 instance [Fintype ι] [DecidableEq F] {ω : CosetFftDomain ι F} : Inhabited ω where
   default := ⟨ω 0, by simp [CosetFftDomainClass.toFinset]⟩
+
+/-- Membership in a coset FFT domain is decidable
+  via membership in its finset of elements. -/
+instance [Fintype ι] [DecidableEq F] : Decidable (x ∈ ω) :=
+  decidable_of_iff _ mem_toFinset_iff_mem
+
+end CosetFftDomainClass
 
 namespace CosetFftDomain
 
@@ -140,10 +145,5 @@ lemma mem_toFinset_self [Fintype ι] [DecidableEq F] {i : ι} :
   ω i ∈ ω.toFinset := CosetFftDomainClass.mem_toFinset_self
 
 end CosetFftDomain
-
-/-- Membership in a concrete coset FFT domain is decidable
-  via membership in its finset of elements. -/
-instance [Fintype ι] [DecidableEq F] {x : F} {ω : CosetFftDomain ι F} : Decidable (x ∈ ω) :=
-  decidable_of_iff _ CosetFftDomain.mem_toFinset_iff_mem
 
 end Domain

--- a/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
@@ -41,8 +41,8 @@ a root-finding procedure.
 
 - `pow_mem_of_mem`:
   Powers move elements down the subdomain tower.
-- `card_roots`:
-  Exact cardinality of fibers of powering maps.
+- `card_block_of_mem_subdomain`:
+  Exact cardinality of blocks when the block point is a member of a subdomain.
 - `root_exists`:
   Existence of roots in higher subdomains.
 - `square_roots_explicit`:
@@ -384,7 +384,7 @@ private lemma card_fin_filter_mod_eq {a j : ℕ} (hj : j ≤ a) (c : ℕ) (hc : 
   then it has exactly `2 ^ j` preimages under `y ↦ y ^ 2 ^ j` from the `i`th subdomain. -/
 lemma card_block_of_mem_subdomain [DecidableEq F]
   {i j : ℕ} (hij : i + j ≤ n) (h : x ∈ subdomain ω (i + j)) :
-  Finset.card (block (subdomain ω i) (2 ^ j) x) = 2 ^ j := by
+  Finset.card (block (subdomain ω i) j x) = 2 ^ j := by
   have hinj : Function.Injective (subdomain ω i) := CosetFftDomainClass.injective _
   unfold block
   obtain ⟨m, hm⟩ := h
@@ -418,8 +418,9 @@ lemma card_block_of_mem_subdomain [DecidableEq F]
 
 set_option linter.unusedDecidableInType false in -- false alert
 /-- Every element of the `(i + j)`th subdomain has a `2 ^ j`th root in the `i`th subdomain. -/
-lemma root_exists [DecidableEq F] {i j : ℕ} (hij : i + j ≤ n) (h : x ∈ subdomain ω (i + j)) :
-  ∃ y ∈ subdomain ω i, y ^ (2 ^ j) = x := by
+lemma root_exists [DecidableEq F]
+  {i j : ℕ} (hij : i + j ≤ n) (h : x ∈ subdomain ω (i + j)) :
+  ∃ y ∈ subdomain ω i, y ^ 2 ^ j = x := by
   have h' : Finset.Nonempty {y ∈ (subdomain ω i).toFinset | y ^ 2 ^ j = x} := by
     have := card_block_of_mem_subdomain hij h
     aesop
@@ -457,7 +458,7 @@ lemma square_roots_explicit [DecidableEq F] {i : ℕ} (hi : i < n) {y : F}
 lemma card_block_of_mem_subdomain' [DecidableEq F] {k : ℕ}
   (hk : k ≤ n)
   (hx : x ∈ subdomain ω k) :
-  Finset.card (block ω (2 ^ k) x) = 2 ^ k := by
+  Finset.card (block ω k x) = 2 ^ k := by
   have h := card_block_of_mem_subdomain (ω := ω)
           (j := k) (i := 0) (x := x)
           (by simp [hk])

--- a/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
@@ -16,6 +16,7 @@ import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Field
 
+import ArkLib.Data.Domain.CosetFftDomain.Block
 import ArkLib.Data.Domain.CosetFftDomain.Ops
 import ArkLib.Data.Domain.FftDomain.Ops
 
@@ -274,7 +275,7 @@ lemma pow_mem_subdomain_of_mem_subdomain_0 {i : ℕ} (hi : i ≤ n)
 /-- `toFinset`-version of `pow_mem_subdomain_of_mem_subdomain_0`. -/
 lemma pow_mem_subdomain_of_mem_subdomain_0_toFinset [DecidableEq F] {i : ℕ} (hi : i ≤ n)
   (h : x ∈ (subdomain ω 0).toFinset) :
-  x ^ (2 ^ i) ∈ (subdomain ω i).toFinset := by
+  x ^ 2 ^ i ∈ (subdomain ω i).toFinset := by
   rw [mem_toFinset_iff_mem]
   exact pow_mem_subdomain_of_mem_subdomain_0 hi (by simpa using h)
 
@@ -381,10 +382,11 @@ private lemma card_fin_filter_mod_eq {a j : ℕ} (hj : j ≤ a) (c : ℕ) (hc : 
 
 /-- If `x` lies in the `(i + j)`th subdomain,
   then it has exactly `2 ^ j` preimages under `y ↦ y ^ 2 ^ j` from the `i`th subdomain. -/
-lemma card_roots [DecidableEq F] {i j : ℕ} (hij : i + j ≤ n) (h : x ∈ subdomain ω (i + j)) :
-  Finset.card {y ∈ (subdomain ω i).toFinset | y ^ (2 ^ j) = x} = 2 ^ j := by
+lemma card_block_of_mem_subdomain [DecidableEq F]
+  {i j : ℕ} (hij : i + j ≤ n) (h : x ∈ subdomain ω (i + j)) :
+  Finset.card (block (subdomain ω i) (2 ^ j) x) = 2 ^ j := by
   have hinj : Function.Injective (subdomain ω i) := CosetFftDomainClass.injective _
-  simp only [CosetFftDomain.toFinset]
+  unfold block
   obtain ⟨m, hm⟩ := h
   have hinj2 : Function.Injective (subdomain ω (i + j)) := CosetFftDomainClass.injective _
   have hfilter_eq : (Finset.univ.filter (fun k : Fin (2 ^ (n - i)) =>
@@ -419,8 +421,10 @@ set_option linter.unusedDecidableInType false in -- false alert
 lemma root_exists [DecidableEq F] {i j : ℕ} (hij : i + j ≤ n) (h : x ∈ subdomain ω (i + j)) :
   ∃ y ∈ subdomain ω i, y ^ (2 ^ j) = x := by
   have h' : Finset.Nonempty {y ∈ (subdomain ω i).toFinset | y ^ 2 ^ j = x} := by
-    have := card_roots hij h
-    aesop (add unsafe (by rw [←Finset.card_ne_zero]))
+    have := card_block_of_mem_subdomain hij h
+    aesop
+      (add simp [block])
+      (add unsafe (by rw [←Finset.card_ne_zero]))
   simpa [Finset.Nonempty] using h'
 
 set_option linter.unusedDecidableInType false in -- false alert
@@ -449,6 +453,19 @@ lemma square_roots_explicit [DecidableEq F] {i : ℕ} (hi : i < n) {y : F}
     exact eq_or_eq_neg_of_sq_eq_sq _ _ <| by rw [hz.2, hy]
   · have hy_mem : y ∈ subdomain ω i := sq_root_mem_subdomain hi hx hy
     simp_all [Finset.subset_iff]
+
+lemma card_block_of_mem_subdomain' [DecidableEq F] {k : ℕ}
+  (hk : k ≤ n)
+  (hx : x ∈ subdomain ω k) :
+  Finset.card (block ω (2 ^ k) x) = 2 ^ k := by
+  have h := card_block_of_mem_subdomain (ω := ω)
+          (j := k) (i := 0) (x := x)
+          (by simp [hk])
+          (by aesop (add simp [mem_subdomain_of_eq_vals]))
+  conv_rhs =>
+    rw [←h]
+  apply congrArg
+  aesop (add safe (by rw [mem_subdomain_0_iff_mem]))
 
 end CosetFftDomainClass
 

--- a/ArkLib/Data/Domain/FftDomain/Mem.lean
+++ b/ArkLib/Data/Domain/FftDomain/Mem.lean
@@ -46,6 +46,11 @@ variable {ω : D}
 @[simp]
 lemma one_mem : 1 ∈ ω := ⟨0, FftDomainClass.generator_eq_one ω⟩
 
+/-- Membership in a FFT domain is decidable
+  via membership in the finset of its elements. -/
+instance [Fintype ι] [DecidableEq F] {x : F} : Decidable (x ∈ ω) :=
+  decidable_of_iff _ CosetFftDomainClass.mem_toFinset_iff_mem
+
 end FftDomainClass
 
 namespace FftDomain
@@ -83,10 +88,5 @@ lemma mem_toFinset_iff_mem [Fintype ι] [DecidableEq F] :
       mem_iff_mem_toCosetFftDomain]
 
 end FftDomain
-
-/-- Membership in a concrete FFT domain is decidable
-  via membership in the finset of its elements. -/
-instance [Fintype ι] [DecidableEq F] {x : F} {ω : FftDomain ι F} : Decidable (x ∈ ω) :=
-  decidable_of_iff _ FftDomain.mem_toFinset_iff_mem
 
 end Domain


### PR DESCRIPTION
This PR introduces the definition of a block into the `Domain` library along with a few useful lemmas.
The definition is taken from the WHIR paper: 
<img width="2024" height="177" alt="image" src="https://github.com/user-attachments/assets/be7e5ef4-e7b5-4a45-bf03-882d3ef3c572" />
