### PR TITLE
Introduce pullback argument for STIR and WHIR theorems

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -113,6 +113,7 @@ import ArkLib.Data.Domain.CosetFftDomain.Defs
 import ArkLib.Data.Domain.CosetFftDomain.Log
 import ArkLib.Data.Domain.CosetFftDomain.Mem
 import ArkLib.Data.Domain.CosetFftDomain.Ops
+import ArkLib.Data.Domain.CosetFftDomain.Pullback
 import ArkLib.Data.Domain.CosetFftDomain.Subdomain
 import ArkLib.Data.Domain.CosetFftDomain.ToFftDomain
 import ArkLib.Data.Domain.CosetFftDomain.ToList

--- a/ArkLib/Data/CodingTheory/Basic/BlockRelDistance.lean
+++ b/ArkLib/Data/CodingTheory/Basic/BlockRelDistance.lean
@@ -208,12 +208,8 @@ lemma card_agreementBlockUnion
   (agreementBlockUnion k φ f g).card =
     2 ^ k * (complDisagreementSet k φ f g).card := by
   unfold agreementBlockUnion
-  rw [Finset.card_biUnion (by
-    aesop
-      (add simp [Set.PairwiseDisjoint, Set.Pairwise])
-      (add safe disjoint_blockIdx)
-  )]
-  rw [Finset.sum_equiv
+  rw [Finset.card_biUnion (by simp),
+      Finset.sum_equiv
         (Equiv.refl _)
         (g := fun _ ↦ 2 ^ k)
         (t := complDisagreementSet k φ f g)

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -16,6 +16,7 @@ import ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.Curves
 import ArkLib.Data.Domain.CosetFftDomain.Block
 import ArkLib.Data.Domain.CosetFftDomain.Subdomain
 import ArkLib.Data.Domain.CosetFftDomain.Log
+import ArkLib.Data.Domain.CosetFftDomain.Pullback
 import ArkLib.Data.Polynomial.Indicator
 import ArkLib.ToMathlib.Polynomial.EvalExt
 import ArkLib.ToMathlib.Polynomial.NatDegreeOfSum
@@ -627,11 +628,7 @@ private lemma eval_comp_x_pow_map_eq {f : Polynomial (Polynomial F)} {x : F}
 
 private noncomputable def hammingDistComplementBound
   {n : ℕ} (k : ℕ) (domain : SmoothCosetFftDomain n F) (s : Finset F) : ℕ :=
-  Finset.card { i ∈
-    Finset.product
-      Finset.univ
-      (Finset.preimage s (domain.subdomain k) (by simp)) |
-    (domain i.1) ^ (2 ^ k) = domain.subdomain k i.2 }
+  Finset.card (Pullback.pullback domain 0 k s)
 
 private noncomputable def hammingDistBound
   {n : ℕ} (k : ℕ) (domain : SmoothCosetFftDomain n F) (s : Finset F) : ℕ :=
@@ -650,64 +647,13 @@ private lemma contradictory_hamming_dist_formula {s : Finset F}
   (h_d : d ≤ 2 ^ n) :
   hammingDistBound k domain s =
     2 ^ n - 2 ^ k * (Finset.card s) := by
-    unfold hammingDistBound hammingDistComplementBound
-    simp only [Fintype.card_fin, product_eq_sprod]
-    congr
-    rw [show @filter _ _ _ _ =
-        (Finset.preimage s (domain.subdomain k) (by simp)).biUnion
-          (fun i ↦ {j | domain j.1 ^ 2 ^ k = domain.subdomain k i ∧ j.2 = i} ) by aesop,
-        Finset.card_biUnion (fun x hx y hy hxy a ha₁ ha₂ ↦ by
-          by_contra contra
-          obtain ⟨c, hc⟩ : ∃ c, c ∈ a := by
-            aesop
-              (add simp [le_eq_subset])
-              (add safe (by grind))
-          specialize (ha₁ hc)
-          specialize (ha₂ hc)
-          aesop
-        )]
-    conv =>
-      lhs
-      congr
-      rfl
-      ext u
-      rw [show (Finset.card _) = #{j | domain j ^ 2 ^ k =
-        (CosetFftDomain.subdomain domain k) u} by
-        aesop (add safe (by apply Finset.card_bij (fun a _ ↦ a.1)))
-      ]
-    rw [Finset.sum_bij (t := s)
-      (g := fun x ↦ Finset.card {j | domain j ^ (2 ^ k) = x})
-      (i := fun i _ ↦ domain.subdomain k i)
-      (by aesop)
-      CosetFftDomain.injOn
-      (by {
-        intro b hb
-        obtain ⟨a, ha⟩ : ∃ i, (CosetFftDomain.subdomain domain k) i = b := by
-          rw [←CosetFftDomainClass.mem_def,
-            ←CosetFftDomainClass.mem_toFinset_iff_mem]
-          exact h_s hb
-        exists a
-        aesop
-      })
-      (by simp)]
-    rw [Finset.sum_bij (t := s)
-      (g := fun i ↦ 2 ^ k) (fun i _ ↦ i)
-      (by aesop)
-      (by aesop)
-      (by aesop)
-      (fun a ha ↦ by
-        rw [
-          show ({j | domain j ^ 2 ^ k = a} : Finset _) = blockIdx domain k a by rfl,
-          card_blockIdx,
-          card_block_of_mem_subdomain' (by {
-            rw [←Nat.pow_le_pow_iff_right (a := 2) (by simp)]
-            omega
-          }) (by {
-            rw [←CosetFftDomainClass.mem_toFinset_iff_mem]
-            exact h_s ha
-          })]
-      )]
-    aesop (add safe (by grind))
+  have hkn : k ≤ n := by
+    rw [←Nat.pow_le_pow_iff_right (a := 2) (by omega)]
+    omega
+  aesop
+    (add simp [hammingDistBound, hammingDistComplementBound])
+    (add safe (by rw [Pullback.card_pullback_eq_mul_card_pullback₂,
+                      Pullback.card_pullback₂_eq]))
 
 private lemma correlated_agreement_implies_contradictory_hamm_dist
   [Fintype F]
