### PR TITLE
feat(proximity-gap): harden BCIKS20 curve regimes

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/Curves.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/Curves.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao, Katerina Hristova, František Silváši, Julian Sutherland,
 -/
 
 import ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.ErrorBound
+import ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.AffineLines.JointAgreement
 import ArkLib.Data.CodingTheory.ReedSolomon
 
 namespace ProximityGap
@@ -26,10 +27,15 @@ omit [DecidableEq ι] in
 Take a Reed-Solomon code of length `ι` and degree `deg`, a proximity-error parameter
 pair `(δ, ε)` and a curve passing through words `u₀, ..., uκ`, such that
 the probability that a random point on the curve is `δ`-close to the Reed-Solomon code
-is at most `ε`. Then, the words `u₀, ..., uκ` have correlated agreement. -/
+is greater than `k * ε`. Then, the words `u₀, ..., uκ` have correlated agreement.
+
+This statement is restricted to the proven open Johnson/Guruswami-Sudan regime
+`0 < δ < 1 - √ρ`. It does not encode the separate capacity-regime extension proposed as
+Conjecture 8.4 of [BCIKS20]. -/
 theorem correlatedAgreement_affine_curves {k : ℕ}
     {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
-    (hδ : δ ≤ 1 - ReedSolomon.sqrtRate deg domain) :
+    (hδ_pos : 0 < δ)
+    (hδ : δ < 1 - ReedSolomon.sqrtRate deg domain) :
     δ_ε_correlatedAgreementCurves (k := k) (A := F) (F := F) (ι := ι)
       (C := ReedSolomon.code domain deg) (δ := δ) (ε := errorBound δ deg domain) := by
   sorry
@@ -44,51 +50,169 @@ variable {n : ℕ} [NeZero n]
 /-- The parameters for which the curve points are `δ`-close to a set `V`
 (typically, a linear code). This is the set `S` from the proximity gap paper. -/
 noncomputable def coeffs_of_close_proximity_curve {l : ℕ}
-    (δ : ℚ≥0) (u : Fin l → Fin n → F) (V : Finset (Fin n → F)) : Finset F :=
+    (δ : ℝ≥0) (u : Fin l → Fin n → F) (V : Finset (Fin n → F)) : Finset F :=
   have : Fintype { z | δᵣ(Curve.polynomialCurveEval (F := F) (A := F) u z, V) ≤ δ } := by
     infer_instance
   @Set.toFinset _ { z | δᵣ(Curve.polynomialCurveEval (F := F) (A := F) u z, V) ≤ δ } this
 
-/-- If the set of points `δ`-close to the code `V` has at least `n * l + 1` points, then
-there exists a curve defined by vectors `v` from `V` such that the points of `curve u`
-and `curve v` are `δ`-close with the same parameters. Moreover, `u` and `v` differ at
-at most `δ * n` positions. -/
-theorem large_agreement_set_on_curve_implies_correlated_agreement {l : ℕ}
-    {rho : ℚ≥0}
-    {δ : ℚ≥0}
-    {V : Finset (Fin n → F)}
-    (hδ : δ ≤ (1 - rho) / 2)
-    {u : Fin l → Fin n → F}
-    (hS : n * l < (coeffs_of_close_proximity_curve (F := F) δ u V).card) :
-    coeffs_of_close_proximity_curve (F := F) δ u V = Finset.univ ∧
-      ∃ v : Fin l → Fin n → F,
-        ∀ z,
+/-- The degree-one case of Theorem 6.1 in [BCIKS20].
+
+This bridges the polynomial-curve presentation to the existing kernel-checked affine-line
+unique-decoding theorem. More than `n` close parameters force every point on the line to be
+close, and the two line coefficients jointly agree with Reed-Solomon codewords. -/
+theorem large_agreement_set_on_line_implies_correlated_agreement {deg : ℕ}
+    {domain : Fin n ↪ F}
+    {δ : ℝ≥0}
+    (hδ : δ ≤ Code.relativeUniqueDecodingRadius
+      (ReedSolomon.code domain deg : Set (Fin n → F)))
+    (u : Fin 2 → Fin n → F)
+    (hS : n < (coeffs_of_close_proximity_curve (F := F) δ u
+      (ReedSolomon.toFinset domain deg)).card) :
+    coeffs_of_close_proximity_curve (F := F) δ u
+        (ReedSolomon.toFinset domain deg) = Finset.univ ∧
+      ∃ v : Fin 2 → Fin n → F,
+        (∀ i, v i ∈ ReedSolomon.code domain deg) ∧
+        (∀ z,
           δᵣ(Curve.polynomialCurveEval (F := F) (A := F) u z,
-            Curve.polynomialCurveEval (F := F) (A := F) v z) ≤ δ ∧
-          ({ x : Fin n | ∃ i, u i x ≠ v i x } : Finset _).card ≤ δ * n := by
+            Curve.polynomialCurveEval (F := F) (A := F) v z) ≤ δ) ∧
+        ({ x : Fin n | ∃ i, u i x ≠ v i x } : Finset _).card ≤ δ * n := by
+  classical
+  have hcoeffs_eq :
+      coeffs_of_close_proximity_curve (F := F) δ u
+          (ReedSolomon.toFinset domain deg) =
+        RS_goodCoeffs (deg := deg) (domain := domain) u δ := by
+    ext z
+    simp [coeffs_of_close_proximity_curve, RS_goodCoeffs, Curve.polynomialCurveEval,
+      Fin.sum_univ_two, ReedSolomon.toFinset]
+  have hgood : (RS_goodCoeffs (deg := deg) (domain := domain) u δ).card > n := by
+    simpa [hcoeffs_eq] using hS
+  have hja := RS_jointAgreement_of_goodCoeffs_card_gt
+    (deg := deg) (domain := domain) (δ := δ) hδ u (by simpa using hgood)
+  rcases hja with ⟨S, hS_card, v, hv⟩
+  have hcurve_close (z : F) :
+      δᵣ(Curve.polynomialCurveEval u z, Curve.polynomialCurveEval v z) ≤ δ := by
+    rw [Code.relCloseToWord_iff_exists_agreementCols]
+    refine ⟨S, ?_, ?_⟩
+    · exact (Code.relDist_floor_bound_iff_complement_bound
+        (Fintype.card (Fin n)) S.card δ).2 hS_card
+    · intro x
+      constructor
+      · intro hx
+        simp only [Curve.polynomialCurveEval, Finset.sum_apply]
+        apply Finset.sum_congr rfl
+        intro i _
+        simp only [Pi.smul_apply]
+        have hix := (hv i).2 hx
+        exact congrArg (z ^ (i : ℕ) • ·) (Finset.mem_filter.mp hix).2.symm
+      · intro hne hx
+        exact hne (by
+          simp only [Curve.polynomialCurveEval, Finset.sum_apply]
+          apply Finset.sum_congr rfl
+          intro i _
+          simp only [Pi.smul_apply]
+          have hix := (hv i).2 hx
+          exact congrArg (z ^ (i : ℕ) • ·) (Finset.mem_filter.mp hix).2.symm)
+  have hcurve_mem (z : F) : Curve.polynomialCurveEval v z ∈ ReedSolomon.code domain deg := by
+    apply Submodule.sum_mem
+    intro i _
+    exact Submodule.smul_mem _ _ (hv i).1
+  have hcoeffs_univ : coeffs_of_close_proximity_curve (F := F) δ u
+      (ReedSolomon.toFinset domain deg) = Finset.univ := by
+    apply Finset.eq_univ_of_forall
+    intro z
+    simp only [coeffs_of_close_proximity_curve, Set.mem_toFinset, Set.mem_setOf_eq]
+    have hcode := Code.relDistFromCode_le_relDist_to_mem
+      (u := Curve.polynomialCurveEval u z)
+      (C := (ReedSolomon.code domain deg : Set (Fin n → F)))
+      (v := Curve.polynomialCurveEval v z) (hcurve_mem z)
+    have : δᵣ(Curve.polynomialCurveEval u z,
+        (ReedSolomon.code domain deg : Set (Fin n → F))) ≤ δ :=
+      le_trans hcode (by exact_mod_cast hcurve_close z)
+    simpa [ReedSolomon.toFinset] using this
+  have hbad_subset :
+      ({x : Fin n | ∃ i, u i x ≠ v i x} : Finset _) ⊆
+        Finset.univ.filter (fun x => x ∉ S) := by
+    intro x hx
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    intro hxS
+    rcases Finset.mem_filter.mp hx with ⟨_, i, hui⟩
+    have hix := (hv i).2 hxS
+    exact hui (Finset.mem_filter.mp hix).2.symm
+  have hcomplement_card :
+      (Finset.univ.filter (fun x : Fin n => x ∉ S)).card = n - S.card := by
+    have hpartition : S.card + (Finset.univ.filter (fun x : Fin n => x ∉ S)).card = n := by
+      simpa using (Finset.card_filter_add_card_filter_not
+        (s := (Finset.univ : Finset (Fin n))) (p := fun x => x ∈ S))
+    omega
+  have hS_nat : n - Nat.floor (δ * n) ≤ S.card :=
+    (Code.relDist_floor_bound_iff_complement_bound n S.card δ).2 (by simpa using hS_card)
+  have hbad_nat : ({x : Fin n | ∃ i, u i x ≠ v i x} : Finset _).card ≤
+      Nat.floor (δ * n) := by
+    have hcard := Finset.card_le_card hbad_subset
+    rw [hcomplement_card] at hcard
+    omega
+  refine ⟨hcoeffs_univ, v, fun i => (hv i).1, hcurve_close, ?_⟩
+  exact_mod_cast le_trans (by exact_mod_cast hbad_nat) (Nat.floor_le (by positivity))
+
+/-- Theorem 6.1 of [BCIKS20], in the unique-decoding regime.
+
+For `l + 1` words, if more than `n * l` parameters give a curve point `δ`-close to the
+fixed Reed-Solomon code, then every parameter is close. Moreover, the curve is close to
+a curve whose coefficients are Reed-Solomon codewords, and the two coefficient stacks
+differ on at most `δ * n` coordinates.
+
+The Reed-Solomon code and its actual relative unique-decoding radius are explicit here.
+They are load-bearing assumptions: replacing the code by an arbitrary finite set and
+leaving the rate unconstrained makes the statement false. -/
+theorem large_agreement_set_on_curve_implies_correlated_agreement {l deg : ℕ}
+    (hdeg_pos : 0 < deg)
+    (hdeg_le : deg ≤ n)
+    {domain : Fin n ↪ F}
+    {δ : ℝ≥0}
+    (hδ : δ ≤ Code.relativeUniqueDecodingRadius
+      (ReedSolomon.code domain deg : Set (Fin n → F)))
+    {u : Fin (l + 1) → Fin n → F}
+    (hS : n * l < (coeffs_of_close_proximity_curve (F := F) δ u
+      (ReedSolomon.toFinset domain deg)).card) :
+    coeffs_of_close_proximity_curve (F := F) δ u
+        (ReedSolomon.toFinset domain deg) = Finset.univ ∧
+      ∃ v : Fin (l + 1) → Fin n → F,
+        (∀ i, v i ∈ ReedSolomon.code domain deg) ∧
+        (∀ z,
+          δᵣ(Curve.polynomialCurveEval (F := F) (A := F) u z,
+            Curve.polynomialCurveEval (F := F) (A := F) v z) ≤ δ) ∧
+        ({ x : Fin n | ∃ i, u i x ≠ v i x } : Finset _).card ≤ δ * n := by
   sorry
 
 /-- The distance bound from [BCIKS20]. -/
