### PR TITLE
feat(proximity-gap): prove BCIKS20 curve agreement bounds

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
@@ -161,9 +161,10 @@ variable {F : Type} [Field F] [DecidableEq F]
 /-- Lemma 7.5 in [BCIKS20].
 This is the "list agreement on a curve implies correlated agreement" lemma.
 
-We are given two lists of functions `u, v : Fin (l + 2) → ι → F`, where each `v i` is a
-Reed-Solomon codeword of degree `deg` over the evaluation domain `domain`. From these
-lists we form the bivariate curve evaluations
+We are given two lists of functions `u, v : Fin (l + 2) → ι → F`. From these lists we
+form the bivariate curve evaluations. Code membership is not needed for this
+combinatorial root-counting bound; callers may separately know that every `v i` is a
+Reed-Solomon codeword.
 
 * `w x z = Curve.polynomialCurveEval u z x`,
 * `wtilde x z = Curve.polynomialCurveEval v z x`.
@@ -176,12 +177,10 @@ has μ-measure strictly larger than
 
 `α - (l + 1) / (S'.card - (l + 1))`. -/
 lemma list_agreement_on_curve_implies_correlated_agreement_bound
-    {k l : ℕ} {u : Fin (l + 2) → ι → F}
-    {deg : ℕ} {domain : ι ↪ F}
+    {l : ℕ} {u : Fin (l + 2) → ι → F}
     {μ : ι → Set.Icc (0 : ℚ) 1}
     {α : ℝ≥0}
     {v : Fin (l + 2) → ι → F}