@@ -748,25 +694,21 @@ private lemma correlated_agreement_implies_contradictory_hamm_dist
     · simp only [hammingDist, ne_eq, hammingDistBound, Fintype.card_fin]
       rw [←Finset.compl_filter, Finset.card_compl, Fintype.card_fin]
       apply Nat.sub_le_sub_left
-      apply Finset.card_le_card_of_injOn Prod.fst
-        (f_inj := fun _ _ _ _ h ↦ by
-          aesop
-            (add unsafe [(by apply CosetFftDomain.injective (ω := domain.subdomain k))])
-)
-      rintro ⟨a₁, a₂⟩ ha
-      simp_all only [product_eq_sprod, coe_filter, mem_product, mem_univ, mem_preimage, true_and,
-        Set.mem_setOf_eq]
-      rcases ha with ⟨h_a_s, h_eq⟩
-      rw [eval_comp_x_pow_map_eq, h_eq]
+      rw [hammingDistComplementBound, Pullback.card_pullback_eq_card_pullback₁]
+      apply Finset.card_le_card
+      intro x hx
+      have hx := Pullback.mem_s_of_mem_pullback₁ hx
+      rw [subdomain_0_apply] at hx
+      simp only [tsub_zero, Nat.sub_zero, mem_filter, mem_univ, true_and] at hx ⊢
+      rw [eval_comp_x_pow_map_eq]
       by_cases h_s'_s : s' = s
       · rw [h_s'_s,
             ←eval_comm,
-            indicated_polynomial_eq_foldAux (by simp [h_a_s]),
-            ←h_eq,
+            indicated_polynomial_eq_foldAux (by simp [hx]),
             ←foldValue_def,
             foldValue_pow_x_k]
       · rw [indicated_polynomial_eq_foldAux' (u := u) (by aesop)] <;> try assumption
-        · rw [←foldValue_def, ←h_eq, foldValue_pow_x_k]
+        · rw [←foldValue_def, foldValue_pow_x_k]
         · intro i x hx
           have hx := (pick_subset_subset : s' ⊆ s) hx
           rw [h_u _ _ hx]
@@ -775,9 +717,8 @@ private lemma correlated_agreement_implies_contradictory_hamm_dist
             (h_u_deg i)
             (by rw [pick_subset_card_eq_of_ne h_s'_s])
 
-set_option linter.unusedFintypeInType false in -- false alert
 private lemma dist_from_code_bound_of_correlated_agreement
-  [Fintype F]
+  [Finite F]
   {s : Finset F}
   (h_s : s ⊆ (domain.subdomain k).toFinset)
   {u : Fin (2 ^ k) → Polynomial F}
@@ -789,7 +730,8 @@ private lemma dist_from_code_bound_of_correlated_agreement
   (h_u_deg : ∀ i, (u i).natDegree < d / (2 ^ k)) :
   Δ₀(f, ReedSolomon.code (domain : Fin (2 ^ n) ↪ F) d)
         ≤ 2 ^ n -
-          2 ^ k * (Finset.card s) := by
+          2 ^ k * Finset.card s := by
+  have := Fintype.ofFinite
   simp only [distFromCode, SetLike.mem_coe]
   exact sInf_le_of_le
     (b := ↑(hammingDistBound k domain s))

--- a/ArkLib/Data/Domain/CosetFftDomain/Block.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Block.lean
@@ -98,6 +98,11 @@ lemma card_block_le :
 theorem disjoint_block {x y : F} (hxy : x ≠ y) :
   Disjoint (block ω k x) (block ω k y) := by aesop (add simp [disjoint_iff])
 
+@[simp]
+theorem pairwise_disjoint_block {s : Set F} :
+  s.PairwiseDisjoint (block ω k) := fun _ _ _ _ _ ↦ by
+  aesop (add simp [Function.onFun, disjoint_block])
+
 /-- The set of indices of a block of `ω` at `x` of the degree `k`. -/
 def blockIdx (ω : D) (k : ℕ) (x : F) : Finset ι :=
   {i | ω i ^ 2 ^ k = x}
@@ -149,6 +154,11 @@ lemma card_blockIdx :
 theorem disjoint_blockIdx {x y : F} (hxy : x ≠ y) :
   Disjoint (blockIdx ω k x) (blockIdx ω k y) := by
   aesop (add simp [disjoint_iff_ne, mem_blockIdx_iff_mem_block])
+
+@[simp]
+theorem pairwise_disjoint_blockIdx {s : Set F} :
+  s.PairwiseDisjoint (blockIdx ω k) := fun _ _ _ _ _ ↦ by
+  aesop (add simp [Function.onFun, disjoint_blockIdx])
 
 end CosetFftDomainClass
 

--- a/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
@@ -181,11 +181,8 @@ lemma mem_pullback₁_iff_mem_pullback₂_l_0 {i : Fin (2 ^ n)} (hr : r ≤ n) :
   rw [←mem_pullback₁_iff_mem_pullback₂ (by omega) hr]
   simp only [Nat.sub_zero, Set.mem_image, SetLike.mem_coe, pow_zero, pow_one]
   constructor <;> intro ⟨x, hx₁, hx₂⟩ <;> exists x
-  · simp only [hx₁, true_and]
-    -- simp [hx₂] doesn't work although subdomain_0_apply is marked @[simp].
-    rw [subdomain_0_apply, hx₂]
-  · rw [subdomain_0_apply] at hx₂
-    aesop (add safe (by rw [CosetFftDomainClass.subdomain_0_apply]))
+  · simp [hx₁, hx₂]
+  · aesop (add safe (by rw [CosetFftDomainClass.subdomain_0_apply]))
 
 /-- The connection between components of the pullback set when `l = 1`. -/
 lemma mem_pullback₁_iff_mem_pullback₂_l_1 {i : Fin (2 ^ n)} (h1r : 1 ≤ r) (hr : r ≤ n) :

--- a/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024-2026 ArkLib Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Ilia Vlasov, Aristotle (Harmonic)
+Authors: František Silváši, Ilia Vlasov, Aristotle (Harmonic)
 -/
 
 import Mathlib.Tactic.CancelDenoms.Core
@@ -178,11 +178,8 @@ lemma mem_pullback₁_iff_mem_pullback₂ {i : Fin (2 ^ n)} (hl : l ≤ r) (hr :
 /-- The connection between components of the pullback set when `l = 0`. -/
 lemma mem_pullback₁_iff_mem_pullback₂_l_0 {i : Fin (2 ^ n)} (hr : r ≤ n) :
   ω i ∈ ω '' pullback₁ ω 0 r s ↔ ω i ^ 2 ^ r ∈ subdomain ω r '' pullback₂ ω 0 r s := by
-  rw [←mem_pullback₁_iff_mem_pullback₂ (by omega) hr]
-  simp only [Nat.sub_zero, Set.mem_image, SetLike.mem_coe, pow_zero, pow_one]
-  constructor <;> intro ⟨x, hx₁, hx₂⟩ <;> exists x
-  · simp [hx₁, hx₂]
-  · aesop (add safe (by rw [CosetFftDomainClass.subdomain_0_apply]))
+  rw [←mem_pullback₁_iff_mem_pullback₂ (by simp) hr]
+  simp_all
 
 /-- The connection between components of the pullback set when `l = 1`. -/
 lemma mem_pullback₁_iff_mem_pullback₂_l_1 {i : Fin (2 ^ n)} (h1r : 1 ≤ r) (hr : r ≤ n) :
@@ -211,10 +208,10 @@ lemma card_pullback₂_eq (hl : l ≤ r) (hr : r ≤ n) (hs : s ⊆ (subdomain �
 lemma pullback₁_eq_biUnion_pullback₂ (hl : l ≤ r) (hr : r ≤ n) :
   pullback₁ ω l r s =
     Finset.biUnion (pullback₂ ω l r s)
-      (fun x ↦ blockIdx (subdomain ω l) (r - l) (subdomain ω r x)) := by
+      (blockIdx (subdomain ω l) (r - l) ∘ (subdomain ω r)) := by
   ext i
-  simp only [mem_pullback₁ hl hr, mem_biUnion, mem_pullback₂ hl hr, mem_blockIdx_iff_mem_block,
-    mem_block, mem_self, true_and]
+  simp only [mem_pullback₁ hl hr, mem_biUnion, mem_pullback₂ hl hr, Function.comp_apply,
+    mem_blockIdx_iff_mem_block, mem_block, mem_self, true_and]
   constructor
   · intro h
     obtain ⟨a, ha⟩ : (subdomain ω l) i ^ 2 ^ (r - l) ∈ subdomain ω r := by
@@ -229,18 +226,15 @@ lemma card_pullback_eq_mul_card_pullback₂ (hl : l ≤ r) (hr : r ≤ n) :
   #(pullback ω l r s) = 2 ^ (r - l) * #(pullback₂ ω l r s) := by
   rw [card_pullback_eq_card_pullback₁,
       pullback₁_eq_biUnion_pullback₂ hl hr,
-      Finset.card_biUnion (fun _ _ _ _ _ ↦ disjoint_blockIdx <| fun contra ↦ by
-          have contra := CosetFftDomainClass.injective _ contra
-          simp_all
-      ),
-      Finset.sum_equiv
-        (Equiv.refl _) (t := pullback₂ ω l r s)
-        (g := fun i ↦ 2 ^ (r - l))
-        (by simp) (fun i hi ↦ by
-          rw [card_blockIdx, card_block_of_mem_subdomain (by omega)]
-          rw [show l + (r - l) = r by omega]
-          simp)]
-  aesop (add safe (by ac_nf))
+      Finset.card_biUnion (by aesop (add safe (by rw [←Set.InjOn.pairwiseDisjoint_image])))]
+  calc
+    _ = ∑ u ∈ pullback₂ ω l r s, 2 ^ (r - l) :=
+      Finset.sum_equiv (Equiv.refl _) (by simp) (fun i hi ↦ by
+        simp only [Function.comp_apply, card_blockIdx]
+        rw [card_block_of_mem_subdomain (by omega)]
+        rw [show l + (r - l) = r by omega]
+        simp)
+    _ = _ := by aesop (add safe (by ac_nf))
 
 end Pullback
 

--- a/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
@@ -182,6 +182,7 @@ lemma mem_pullback₁_iff_mem_pullback₂_l_0 {i : Fin (2 ^ n)} (hr : r ≤ n) :
   simp only [Nat.sub_zero, Set.mem_image, SetLike.mem_coe, pow_zero, pow_one]
   constructor <;> intro ⟨x, hx₁, hx₂⟩ <;> exists x
   · simp only [hx₁, true_and]
+    -- simp [hx₂] doesn't work although subdomain_0_apply is marked @[simp].
     rw [subdomain_0_apply, hx₂]
   · rw [subdomain_0_apply] at hx₂
     aesop (add safe (by rw [CosetFftDomainClass.subdomain_0_apply]))

--- a/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
@@ -4,20 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: František Silváši, Ilia Vlasov, Aristotle (Harmonic)
 -/
 
-import Mathlib.Tactic.CancelDenoms.Core
-import Mathlib.Data.Set.Finite.Basic
-import Mathlib.GroupTheory.SpecificGroups.Cyclic
-import Mathlib.Algebra.Group.Fin.Basic
-import Mathlib.Algebra.Group.TypeTags.Basic
-import Mathlib.Algebra.Group.Defs
-import Mathlib.Data.Fintype.Card
-import Mathlib.Algebra.BigOperators.Fin
-import Mathlib.Tactic.Cases
-import Mathlib.Tactic.Linarith
-import Mathlib.Tactic.LinearCombination
-import Mathlib.Tactic.Field
-
-import ArkLib.Data.Domain.CosetFftDomain.Block
 import ArkLib.Data.Domain.CosetFftDomain.Subdomain
 
 /-! Claim 4.23 from [ACFY24] and lemma 4.9 from [ACFY24stir] share

--- a/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024-2026 ArkLib Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: František Silváši, Ilia Vlasov, Aristotle (Harmonic)
+Authors: František Silváši, Ilia Vlasov
 -/
 
 import ArkLib.Data.Domain.CosetFftDomain.Subdomain

--- a/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Pullback.lean
@@ -1,0 +1,251 @@
+/-
+Copyright (c) 2024-2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ilia Vlasov, Aristotle (Harmonic)
+-/
+
+import Mathlib.Tactic.CancelDenoms.Core
+import Mathlib.Data.Set.Finite.Basic
+import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.Algebra.Group.Fin.Basic
+import Mathlib.Algebra.Group.TypeTags.Basic
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Data.Fintype.Card
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Tactic.Cases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Field
+
+import ArkLib.Data.Domain.CosetFftDomain.Block
+import ArkLib.Data.Domain.CosetFftDomain.Subdomain
+
+/-! Claim 4.23 from [ACFY24] and lemma 4.9 from [ACFY24stir] share
+  a similar combinatorial proof technique which we call "pullback argument".
+
+  This file introduces the definition of a pullback set for two subdomains and
+  various lemmas establishing relations between cardinalities
+  of the pullback set and its projections on either of the components.
+
+  ## Main results
+
+  The main results establish structural and cardinality properties of this
+  construction:
+
+  * the first projection of the pullback is in bijection with the pullback
+    itself (`card_pullback_eq_card_pullback₁`);
+  * the second projection is exactly the given subset whenever the subset lies
+    in the smaller subdomain (`card_pullback₂_eq`);
+  * the first projection decomposes as a disjoint union of blocks indexed by
+    the second projection (`pullback₁_eq_biUnion_pullback₂`);
+  * consequently, the pullback has cardinality
+    `2 ^ (r - l) * #(pullback₂ ω l r s)`
+    (`card_pullback_eq_mul_card_pullback₂`).
+
+  ## References
+
+  * [Arnon, G., Chiesa, A., Fenzi, G., Yogev, E.,
+    *STIR: Reed–Solomon Proximity Testing with Fewer Queries*][ACFY24stir]
+  * [Arnon, G., Chiesa, A., Fenzi, G., and Yogev, E., *WHIR: Reed–Solomon Proximity Testing
+        with Super-Fast Verification*][ACFY24]
+-/
+
+namespace Domain
+
+variable {F : Type} [Field F] [DecidableEq F]
+
+namespace CosetFftDomainClass
+
+variable {n : ℕ}
+variable {D : Type} [FunLike D (Fin (2 ^ n)) F] [CosetFftDomainClass D (Fin (2 ^ n)) F]
+variable {ω : D}
+
+namespace Pullback
+
+open Finset
+
+variable {l r : ℕ} {s : Finset F}
+
+/-- The pullback set is the pullback of the following maps:
+   pullback ω l r s ·······································> (subdomain ω r)⁻¹ s
+         ·__|                                                         |
+         ·                                                            |
+         ·                                                            |
+         ·
+         ·                                                       subdomain ω r
+         ·
+         ·                                                            |
+         ·                                                            |
+         ·                                                            |
+         V                                                            v
+  Fin (2 ^ (n - l)) --- subdomain ω l --→ F --- (-) ^ 2 ^ (r - l) --→ F
+-/
+def pullback (ω : D) (l r : ℕ) (s : Finset F) : Finset (Fin (2 ^ (n - l)) × Fin (2 ^ (n - r))) :=
+  { i | subdomain ω l i.1 ^ 2 ^ (r - l) = subdomain ω r i.2 ∧ subdomain ω r i.2 ∈ s }
+
+/-- The pullback set is empty when `s` is empty. -/
+@[simp]
+lemma pullback_empty : pullback ω l r ∅ = ∅ := by simp [pullback]
+
+@[simp]
+lemma mem_pullback {i : Fin (2 ^ (n - l)) × Fin (2 ^ (n - r))} :
+  i ∈ pullback ω l r s ↔
+    subdomain ω l i.1 ^ 2 ^ (r - l) = subdomain ω r i.2 ∧
+          subdomain ω r i.2 ∈ s := by simp [pullback]
+
+/-- `Prod.fst` is injective on the pullback set. -/
+@[simp]
+lemma proj₁_injOn :
+  Set.InjOn Prod.fst
+    (pullback ω l r s : Set (Fin (2 ^ (n - l)) × Fin (2 ^ (n - r)))) := fun x hx y hy hxy ↦ by
+  have := injective (subdomain ω r) (a₁ := x.2) (a₂ := y.2)
+  aesop
+
+/-- The projection of the pullback set onto the first component. -/
+def pullback₁ (ω : D) (l r : ℕ) (s : Finset F) : Finset (Fin (2 ^ (n - l))) :=
+  image Prod.fst (pullback ω l r s)
+
+lemma mem_s_of_mem_pullback₁ {i : Fin (2 ^ (n - l))} (h : i ∈ pullback₁ ω l r s) :
+  subdomain ω l i ^ 2 ^ (r - l) ∈ s := by aesop (add simp pullback₁)
+
+lemma mem_pullback₁ {i : Fin (2 ^ (n - l))} (hl : l ≤ r) (hr : r ≤ n) :
+  i ∈ pullback₁ ω l r s ↔ subdomain ω l i ^ 2 ^ (r - l) ∈ s := by
+  simp only [pullback₁, mem_image, mem_pullback, Prod.exists, exists_and_right, exists_eq_right]
+  constructor
+  · aesop
+  · intro h
+    have : (subdomain ω l) i ^ 2 ^ (r - l) ∈ subdomain ω (l + (r - l)) :=
+      pow_mem_of_mem (by omega) (by simp)
+    rw [show l + (r - l) = r by omega] at this
+    have ⟨x, hx⟩ := this
+    exact ⟨x, by aesop⟩
+
+@[simp]
+lemma proj₁_mapsTo :
+  Set.MapsTo Prod.fst
+    (pullback ω l r s : Set ((Fin (2 ^ (n - l))) × Fin (2 ^ (n - r))))
+    (pullback₁ ω l r s : Set (Fin (2 ^ (n - l)))) := by
+  aesop (add simp pullback₁) (add safe Set.mapsTo_image)
+
+@[simp]
+lemma proj₁_surjOn :
+  Set.SurjOn Prod.fst
+    (pullback ω l r s : Set (Fin (2 ^ (n - l)) × Fin (2 ^ (n - r))))
+    (pullback₁ ω l r s : Set (Fin (2 ^ (n - l)))) := by
+  aesop (add simp pullback₁) (add safe Set.surjOn_image)
+
+/-- The cardinality of the pullback set is equal to
+  the cardinality of its first projection. -/
+lemma card_pullback_eq_card_pullback₁ :
+  #(pullback ω l r s) = #(pullback₁ ω l r s) := by
+  apply Finset.card_nbij Prod.fst <;> simp
+
+/-- The projection of the pullback set onto the second component. -/
+def pullback₂ (ω : D) (l r : ℕ) (s : Finset F) : Finset (Fin (2 ^ (n - r))) :=
+  image Prod.snd (pullback ω l r s)
+
+lemma mem_pullback₂ {i : Fin (2 ^ (n - r))} (hl : l ≤ r) (hr : r ≤ n) :
+  i ∈ pullback₂ ω l r s ↔ subdomain ω r i ∈ s := by
+  simp only [pullback₂, mem_image, mem_pullback, Prod.exists, exists_eq_right, exists_and_right,
+    and_iff_right_iff_imp]
+  intro h
+  have : subdomain ω r i ∈ subdomain ω (l + (r - l)) := by
+    rw [show l + (r - l) = r by omega]
+    simp
+  obtain ⟨y, hy⟩ := root_exists (by omega) this
+  aesop (add simp mem_def)
+
+/-- The connection between components of the pullback set. -/
+lemma mem_pullback₁_iff_mem_pullback₂ {i : Fin (2 ^ n)} (hl : l ≤ r) (hr : r ≤ n) :
+  ω i ^ 2 ^ l ∈ subdomain ω l '' pullback₁ ω l r s ↔
+    ω i ^ 2 ^ r ∈ subdomain ω r '' pullback₂ ω l r s := by
+  simp only [Set.mem_image, SetLike.mem_coe]
+  constructor <;> intro ⟨x, hx₁, hx₂⟩
+  · simp only [mem_pullback₁ hl hr] at hx₁
+    rw [hx₂, ←pow_mul, ←pow_add, show l + (r - l) = r by omega] at hx₁
+    obtain ⟨j, hj⟩ : ω i ^ 2 ^ r ∈ subdomain ω r :=
+      pow_mem_subdomain_of_mem_subdomain_0 (by omega) (by rw [mem_subdomain_0_iff_mem]; simp)
+    aesop (add safe (by rw [mem_pullback₂]))
+  · simp [mem_pullback₂ hl hr] at hx₁
+    obtain ⟨j, hj⟩ : ω i ^ 2 ^ l ∈ subdomain ω l :=
+      pow_mem_subdomain_of_mem_subdomain_0 (by omega) (by rw [mem_subdomain_0_iff_mem]; simp)
+    exists j
+    rw [mem_pullback₁ hl hr]
+    simp only [hj, and_true]
+    rw [←pow_mul, ←pow_add, show l + (r - l) = r by omega]
+    simp_all
+
+/-- The connection between components of the pullback set when `l = 0`. -/
+lemma mem_pullback₁_iff_mem_pullback₂_l_0 {i : Fin (2 ^ n)} (hr : r ≤ n) :
+  ω i ∈ ω '' pullback₁ ω 0 r s ↔ ω i ^ 2 ^ r ∈ subdomain ω r '' pullback₂ ω 0 r s := by
+  rw [←mem_pullback₁_iff_mem_pullback₂ (by omega) hr]
+  simp only [Nat.sub_zero, Set.mem_image, SetLike.mem_coe, pow_zero, pow_one]
+  constructor <;> intro ⟨x, hx₁, hx₂⟩ <;> exists x
+  · simp only [hx₁, true_and]
+    rw [subdomain_0_apply, hx₂]
+  · rw [subdomain_0_apply] at hx₂
+    aesop (add safe (by rw [CosetFftDomainClass.subdomain_0_apply]))
+
+/-- The connection between components of the pullback set when `l = 1`. -/
+lemma mem_pullback₁_iff_mem_pullback₂_l_1 {i : Fin (2 ^ n)} (h1r : 1 ≤ r) (hr : r ≤ n) :
+  ω i ^ 2 ∈ subdomain ω 1 '' pullback₁ ω 1 r s ↔
+    ω i ^ 2 ^ r ∈ subdomain ω r '' pullback₂ ω 1 r s := by
+  simp [←mem_pullback₁_iff_mem_pullback₂ h1r hr]
+
+/-- If `s` is a subset of the subdomain `subdomain ω r` then
+  the cardinality of `pullback₂ ω l r s` is exactly the cardinality
+  of `s`. -/
+lemma card_pullback₂_eq (hl : l ≤ r) (hr : r ≤ n) (hs : s ⊆ (subdomain ω r).toFinset) :
+  #(pullback₂ ω l r s) = #s := by
+  apply Finset.card_bij (fun i _ ↦ subdomain ω r i)
+  · aesop (add simp mem_pullback₂)
+  · intro x _ y _ hxy
+    exact CosetFftDomainClass.injective _ hxy
+  · intro b hb
+    obtain ⟨a, ha⟩ : b ∈ subdomain ω r := by
+      specialize hs hb
+      aesop
+    exists a
+    aesop (add simp mem_pullback₂)
+
+/-- `pullback₁ ω l r s` is a union of blocks indexed by
+  `pullback₂ ω l r s`. -/
+lemma pullback₁_eq_biUnion_pullback₂ (hl : l ≤ r) (hr : r ≤ n) :
+  pullback₁ ω l r s =
+    Finset.biUnion (pullback₂ ω l r s)
+      (fun x ↦ blockIdx (subdomain ω l) (r - l) (subdomain ω r x)) := by
+  ext i
+  simp only [mem_pullback₁ hl hr, mem_biUnion, mem_pullback₂ hl hr, mem_blockIdx_iff_mem_block,
+    mem_block, mem_self, true_and]
+  constructor
+  · intro h
+    obtain ⟨a, ha⟩ : (subdomain ω l) i ^ 2 ^ (r - l) ∈ subdomain ω r := by
+      rw [mem_subdomain_of_eq_vals (j := l + (r - l)) (by omega)]
+      exact pow_mem_of_mem (by omega) (by simp)
+    exact ⟨a, by aesop⟩
+  · aesop
+
+/-- The expression of the cardinality of `pullback ω l r s`
+  in terms of `pullback₂ ω l r s`. -/
+lemma card_pullback_eq_mul_card_pullback₂ (hl : l ≤ r) (hr : r ≤ n) :
+  #(pullback ω l r s) = 2 ^ (r - l) * #(pullback₂ ω l r s) := by
+  rw [card_pullback_eq_card_pullback₁,
+      pullback₁_eq_biUnion_pullback₂ hl hr,
+      Finset.card_biUnion (fun _ _ _ _ _ ↦ disjoint_blockIdx <| fun contra ↦ by
+          have contra := CosetFftDomainClass.injective _ contra
+          simp_all
+      ),
+      Finset.sum_equiv
+        (Equiv.refl _) (t := pullback₂ ω l r s)
+        (g := fun i ↦ 2 ^ (r - l))
+        (by simp) (fun i hi ↦ by
+          rw [card_blockIdx, card_block_of_mem_subdomain (by omega)]
+          rw [show l + (r - l) = r by omega]
+          simp)]
+  aesop (add safe (by ac_nf))
+
+end Pullback
+
+end CosetFftDomainClass
+
+end Domain

--- a/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
@@ -142,6 +142,19 @@ lemma subdomain_generator_pow_generator (i : ℕ) :
   (subdomain ω i).cosetGenerator = ω 0 ^ 2 ^ i := rfl
 
 set_option warning.simp.varHead false in
+@[simp]
+lemma subdomain_0_apply (i : Fin (2 ^ n)) :
+  subdomain ω 0 i = ω i := by
+  aesop
+    (add unsafe [cases Fin, cases Nat])
+    (add safe (by grind))
+    (add simp
+      [subdomain,
+       CosetFftDomainClass.subdomain_embed,
+       mkSubgroupUnit,
+       CosetFftDomain.eval_coset_fft_domain_eq_eval_generator_mul_domain])
+
+set_option warning.simp.varHead false in
 /-- Membership to the `0`th subdomain is
   the same as membership to the original coset FFT domain. -/
 @[simp]

--- a/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
@@ -144,7 +144,7 @@ lemma subdomain_generator_pow_generator (i : ℕ) :
 set_option warning.simp.varHead false in
 @[simp]
 lemma subdomain_0_apply (i : Fin (2 ^ n)) :
-  subdomain ω 0 i = ω i := by
+  no_index (subdomain ω 0 i) = ω i := by
   aesop
     (add unsafe [cases Fin, cases Nat])
     (add safe (by grind))

--- a/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
@@ -159,15 +159,7 @@ set_option warning.simp.varHead false in
   the same as membership to the original coset FFT domain. -/
 @[simp]
 lemma mem_subdomain_0_iff_mem :
-  no_index (x ∈ subdomain ω 0) ↔ x ∈ ω := by
-  aesop
-    (add safe cases Nat)
-    (add simp
-      [subdomain,
-       CosetFftDomainClass.subdomain_embed,
-       mkSubgroupUnit,
-       mem_def,
-       CosetFftDomain.eval_coset_fft_domain_eq_eval_generator_mul_domain])
+  no_index (x ∈ subdomain ω 0) ↔ x ∈ ω := by simp [mem_def]
 
 /-- The `n`th subdomain consists exactly of the single element `ω 0 ^ 2 ^ n`. -/
 lemma mem_subdomain_n_iff_eq_pow_generator :


### PR DESCRIPTION
Claim 4.23 from [ACFY24] and lemma 4.9 from [ACFY24stir] share a similar combinatorial proof technique which we call "pullback argument" since the combinatorics is done via a set that is called a pullback in category theory.

In this PR we introduce various stuff simplifying the pullback argument and rewrite parts of the proof of lemma 4.9 to use the introduced infra. The upcoming PR with claim 4.23 is going to rely on that as well. 