-noncomputable def δ₀ (rho : ℚ) (m : ℕ) : ℝ :=
+noncomputable def δ₀ (rho : ℝ) (m : ℕ) : ℝ :=
   1 - Real.sqrt rho - Real.sqrt rho / (2 * m)
 
-/-- If the set of points on the curve defined by `u` close to `V` has at least
+/-- Theorem 6.2 of [BCIKS20], strictly within the Johnson/Guruswami-Sudan regime.
+
+If the set of points on the curve defined by `u` close to the fixed Reed-Solomon code has at least
 `((1 + 1 / (2 * m)) ^ 7 * m ^ 7) / (3 * (Real.rpow rho (3 / 2 : ℚ))) * n ^ 2 * l + 1`
-points, then there exist vectors `v` from `V` that are `(1 - δ) * n` close to `u`. -/
-theorem large_agreement_set_on_curve_implies_correlated_agreement' {l : ℕ}
-    [Finite F]
+points, then there exist Reed-Solomon codewords `v` that are `(1 - δ) * n` close to `u`.
+
+Here `rho` is the actual rate of `ReedSolomon.code domain deg`; it is not a free
+parameter. The theorem does not assert the capacity-regime Conjecture 8.4 of [BCIKS20]. -/
+theorem large_agreement_set_on_curve_implies_correlated_agreement' {l deg : ℕ}
+    (hdeg_pos : 0 < deg)
+    (hdeg_le : deg ≤ n)
+    {domain : Fin n ↪ F}
     {m : ℕ}
