### PR TITLE
Fix website build after PyGraphviz 2.0 release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,8 @@ jobs:
             python3 -m venv env
             source env/bin/activate
             pip install --upgrade pip requests wheel
-            pip install pygraphviz
+            # PyGraphviz 2.0 fails to link Graphviz plugins in this Alpine-based image.
+            pip install pygraphviz==1.14
             pip install leanblueprint
             leanblueprint pdf
             leanblueprint web


### PR DESCRIPTION
## What changed

- Pin PyGraphviz to 1.14 in the GitHub Pages blueprint build.
- Document why PyGraphviz 2.0 is not currently usable in the pinned Alpine/TeX Live image.

## Why

The website workflow began failing after the unpinned dependency resolved to PyGraphviz 2.0. Its extension build tries to link Graphviz plugin libraries such as `gvplugin_core` and `gvplugin_dot_layout`, but those libraries are not exposed under those names by the Alpine Graphviz packages in `ghcr.io/xu-cheng/texlive-full:20231201`. PyGraphviz 1.14 is the exact release used by the last successful website run.

The Lean project and API documentation builds were succeeding; the failed blueprint dependency installation prevented artifact assembly and deployment.

## Validation

- `git diff --check`
- Parsed `.github/workflows/docs.yml` with Ruby YAML
- Manual branch dispatch of the website workflow on GitHub Actions (pending)