-    (hv : ∀ i, v i ∈ ReedSolomon.code domain deg)
     {S' : Finset F}
     (hS'_card : S'.card > l + 1) :
     letI w (x : ι) (z : F) : F := Curve.polynomialCurveEval (F := F) (A := F) u z x
@@ -189,7 +188,171 @@ lemma list_agreement_on_curve_implies_correlated_agreement_bound
     (hS'_agree : ∀ z ∈ S', agree μ (w · z) (wtilde · z) ≥ α) →
     mu_set μ { x : ι | ∀ i, u i x = v i x } >
       α - ((l + 1) : ℝ) / (S'.card - (l + 1)) := by
-  sorry
+  dsimp only
+  classical
+  intro hS'_agree
+  let common : Finset ι := {x | ∀ i, u i x = v i x}
+  let agreementPoints (x : ι) : Finset F := S'.filter fun z =>
+    Curve.polynomialCurveEval u z x = Curve.polynomialCurveEval v z x
+  let difference (x : ι) : Polynomial F :=
+    ∑ i : Fin (l + 2), Polynomial.monomial i (u i x - v i x)
+  have difference_eval (x : ι) (z : F) :
+      (difference x).eval z =
+        Curve.polynomialCurveEval u z x - Curve.polynomialCurveEval v z x := by
+    simp only [difference, Polynomial.eval_finsetSum, Polynomial.eval_monomial,
+      Curve.polynomialCurveEval, Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+    rw [← Finset.sum_sub_distrib]
+    apply Finset.sum_congr rfl
+    intro i _
+    ring
+  have difference_degree (x : ι) : (difference x).natDegree ≤ l + 1 := by
+    apply Polynomial.natDegree_sum_le_of_forall_le
+    intro i _
+    exact (Polynomial.natDegree_monomial_le _).trans (by omega)
+  have difference_ne_zero {x : ι} (hx : x ∉ common) : difference x ≠ 0 := by
+    intro hzero
+    apply hx
+    simp only [common, Finset.mem_filter, Finset.mem_univ, true_and]
+    intro i
+    have hcoeff := congrArg (fun p : Polynomial F => p.coeff i) hzero
+    simp only [difference, Polynomial.finsetSum_coeff, Polynomial.coeff_monomial,
+      Polynomial.coeff_zero] at hcoeff
+    have : u i x - v i x = 0 := by
+      rw [Finset.sum_eq_single i] at hcoeff
+      · simpa using hcoeff
+      · intro j _ hji
+        simp only [if_neg (fun hval => hji (Fin.ext hval))]
+      · simp
+    exact sub_eq_zero.mp this
+  have agreementPoints_card {x : ι} (hx : x ∉ common) :
+      (agreementPoints x).card ≤ l + 1 := by
+    calc
+      (agreementPoints x).card ≤ (difference x).natDegree := by
+        apply Polynomial.card_le_degree_of_subset_roots
+        intro z hz
+        rw [Polynomial.mem_roots (difference_ne_zero hx), Polynomial.IsRoot.def,
+          difference_eval]
+        exact sub_eq_zero.mpr (Finset.mem_filter.mp hz).2
+      _ ≤ l + 1 := difference_degree x
+  have agreementPoints_eq {x : ι} (hx : x ∈ common) : agreementPoints x = S' := by
+    apply Finset.filter_eq_self.2
+    intro z _
+    have hx' : ∀ i, u i x = v i x := by simpa [common] using hx
+    simp only [Curve.polynomialCurveEval, Finset.sum_apply]
+    apply Finset.sum_congr rfl
+    intro i _
+    simp only [Pi.smul_apply, hx' i]
+  have weight_nonneg (x : ι) : 0 ≤ (μ x).1 := (μ x).property.1
+  have weight_le_one (x : ι) : (μ x).1 ≤ 1 := (μ x).property.2
+  have hsum_lower :
+      (S'.card : ℝ) * (α : ℝ) ≤
+        ∑ z ∈ S', agree μ
+          (fun x => Curve.polynomialCurveEval u z x)
+          (fun x => Curve.polynomialCurveEval v z x) := by
+    calc
+      (S'.card : ℝ) * (α : ℝ) = ∑ _z ∈ S', (α : ℝ) := by simp
+      _ ≤ ∑ z ∈ S', agree μ
+          (fun x => Curve.polynomialCurveEval u z x)
+          (fun x => Curve.polynomialCurveEval v z x) :=
+        Finset.sum_le_sum fun z hz => hS'_agree z hz
+  have hsum_eq :
+      ∑ z ∈ S', agree μ
+          (fun x => Curve.polynomialCurveEval u z x)
+          (fun x => Curve.polynomialCurveEval v z x) =
+        1 / (Fintype.card ι : ℝ) *
+          ∑ x : ι, (agreementPoints x).card * (μ x).1 := by
+    simp only [agree]
+    rw [← Finset.mul_sum]
+    congr 1
+    push_cast
+    simp_rw [Finset.sum_filter]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro x _
+    rw [← Finset.sum_filter]
+    simp [agreementPoints, nsmul_eq_mul, mul_comm]
+  have hweighted_upper :
+      (∑ x : ι, ((agreementPoints x).card : ℚ) * (μ x).1) ≤
+        (S'.card : ℚ) * (∑ x ∈ common, (μ x).1) +
+          (l + 1 : ℚ) * Fintype.card ι := by
+    calc
+      (∑ x : ι, ((agreementPoints x).card : ℚ) * (μ x).1) =
+          (∑ x ∈ common, ((agreementPoints x).card : ℚ) * (μ x).1) +
+            ∑ x ∈ Finset.univ.filter (fun x => x ∉ common),
+              ((agreementPoints x).card : ℚ) * (μ x).1 := by
+        simpa only [Finset.filter_mem_eq_inter, Finset.univ_inter] using
+          (Finset.sum_filter_add_sum_filter_not
+            (s := Finset.univ) (p := fun x => x ∈ common)
+            (f := fun x => ((agreementPoints x).card : ℚ) * (μ x).1)).symm
+      _ ≤ (S'.card : ℚ) * (∑ x ∈ common, (μ x).1) +
+            (l + 1 : ℚ) *
+              (∑ x ∈ Finset.univ.filter (fun x => x ∉ common), (μ x).1) := by
+        apply add_le_add
+        · rw [Finset.mul_sum]
+          apply Finset.sum_le_sum
+          intro x hx
+          rw [agreementPoints_eq hx]
+        · rw [Finset.mul_sum]
+          apply Finset.sum_le_sum
+          intro x hx
+          exact mul_le_mul_of_nonneg_right
+            (by exact_mod_cast agreementPoints_card (Finset.mem_filter.mp hx).2)
+            (weight_nonneg x)
+      _ ≤ (S'.card : ℚ) * (∑ x ∈ common, (μ x).1) +
+            (l + 1 : ℚ) * Fintype.card ι := by
+        apply add_le_add_right
+        apply mul_le_mul_of_nonneg_left _ (by positivity)
+        calc
+          (∑ x ∈ Finset.univ.filter (fun x => x ∉ common), (μ x).1) ≤
+              ∑ _x ∈ Finset.univ.filter (fun x => x ∉ common), (1 : ℚ) := by
+            apply Finset.sum_le_sum
+            intro i _
+            exact weight_le_one i
+          _ ≤ ∑ _x : ι, (1 : ℚ) := by
+            exact Finset.sum_le_sum_of_subset_of_nonneg
+              (Finset.filter_subset _ _) (fun _ _ _ => by positivity)
+          _ = Fintype.card ι := by simp
+  have hweighted_upper_real :
+      ((∑ x : ι, ((agreementPoints x).card : ℚ) * (μ x).1 : ℚ) : ℝ) ≤
+        (S'.card : ℝ) * ((∑ x ∈ common, (μ x).1 : ℚ) : ℝ) +
+          (l + 1 : ℝ) * Fintype.card ι := by
+    exact_mod_cast hweighted_upper
+  have hn_pos : (0 : ℝ) < Fintype.card ι := by positivity
+  have hcore :
+      (S'.card : ℝ) * (α : ℝ) ≤
+        (S'.card : ℝ) * mu_set μ common + (l + 1 : ℝ) := by
+    calc
+      (S'.card : ℝ) * (α : ℝ) ≤
+          ∑ z ∈ S', agree μ
+            (fun x => Curve.polynomialCurveEval u z x)
+            (fun x => Curve.polynomialCurveEval v z x) := hsum_lower
+      _ = 1 / (Fintype.card ι : ℝ) *
+          ((∑ x : ι, ((agreementPoints x).card : ℚ) * (μ x).1 : ℚ) : ℝ) := hsum_eq
+      _ ≤ 1 / (Fintype.card ι : ℝ) *
+          ((S'.card : ℝ) * ((∑ x ∈ common, (μ x).1 : ℚ) : ℝ) +
+            (l + 1 : ℝ) * Fintype.card ι) :=
+        mul_le_mul_of_nonneg_left hweighted_upper_real (by positivity)
+      _ = (S'.card : ℝ) * mu_set μ common + (l + 1 : ℝ) := by
+        simp only [mu_set]
+        field_simp
+  change mu_set μ common >
+    (α : ℝ) - (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ))
+  have hcard_real : (l + 1 : ℝ) < S'.card := by exact_mod_cast hS'_card
+  have hgap_pos : (0 : ℝ) < (S'.card : ℝ) - (l + 1 : ℝ) := by
+    linarith
+  have hcard_pos : (0 : ℝ) < S'.card := by
+    linarith
+  have hfraction :
+      (l + 1 : ℝ) / S'.card <
+        (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ)) := by
+    rw [div_lt_div_iff₀ hcard_pos hgap_pos]
+    nlinarith
+  have hcancel : ((l + 1 : ℝ) / S'.card) * S'.card = l + 1 := by
+    field_simp
+  have hcommon_lower :
+      (α : ℝ) - (l + 1 : ℝ) / S'.card ≤ mu_set μ common := by
+    nlinarith [hcore, hcancel]
+  exact lt_of_lt_of_le (by linarith [hfraction]) hcommon_lower
 
 /-- Lemma 7.6 in [BCIKS20].
 This is the "integral-weight" strengthening of the list-agreement-on-a-curve =>

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
@@ -358,9 +358,9 @@ lemma list_agreement_on_curve_implies_correlated_agreement_bound
 This is the "integral-weight" strengthening of the list-agreement-on-a-curve =>
 correlated-agreement bound.
 
-We have two lists of functions `u, v : Fin (l + 2) → ι → F`, where each `v i` is a
-Reed-Solomon codeword of degree `deg` over the evaluation domain `domain`. From
-these lists we form the bivariate curve evaluations
+We have two lists of functions `u, v : Fin (l + 2) → ι → F`. From these lists we
+form the bivariate curve evaluations. As in Lemma 7.5, code membership is not
+needed for this combinatorial strengthening.
 
 * `w x z = Curve.polynomialCurveEval u z x`,
 * `wtilde x z = Curve.polynomialCurveEval v z x`.
@@ -377,14 +377,12 @@ coordinates agree, i.e. where `u i x = v i x` for every `i`, is at least `α`:
 
 `mu_set μ {x | ∀ i, u i x = v i x} ≥ α`. -/
 lemma sufficiently_large_list_agreement_on_curve_implies_correlated_agreement
-    {k l : ℕ} {u : Fin (l + 2) → ι → F}
-    {deg : ℕ} {domain : ι ↪ F}
+    {l : ℕ} {u : Fin (l + 2) → ι → F}
     {μ : ι → Set.Icc (0 : ℚ) 1}
     {α : ℝ≥0}
     {M : ℕ}
     (hμ : ∀ i, ∃ n : ℤ, (μ i).1 = (n : ℚ) / (M : ℚ))
     {v : Fin (l + 2) → ι → F}
-    (hv : ∀ i, v i ∈ ReedSolomon.code domain deg)
     {S' : Finset F}
     (hS'_card : S'.card > l + 1)
     (hS'_card₁ : S'.card ≥ (M * Fintype.card ι + 1) * (l + 1)) :
@@ -392,7 +390,98 @@ lemma sufficiently_large_list_agreement_on_curve_implies_correlated_agreement
     letI wtilde (x : ι) (z : F) : F := Curve.polynomialCurveEval (F := F) (A := F) v z x
     (hS'_agree : ∀ z ∈ S', agree μ (w · z) (wtilde · z) ≥ α) →
     mu_set μ { x : ι | ∀ i, u i x = v i x } ≥ α := by
-  sorry
+  dsimp only
+  classical
+  intro hS'_agree
+  let w (x : ι) (z : F) : F := Curve.polynomialCurveEval u z x
+  let wtilde (x : ι) (z : F) : F := Curve.polynomialCurveEval v z x
+  let values : Finset ℝ := S'.image fun z => agree μ (w · z) (wtilde · z)
+  have hS'_nonempty : S'.Nonempty := Finset.card_pos.mp (by omega)
+  have hvalues_nonempty : values.Nonempty := hS'_nonempty.image _
+  let β : ℝ := values.min' hvalues_nonempty
+  have hβ_le (z : F) (hz : z ∈ S') : β ≤ agree μ (w · z) (wtilde · z) := by
+    exact Finset.min'_le _ _ (Finset.mem_image.mpr ⟨z, hz, rfl⟩)
+  have hαβ : (α : ℝ) ≤ β := by
+    apply Finset.le_min'
+    intro y hy
+    rcases Finset.mem_image.mp hy with ⟨z, hz, rfl⟩
+    exact hS'_agree z hz
+  have hβ_nonneg : 0 ≤ β := le_trans α.coe_nonneg hαβ
+  let βnn : ℝ≥0 := ⟨β, hβ_nonneg⟩
+  have hcurve_bound :
+      mu_set μ {x : ι | ∀ i, u i x = v i x} >
+        β - (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ)) := by
+    have := list_agreement_on_curve_implies_correlated_agreement_bound
+      (u := u) (v := v) (μ := μ) (α := βnn) hS'_card
+      (fun z hz => hβ_le z hz)
+    simpa [βnn] using this
+  by_contra hnot
+  have hmu_lt_alpha :
+      mu_set μ {x : ι | ∀ i, u i x = v i x} < (α : ℝ) := by
+    simpa only [not_le] using hnot
+  have hmu_lt_beta :
+      mu_set μ {x : ι | ∀ i, u i x = v i x} < β :=
+    lt_of_lt_of_le hmu_lt_alpha hαβ
+  rcases Finset.mem_image.mp (Finset.min'_mem values hvalues_nonempty) with
+    ⟨zβ, hzβ, hβeq⟩
+  change agree μ (w · zβ) (wtilde · zβ) = β at hβeq
+  choose numerator hnum using hμ
+  have measure_grid (s : Finset ι) :
+      ∃ n : ℤ, mu_set μ s = (n : ℝ) / ((M * Fintype.card ι : ℕ) : ℝ) := by
+    refine ⟨∑ i ∈ s, numerator i, ?_⟩
+    simp only [mu_set]
+    simp_rw [hnum]
+    push_cast
+    rw [← Finset.sum_div]
+    field_simp
+  have agree_grid (a b : ι → F) :
+      ∃ n : ℤ, agree μ a b = (n : ℝ) / ((M * Fintype.card ι : ℕ) : ℝ) := by
+    simpa only [agree] using measure_grid {i | a i = b i}
+  rcases measure_grid {x : ι | ∀ i, u i x = v i x} with ⟨a, ha⟩
+  rcases agree_grid (w · zβ) (wtilde · zβ) with ⟨b, hb⟩
+  have hM_pos : 0 < M := by
+    by_contra hM
+    have hMzero : M = 0 := Nat.eq_zero_of_not_pos hM
+    have hweights_zero (i : ι) : (μ i).1 = 0 := by
+      simpa [hMzero] using hnum i
+    have hagree_zero : agree μ (w · zβ) (wtilde · zβ) = 0 := by
+      simp [agree, hweights_zero]
+    rw [← hβeq, hagree_zero] at hmu_lt_beta
+    have hmu_nonneg : 0 ≤ mu_set μ {x : ι | ∀ i, u i x = v i x} := by
+      simp [mu_set, hweights_zero]
+    linarith
+  have hd_pos : (0 : ℝ) < (M * Fintype.card ι : ℕ) := by positivity
+  have hab_real : (a : ℝ) < b := by
+    rw [ha, ← hβeq, hb] at hmu_lt_beta
+    exact (div_lt_div_iff_of_pos_right hd_pos).mp hmu_lt_beta
+  have hab : a + 1 ≤ b := by
+    have : a < b := by exact_mod_cast hab_real
+    omega
+  have hgrid_gap :
+      1 / ((M * Fintype.card ι : ℕ) : ℝ) ≤
+        β - mu_set μ {x : ι | ∀ i, u i x = v i x} := by
+    rw [ha, ← hβeq, hb]
+    rw [div_sub_div_same]
+    apply (div_le_div_iff_of_pos_right hd_pos).2
+    have : (1 : ℤ) ≤ b - a := by omega
+    exact_mod_cast this
+  have hdenom_pos : 0 < (S'.card : ℝ) - (l + 1 : ℝ) := by
+    have : (l + 1 : ℝ) < S'.card := by exact_mod_cast hS'_card
+    linarith
+  have hdenom_large :
+      ((M * Fintype.card ι : ℕ) : ℝ) * (l + 1 : ℝ) ≤
+        (S'.card : ℝ) - (l + 1 : ℝ) := by
+    have hcast :
+        (((M * Fintype.card ι + 1) * (l + 1) : ℕ) : ℝ) ≤ S'.card := by
+      exact_mod_cast hS'_card₁
+    norm_num [Nat.cast_mul] at hcast ⊢
+    nlinarith
+  have herror_le_grid :
+      (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ)) ≤
+        1 / ((M * Fintype.card ι : ℕ) : ℝ) := by
+    rw [div_le_div_iff₀ hdenom_pos hd_pos]
+    nlinarith
+  linarith
 
 end ListAgreementLemmas
 


### PR DESCRIPTION
## Summary

- prove BCIKS20 Lemma 7.5 (`list_agreement_on_curve_implies_correlated_agreement_bound`)
- prove its integral-weight strengthening, BCIKS20 Lemma 7.6 (`sufficiently_large_list_agreement_on_curve_implies_correlated_agreement`)
- formalize the coefficient-difference polynomial root bound and weighted double-counting argument
- derive Lemma 7.6 by placing the minimum curve agreement and correlated agreement on the common `1 / (M * |ι|)` grid
- remove Reed–Solomon membership parameters that neither combinatorial lemma needs

These are two genuine prerequisites in the BCIKS20 affine-lines list-decoding chain. This PR does **not** claim to prove Theorem 1.4, `RS_correlatedAgreement_affineLines`, or STIR's `Combine.combine_theorem`; those remain blocked by other admitted prerequisites.

## Trust and verification

- both declarations build with the real Lean kernel
- `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound` for each declaration (no `sorryAx`)
- `./scripts/validate.sh` passes: full build, Data warning budget, umbrella imports, docs integrity, and knowledge-base lint
- `git diff --check` passes
- no in-repository caller uses the removed irrelevant parameters

The optional repository-wide style lint still reports ArkLib's existing style backlog. The only finding when the modified file is checked directly is its pre-existing missing module-docstring exception; the new proofs add no style finding.
