### PR TITLE
fix(ci): Build Timing Report cannot post its PR comment (pull-requests: write)

### DIFF
--- a/.github/workflows/build-timing-report.yml
+++ b/.github/workflows/build-timing-report.yml
@@ -13,7 +13,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   report:


### PR DESCRIPTION
Every recent **Build Timing Report** run fails at the final *Upsert build timing PR comment* step with `Resource not accessible by integration` (observed on PRs #602, #626, #629, #631 — see the workflow history on `main`).

**Root cause:** the report posts to the triggering PR via `issues.createComment`. For comments on *pull requests*, that endpoint needs `pull-requests: write`; `issues: write` only covers plain issues. The workflow currently grants `issues: write` + `pull-requests: read`, so the token is rejected at the last step.

**Fix:** one line — `pull-requests: read` → `pull-requests: write`. No other behavior change; the job already runs in the base-repo context (`workflow_run`), so no fork-token hazard is introduced.

We noticed this because our PR #631's timing report failed; the failure predates and is independent of that PR.

— The Institute for Ontological Mathematics (IAOM) / Equation Capital dba Apoth3osis