### PR TITLE
feat(Data/Fin): prove fflatten_embedSum and fflatten₂_embedSum

### DIFF
--- a/ArkLib/Data/Fin/Sigma.lean
+++ b/ArkLib/Data/Fin/Sigma.lean
@@ -323,7 +323,18 @@ theorem fflatten_embedSum {A : Sort u} {F : A → Sort v} {m : ℕ} {n : Fin m �
     {α : (i : Fin m) → (j : Fin (n i)) → A}
     (v : (i : Fin m) → (j : Fin (n i)) → F (α i j)) (i : Fin m) (j : Fin (n i)) :
     fflatten v (embedSum i j) = cast (by simp) (v i j) := by
-  sorry
+  induction m with
+  | zero => exact Fin.elim0 i
+  | succ m ih =>
+    induction i using Fin.cases with
+    | zero =>
+      simp only [embedSum_succ_zero, fflatten_succ]
+      erw [fappend_left]
+      rfl
+    | succ i =>
+      simp only [embedSum_succ_succ, fflatten_succ]
+      erw [fappend_right, ih (fun i => v i.succ) i j, _root_.cast_cast]
+      rfl
 
 /-- Functorial flatten with two arguments: flattens two nested heterogeneous tuple
 `(i : Fin m) → (j : Fin (n i)) → F (α i j)` into a single heterogeneous tuple with type
@@ -380,7 +391,18 @@ theorem fflatten₂_embedSum {A : Sort u} {B : Sort v} {F : A → B → Sort w} 
     {β : (i : Fin m) → (j : Fin (n i)) → B}
     (v : (i : Fin m) → (j : Fin (n i)) → F (α i j) (β i j)) (i : Fin m) (j : Fin (n i)) :
     fflatten₂ v (embedSum i j) = cast (by simp) (v i j) := by
-  sorry
+  induction m with
+  | zero => exact Fin.elim0 i
+  | succ m ih =>
+    induction i using Fin.cases with
+    | zero =>
+      simp only [embedSum_succ_zero, fflatten₂_succ]
+      erw [fappend₂_left]
+      rfl
+    | succ i =>
+      simp only [embedSum_succ_succ, fflatten₂_succ]
+      erw [fappend₂_right, ih (fun i => v i.succ) i j, _root_.cast_cast]
+      rfl
 
 /-- Heterogeneous flatten: flattens a nested heterogeneous tuple
 `(i : Fin m) → (j : Fin (n i)) → α i j` into a single heterogeneous tuple with type


### PR DESCRIPTION
Discharges two `sorry`s in `ArkLib/Data/Fin/Sigma.lean` — the functorial-flatten analogues of the
already-proven `dflatten_embedSum`:

- `fflatten_embedSum`  : `fflatten v (embedSum i j) = cast _ (v i j)`
- `fflatten₂_embedSum` : `fflatten₂ v (embedSum i j) = cast _ (v i j)`

i.e. flattening a nested tuple and indexing at `embedSum i j` recovers the `(i, j)` entry, up to the
canonical `cast` along `vflatten_embedSum`.

Both proofs mirror the existing `dflatten_embedSum`: induct on `m`, case on `i` with `Fin.cases`,
reduce with `fflatten_succ` / `fflatten₂_succ` + `fappend_left` / `fappend_right` (resp. `fappend₂_*`),
and merge the nested casts with `cast_cast` — the same dependent-`cast` family and technique as #586 /
#587.

- Sorry count in the file: 9 → 7. No new declarations, imports, or files; no declaration consumes
  these two lemmas, so nothing downstream is affected.
- `validate.sh` green (build + Data warning budget + imports/docs/kb).
- Scope note: this touches only `fflatten_embedSum` / `fflatten₂_embedSum` (≈ lines 322 / 389),
  outside the region #383 edits (`embedSum_splitSum` / `dflatten_splitSum`, ≈ 131–223), so it should
  not conflict.