-    {rho : ℚ≥0}
-    {δ : ℚ≥0}
+    {δ : ℝ≥0}
     (hm : 3 ≤ m)
-    {V : Finset (Fin n → F)}
-    (hδ : δ ≤ δ₀ rho m)
-    {u : Fin l → Fin n → F}
-    (hS : ((1 + 1 / (2 * m)) ^ 7 * m ^ 7) / (3 * (Real.rpow rho (3 / 2 : ℚ)))
-      * n ^ 2 * l < (coeffs_of_close_proximity_curve (F := F) δ u V).card) :
-    ∃ v : Fin l → Fin n → F,
-      ∀ i, v i ∈ V ∧
-        (1 - δ) * n ≤ ({ x : Fin n | ∀ i, u i x = v i x } : Finset _).card := by
+    (hδ : (δ : ℝ) ≤ δ₀ (((LinearCode.rate (ReedSolomon.code domain deg) : ℚ≥0) : ℝ)) m)
+    {u : Fin (l + 1) → Fin n → F}
+    (hS : ((1 + 1 / (2 * m)) ^ 7 * m ^ 7) /
+        (3 * Real.rpow ((LinearCode.rate (ReedSolomon.code domain deg) : ℚ≥0) : ℝ)
+          (3 / 2 : ℚ)) * n ^ 2 * l <
+      (coeffs_of_close_proximity_curve (F := F) δ u
+        (ReedSolomon.toFinset domain deg)).card) :
+    ∃ v : Fin (l + 1) → Fin n → F,
+      (∀ i, v i ∈ ReedSolomon.code domain deg) ∧
+      (1 - δ) * n ≤ ({ x : Fin n | ∀ i, u i x = v i x } : Finset _).card := by
   sorry
 
 end BCIKS20ProximityGapSection6

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
@@ -161,9 +161,10 @@ variable {F : Type} [Field F] [DecidableEq F]
 /-- Lemma 7.5 in [BCIKS20].
 This is the "list agreement on a curve implies correlated agreement" lemma.
 
-We are given two lists of functions `u, v : Fin (l + 2) → ι → F`, where each `v i` is a
-Reed-Solomon codeword of degree `deg` over the evaluation domain `domain`. From these
-lists we form the bivariate curve evaluations
+We are given two lists of functions `u, v : Fin (l + 2) → ι → F`. From these lists we
+form the bivariate curve evaluations. Code membership is not needed for this
+combinatorial root-counting bound; callers may separately know that every `v i` is a
+Reed-Solomon codeword.
 
 * `w x z = Curve.polynomialCurveEval u z x`,
 * `wtilde x z = Curve.polynomialCurveEval v z x`.
@@ -176,12 +177,10 @@ has μ-measure strictly larger than
 
 `α - (l + 1) / (S'.card - (l + 1))`. -/
 lemma list_agreement_on_curve_implies_correlated_agreement_bound
-    {k l : ℕ} {u : Fin (l + 2) → ι → F}
-    {deg : ℕ} {domain : ι ↪ F}
+    {l : ℕ} {u : Fin (l + 2) → ι → F}
     {μ : ι → Set.Icc (0 : ℚ) 1}
     {α : ℝ≥0}
     {v : Fin (l + 2) → ι → F}
-    (hv : ∀ i, v i ∈ ReedSolomon.code domain deg)
     {S' : Finset F}
     (hS'_card : S'.card > l + 1) :
     letI w (x : ι) (z : F) : F := Curve.polynomialCurveEval (F := F) (A := F) u z x
@@ -189,7 +188,171 @@ lemma list_agreement_on_curve_implies_correlated_agreement_bound
     (hS'_agree : ∀ z ∈ S', agree μ (w · z) (wtilde · z) ≥ α) →
     mu_set μ { x : ι | ∀ i, u i x = v i x } >
       α - ((l + 1) : ℝ) / (S'.card - (l + 1)) := by
-  sorry
+  dsimp only
+  classical
+  intro hS'_agree
+  let common : Finset ι := {x | ∀ i, u i x = v i x}
+  let agreementPoints (x : ι) : Finset F := S'.filter fun z =>
+    Curve.polynomialCurveEval u z x = Curve.polynomialCurveEval v z x
+  let difference (x : ι) : Polynomial F :=
+    ∑ i : Fin (l + 2), Polynomial.monomial i (u i x - v i x)
+  have difference_eval (x : ι) (z : F) :
+      (difference x).eval z =
+        Curve.polynomialCurveEval u z x - Curve.polynomialCurveEval v z x := by
+    simp only [difference, Polynomial.eval_finsetSum, Polynomial.eval_monomial,
+      Curve.polynomialCurveEval, Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+    rw [← Finset.sum_sub_distrib]
+    apply Finset.sum_congr rfl
+    intro i _
+    ring
+  have difference_degree (x : ι) : (difference x).natDegree ≤ l + 1 := by
+    apply Polynomial.natDegree_sum_le_of_forall_le
+    intro i _
+    exact (Polynomial.natDegree_monomial_le _).trans (by omega)
+  have difference_ne_zero {x : ι} (hx : x ∉ common) : difference x ≠ 0 := by
+    intro hzero
+    apply hx
+    simp only [common, Finset.mem_filter, Finset.mem_univ, true_and]
+    intro i
+    have hcoeff := congrArg (fun p : Polynomial F => p.coeff i) hzero
+    simp only [difference, Polynomial.finsetSum_coeff, Polynomial.coeff_monomial,
+      Polynomial.coeff_zero] at hcoeff
+    have : u i x - v i x = 0 := by
+      rw [Finset.sum_eq_single i] at hcoeff
+      · simpa using hcoeff
+      · intro j _ hji
+        simp only [if_neg (fun hval => hji (Fin.ext hval))]
+      · simp
+    exact sub_eq_zero.mp this
+  have agreementPoints_card {x : ι} (hx : x ∉ common) :
+      (agreementPoints x).card ≤ l + 1 := by
+    calc
+      (agreementPoints x).card ≤ (difference x).natDegree := by
+        apply Polynomial.card_le_degree_of_subset_roots
+        intro z hz
+        rw [Polynomial.mem_roots (difference_ne_zero hx), Polynomial.IsRoot.def,
+          difference_eval]
+        exact sub_eq_zero.mpr (Finset.mem_filter.mp hz).2
+      _ ≤ l + 1 := difference_degree x
+  have agreementPoints_eq {x : ι} (hx : x ∈ common) : agreementPoints x = S' := by
+    apply Finset.filter_eq_self.2
+    intro z _
+    have hx' : ∀ i, u i x = v i x := by simpa [common] using hx
+    simp only [Curve.polynomialCurveEval, Finset.sum_apply]
+    apply Finset.sum_congr rfl
+    intro i _
+    simp only [Pi.smul_apply, hx' i]
+  have weight_nonneg (x : ι) : 0 ≤ (μ x).1 := (μ x).property.1
+  have weight_le_one (x : ι) : (μ x).1 ≤ 1 := (μ x).property.2
+  have hsum_lower :
+      (S'.card : ℝ) * (α : ℝ) ≤
+        ∑ z ∈ S', agree μ
+          (fun x => Curve.polynomialCurveEval u z x)
+          (fun x => Curve.polynomialCurveEval v z x) := by
+    calc
+      (S'.card : ℝ) * (α : ℝ) = ∑ _z ∈ S', (α : ℝ) := by simp
+      _ ≤ ∑ z ∈ S', agree μ
+          (fun x => Curve.polynomialCurveEval u z x)
+          (fun x => Curve.polynomialCurveEval v z x) :=
+        Finset.sum_le_sum fun z hz => hS'_agree z hz
+  have hsum_eq :
+      ∑ z ∈ S', agree μ
+          (fun x => Curve.polynomialCurveEval u z x)
+          (fun x => Curve.polynomialCurveEval v z x) =
+        1 / (Fintype.card ι : ℝ) *
+          ∑ x : ι, (agreementPoints x).card * (μ x).1 := by
+    simp only [agree]
+    rw [← Finset.mul_sum]
+    congr 1
+    push_cast
+    simp_rw [Finset.sum_filter]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro x _
+    rw [← Finset.sum_filter]
+    simp [agreementPoints, nsmul_eq_mul, mul_comm]
+  have hweighted_upper :
+      (∑ x : ι, ((agreementPoints x).card : ℚ) * (μ x).1) ≤
+        (S'.card : ℚ) * (∑ x ∈ common, (μ x).1) +
+          (l + 1 : ℚ) * Fintype.card ι := by
+    calc
+      (∑ x : ι, ((agreementPoints x).card : ℚ) * (μ x).1) =
+          (∑ x ∈ common, ((agreementPoints x).card : ℚ) * (μ x).1) +
+            ∑ x ∈ Finset.univ.filter (fun x => x ∉ common),
+              ((agreementPoints x).card : ℚ) * (μ x).1 := by
+        simpa only [Finset.filter_mem_eq_inter, Finset.univ_inter] using
+          (Finset.sum_filter_add_sum_filter_not
+            (s := Finset.univ) (p := fun x => x ∈ common)
+            (f := fun x => ((agreementPoints x).card : ℚ) * (μ x).1)).symm
+      _ ≤ (S'.card : ℚ) * (∑ x ∈ common, (μ x).1) +
+            (l + 1 : ℚ) *
+              (∑ x ∈ Finset.univ.filter (fun x => x ∉ common), (μ x).1) := by
+        apply add_le_add
+        · rw [Finset.mul_sum]
+          apply Finset.sum_le_sum
+          intro x hx
+          rw [agreementPoints_eq hx]
+        · rw [Finset.mul_sum]
+          apply Finset.sum_le_sum
+          intro x hx
+          exact mul_le_mul_of_nonneg_right
+            (by exact_mod_cast agreementPoints_card (Finset.mem_filter.mp hx).2)
+            (weight_nonneg x)
+      _ ≤ (S'.card : ℚ) * (∑ x ∈ common, (μ x).1) +
+            (l + 1 : ℚ) * Fintype.card ι := by
+        apply add_le_add_right
+        apply mul_le_mul_of_nonneg_left _ (by positivity)
+        calc
+          (∑ x ∈ Finset.univ.filter (fun x => x ∉ common), (μ x).1) ≤
+              ∑ _x ∈ Finset.univ.filter (fun x => x ∉ common), (1 : ℚ) := by
+            apply Finset.sum_le_sum
+            intro i _
+            exact weight_le_one i
+          _ ≤ ∑ _x : ι, (1 : ℚ) := by
+            exact Finset.sum_le_sum_of_subset_of_nonneg
+              (Finset.filter_subset _ _) (fun _ _ _ => by positivity)
+          _ = Fintype.card ι := by simp
+  have hweighted_upper_real :
+      ((∑ x : ι, ((agreementPoints x).card : ℚ) * (μ x).1 : ℚ) : ℝ) ≤
+        (S'.card : ℝ) * ((∑ x ∈ common, (μ x).1 : ℚ) : ℝ) +
+          (l + 1 : ℝ) * Fintype.card ι := by
+    exact_mod_cast hweighted_upper
+  have hn_pos : (0 : ℝ) < Fintype.card ι := by positivity
+  have hcore :
+      (S'.card : ℝ) * (α : ℝ) ≤
+        (S'.card : ℝ) * mu_set μ common + (l + 1 : ℝ) := by
+    calc
+      (S'.card : ℝ) * (α : ℝ) ≤
+          ∑ z ∈ S', agree μ
+            (fun x => Curve.polynomialCurveEval u z x)
+            (fun x => Curve.polynomialCurveEval v z x) := hsum_lower
+      _ = 1 / (Fintype.card ι : ℝ) *
+          ((∑ x : ι, ((agreementPoints x).card : ℚ) * (μ x).1 : ℚ) : ℝ) := hsum_eq
+      _ ≤ 1 / (Fintype.card ι : ℝ) *
+          ((S'.card : ℝ) * ((∑ x ∈ common, (μ x).1 : ℚ) : ℝ) +
+            (l + 1 : ℝ) * Fintype.card ι) :=
+        mul_le_mul_of_nonneg_left hweighted_upper_real (by positivity)
+      _ = (S'.card : ℝ) * mu_set μ common + (l + 1 : ℝ) := by
+        simp only [mu_set]
+        field_simp
+  change mu_set μ common >
+    (α : ℝ) - (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ))
+  have hcard_real : (l + 1 : ℝ) < S'.card := by exact_mod_cast hS'_card
+  have hgap_pos : (0 : ℝ) < (S'.card : ℝ) - (l + 1 : ℝ) := by
+    linarith
+  have hcard_pos : (0 : ℝ) < S'.card := by
+    linarith
+  have hfraction :
+      (l + 1 : ℝ) / S'.card <
+        (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ)) := by
+    rw [div_lt_div_iff₀ hcard_pos hgap_pos]
+    nlinarith
+  have hcancel : ((l + 1 : ℝ) / S'.card) * S'.card = l + 1 := by
+    field_simp
+  have hcommon_lower :
+      (α : ℝ) - (l + 1 : ℝ) / S'.card ≤ mu_set μ common := by
+    nlinarith [hcore, hcancel]
+  exact lt_of_lt_of_le (by linarith [hfraction]) hcommon_lower
 
 /-- Lemma 7.6 in [BCIKS20].
 This is the "integral-weight" strengthening of the list-agreement-on-a-curve =>

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
@@ -358,9 +358,9 @@ lemma list_agreement_on_curve_implies_correlated_agreement_bound
 This is the "integral-weight" strengthening of the list-agreement-on-a-curve =>
 correlated-agreement bound.
 
-We have two lists of functions `u, v : Fin (l + 2) → ι → F`, where each `v i` is a
-Reed-Solomon codeword of degree `deg` over the evaluation domain `domain`. From
-these lists we form the bivariate curve evaluations
+We have two lists of functions `u, v : Fin (l + 2) → ι → F`. From these lists we
+form the bivariate curve evaluations. As in Lemma 7.5, code membership is not
+needed for this combinatorial strengthening.
 
 * `w x z = Curve.polynomialCurveEval u z x`,
 * `wtilde x z = Curve.polynomialCurveEval v z x`.
@@ -377,14 +377,12 @@ coordinates agree, i.e. where `u i x = v i x` for every `i`, is at least `α`:
 
 `mu_set μ {x | ∀ i, u i x = v i x} ≥ α`. -/
 lemma sufficiently_large_list_agreement_on_curve_implies_correlated_agreement
-    {k l : ℕ} {u : Fin (l + 2) → ι → F}
-    {deg : ℕ} {domain : ι ↪ F}
+    {l : ℕ} {u : Fin (l + 2) → ι → F}
     {μ : ι → Set.Icc (0 : ℚ) 1}
     {α : ℝ≥0}
     {M : ℕ}
     (hμ : ∀ i, ∃ n : ℤ, (μ i).1 = (n : ℚ) / (M : ℚ))
     {v : Fin (l + 2) → ι → F}
-    (hv : ∀ i, v i ∈ ReedSolomon.code domain deg)
     {S' : Finset F}
     (hS'_card : S'.card > l + 1)
     (hS'_card₁ : S'.card ≥ (M * Fintype.card ι + 1) * (l + 1)) :
@@ -392,7 +390,98 @@ lemma sufficiently_large_list_agreement_on_curve_implies_correlated_agreement
     letI wtilde (x : ι) (z : F) : F := Curve.polynomialCurveEval (F := F) (A := F) v z x
     (hS'_agree : ∀ z ∈ S', agree μ (w · z) (wtilde · z) ≥ α) →
     mu_set μ { x : ι | ∀ i, u i x = v i x } ≥ α := by
-  sorry
+  dsimp only
+  classical
+  intro hS'_agree
+  let w (x : ι) (z : F) : F := Curve.polynomialCurveEval u z x
+  let wtilde (x : ι) (z : F) : F := Curve.polynomialCurveEval v z x
+  let values : Finset ℝ := S'.image fun z => agree μ (w · z) (wtilde · z)
+  have hS'_nonempty : S'.Nonempty := Finset.card_pos.mp (by omega)
+  have hvalues_nonempty : values.Nonempty := hS'_nonempty.image _
+  let β : ℝ := values.min' hvalues_nonempty
+  have hβ_le (z : F) (hz : z ∈ S') : β ≤ agree μ (w · z) (wtilde · z) := by
+    exact Finset.min'_le _ _ (Finset.mem_image.mpr ⟨z, hz, rfl⟩)
+  have hαβ : (α : ℝ) ≤ β := by
+    apply Finset.le_min'
+    intro y hy
+    rcases Finset.mem_image.mp hy with ⟨z, hz, rfl⟩
+    exact hS'_agree z hz
+  have hβ_nonneg : 0 ≤ β := le_trans α.coe_nonneg hαβ
+  let βnn : ℝ≥0 := ⟨β, hβ_nonneg⟩
+  have hcurve_bound :
+      mu_set μ {x : ι | ∀ i, u i x = v i x} >
+        β - (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ)) := by
+    have := list_agreement_on_curve_implies_correlated_agreement_bound
+      (u := u) (v := v) (μ := μ) (α := βnn) hS'_card
+      (fun z hz => hβ_le z hz)
+    simpa [βnn] using this
+  by_contra hnot
+  have hmu_lt_alpha :
+      mu_set μ {x : ι | ∀ i, u i x = v i x} < (α : ℝ) := by
+    simpa only [not_le] using hnot
+  have hmu_lt_beta :
+      mu_set μ {x : ι | ∀ i, u i x = v i x} < β :=
+    lt_of_lt_of_le hmu_lt_alpha hαβ
+  rcases Finset.mem_image.mp (Finset.min'_mem values hvalues_nonempty) with
+    ⟨zβ, hzβ, hβeq⟩
+  change agree μ (w · zβ) (wtilde · zβ) = β at hβeq
+  choose numerator hnum using hμ
+  have measure_grid (s : Finset ι) :
+      ∃ n : ℤ, mu_set μ s = (n : ℝ) / ((M * Fintype.card ι : ℕ) : ℝ) := by
+    refine ⟨∑ i ∈ s, numerator i, ?_⟩
+    simp only [mu_set]
+    simp_rw [hnum]
+    push_cast
+    rw [← Finset.sum_div]
+    field_simp
+  have agree_grid (a b : ι → F) :
+      ∃ n : ℤ, agree μ a b = (n : ℝ) / ((M * Fintype.card ι : ℕ) : ℝ) := by
+    simpa only [agree] using measure_grid {i | a i = b i}
+  rcases measure_grid {x : ι | ∀ i, u i x = v i x} with ⟨a, ha⟩
+  rcases agree_grid (w · zβ) (wtilde · zβ) with ⟨b, hb⟩
+  have hM_pos : 0 < M := by
+    by_contra hM
+    have hMzero : M = 0 := Nat.eq_zero_of_not_pos hM
+    have hweights_zero (i : ι) : (μ i).1 = 0 := by
+      simpa [hMzero] using hnum i
+    have hagree_zero : agree μ (w · zβ) (wtilde · zβ) = 0 := by
+      simp [agree, hweights_zero]
+    rw [← hβeq, hagree_zero] at hmu_lt_beta
+    have hmu_nonneg : 0 ≤ mu_set μ {x : ι | ∀ i, u i x = v i x} := by
+      simp [mu_set, hweights_zero]
+    linarith
+  have hd_pos : (0 : ℝ) < (M * Fintype.card ι : ℕ) := by positivity
+  have hab_real : (a : ℝ) < b := by
+    rw [ha, ← hβeq, hb] at hmu_lt_beta
+    exact (div_lt_div_iff_of_pos_right hd_pos).mp hmu_lt_beta
+  have hab : a + 1 ≤ b := by
+    have : a < b := by exact_mod_cast hab_real
+    omega
+  have hgrid_gap :
+      1 / ((M * Fintype.card ι : ℕ) : ℝ) ≤
+        β - mu_set μ {x : ι | ∀ i, u i x = v i x} := by
+    rw [ha, ← hβeq, hb]
+    rw [div_sub_div_same]
+    apply (div_le_div_iff_of_pos_right hd_pos).2
+    have : (1 : ℤ) ≤ b - a := by omega
+    exact_mod_cast this
+  have hdenom_pos : 0 < (S'.card : ℝ) - (l + 1 : ℝ) := by
+    have : (l + 1 : ℝ) < S'.card := by exact_mod_cast hS'_card
+    linarith
+  have hdenom_large :
+      ((M * Fintype.card ι : ℕ) : ℝ) * (l + 1 : ℝ) ≤
+        (S'.card : ℝ) - (l + 1 : ℝ) := by
+    have hcast :
+        (((M * Fintype.card ι + 1) * (l + 1) : ℕ) : ℝ) ≤ S'.card := by
+      exact_mod_cast hS'_card₁
+    norm_num [Nat.cast_mul] at hcast ⊢
+    nlinarith
+  have herror_le_grid :
+      (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ)) ≤
+        1 / ((M * Fintype.card ι : ℕ) : ℝ) := by
+    rw [div_le_div_iff₀ hdenom_pos hd_pos]
+    nlinarith
+  linarith
 
 end ListAgreementLemmas
 

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -900,9 +900,9 @@ theorem folding_preserves_distance
       rw [←Nat.pow_le_pow_iff_right (a := 2) (by simp)]
       omega
     have bound_tighter :
-      (↑δ) ≤ 1 - ReedSolomon.sqrtRate (d / (2 ^ k))
+      (↑δ) < 1 - ReedSolomon.sqrtRate (d / (2 ^ k))
         (domain.subdomain k : Fin (2 ^ (n - k)) ↪ F) :=
-      le_of_lt <| by
+      by
         aesop
           (add safe [(by rw [folded_sqrtRate_eq])])
           (add safe [(by grind)])
@@ -911,7 +911,7 @@ theorem folding_preserves_distance
       @correlatedAgreement_affine_curves (Fin (2 ^ (n - k))) _ _ F _ _ _
         (2 ^ k - 1) (d / (2 ^ k))
         (domain := domain.subdomain k) (δ := δ)
-        (hδ := bound_tighter)
+        (hδ_pos := δ_gt_0) (hδ := bound_tighter)
     unfold foldWord δ_ε_correlatedAgreementCurves at *
     by_contra contra
     simp only [not_le, foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha, bind_pure_comp, Functor.map,

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -582,7 +582,7 @@ theorem combine_theorem
       · aesop (add simp [total_terms, block_size])
     · have proximity_gap :=
         @ProximityGap.correlatedAgreement_affine_curves ι _ _ F _ _ _
-          (total_terms dstar degs - 1) dstar φ δ (le_of_lt <| by
+          (total_terms dstar degs - 1) dstar φ δ hδPos (by
             aesop (add simp [lt_min_iff, ReedSolomon.sqrtRate]))
       simp only [ProximityGap.δ_ε_correlatedAgreementCurves] at proximity_gap
       specialize proximity_gap


### PR DESCRIPTION
## Summary

This is a stacked follow-up to #639. The new changes in commit `5901e0a9` harden the BCIKS20 Section 6 curve statements and add a kernel-checked degree-one case of Theorem 6.1.

- bind the Section 6 helpers to the actual Reed-Solomon code and its actual rate/radius instead of arbitrary `V` and free `rho`
- use `Fin (l + 1)` for the paper's degree-`l` curve convention
- include the missing requirement that reconstructed coefficients are Reed-Solomon codewords
- restrict the headline proximity-gap theorem to the proven open Johnson/Guruswami-Sudan regime `0 < delta < 1 - sqrt(rho)`
- explicitly exclude BCIKS20's separate capacity-regime Conjecture 8.4
- prove the degree-one Theorem 6.1 bridge from polynomial curves to the existing affine-line joint-agreement result
- update STIR/Folding callers for the strict regime contract

## Why the contract change is necessary

The previous general helper quantified over an arbitrary finite set `V` and an unconstrained `rho`. That is stronger than BCIKS20 and false in general: the source theorem fixes `V` to the Reed-Solomon code and uses its actual rate. The paper also uses `l + 1` coefficient words for a degree-`l` curve.

This PR preserves BCIKS20's proved unique-decoding and sub-Johnson statements. It does **not** promote the later capacity conjecture that was refuted in IACR ePrint 2025/2046.

## Verification

- `lake build ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.Curves ArkLib.ProofSystem.Stir.Combine ArkLib.Data.CodingTheory.ProximityGap.Folding`
- `#print axioms ProximityGap.large_agreement_set_on_line_implies_correlated_agreement`
  - `[propext, Classical.choice, Quot.sound]`
  - no `sorryAx`
- `./scripts/validate.sh`
  - 4,048 build jobs completed
  - Data warning budget passed
  - umbrella imports passed
  - docs integrity passed
  - knowledge-base lint passed
- `git diff --check`

## Honest boundary

Three admissions remain in `Curves.lean`: the full degree-`l` Theorem 6.1 helper, Theorem 6.2, and the headline correlated-agreement theorem. Consequently STIR `combine_theorem` remains readiness-blocked. This PR repairs their mathematical contracts and proves only the degree-one Theorem 6.1 case.

## Stack

- depends on #639 (`agent/bciks20-affine-lines-list-decoding`)
- review the final commit `5901e0a9` for this slice until #639 merges
