### PR TITLE
chore(BlockRelDistance): naming and docs follow-up to #616

### DIFF
--- a/ArkLib/Data/CodingTheory/Basic/BlockRelDistance.lean
+++ b/ArkLib/Data/CodingTheory/Basic/BlockRelDistance.lean
@@ -147,24 +147,31 @@ noncomputable def blockRelDistanceBall
 scoped notation "Λ𞁒("C", "k", "φ'", "f", "δ")" =>
   blockRelDistanceBall k φ' f δ C
 
-private def complDisagreementSet
+/-- The complement of `disagreementSet` inside the `k`th subdomain: the points `z` of
+  `φ.subdomain k` on which `f` and `g` agree across the whole block indexed by `z`. -/
+def complDisagreementSet
   (k : ℕ) (φ : SmoothCosetFftDomain n F) (f g : Fin (2 ^ n) → F) : Finset F :=
   (φ.subdomain k).toFinset \ disagreementSet k φ f g
 
-lemma complDisagreementSet_def' :
+/-- `complDisagreementSet` as a filter: the subdomain points `z` such that `f` and `g` agree at
+  every index of the block indexed by `z`. -/
+lemma complDisagreementSet_def :
   complDisagreementSet k φ f g =
     { z ∈ (φ.subdomain k).toFinset | ∀ i ∈ blockIdx φ k z, f i = g i  } := by
   aesop (add simp [complDisagreementSet, disagreementSet])
 
+/-- The agreement set sits inside the `k`th subdomain, so has at most `2 ^ (n - k)` points. -/
 @[simp]
 lemma card_complDisagreementSet_le :
   (complDisagreementSet k φ f g).card ≤ 2 ^ (n - k) := by
   simp [complDisagreementSet, Finset.card_sdiff]
 
+/-- The agreement set is a subset of the `k`th subdomain. -/
 @[simp]
-lemma complDisagreementSet_sub_subdomain :
+lemma complDisagreementSet_subset_subdomain :
   complDisagreementSet k φ f g ⊆ (φ.subdomain k).toFinset := by simp [complDisagreementSet]
 
+/-- Block relative distance as one minus the agreement fraction, over `ℚ`. -/
 lemma blockRelDistance_eq_one_sub' :
   δ𞁒(k, φ, f, g) =
     1 - ((complDisagreementSet k φ f g).card : ℚ) / (φ.subdomain k).toFinset.card := by
@@ -172,6 +179,7 @@ lemma blockRelDistance_eq_one_sub' :
     (add simp [complDisagreementSet, Finset.card_sdiff, blockRelDistance, blockDistance])
     (add unsafe (by ring_nf))
 
+/-- Block relative distance as one minus the agreement fraction, over `ℚ≥0`. -/
 lemma blockRelDistance_eq_one_sub :
   δ𞁒(k, φ, f, g) =
     1 - ((complDisagreementSet k φ f g).card : ℚ≥0) / (φ.subdomain k).toFinset.card := by
@@ -179,23 +187,29 @@ lemma blockRelDistance_eq_one_sub :
       NNRat.coe_sub (by aesop (add safe [(by field_simp), (by norm_cast)]))]
   rfl
 
+/-- The agreement and disagreement sets partition the `k`th subdomain, so the size of one is the
+  size of the subdomain minus the size of the other. -/
 lemma card_complDisagreementSet :
   (complDisagreementSet k φ f g).card =
     (φ.subdomain k).toFinset.card - (disagreementSet k φ f g).card := by
   simp [complDisagreementSet, Finset.card_sdiff]
 
-lemma card_disagreementSet' :
+/-- `card_complDisagreementSet` solved for the disagreement count. -/
+lemma card_disagreementSet :
   (disagreementSet k φ f g).card =
     (φ.subdomain k).toFinset.card - (complDisagreementSet k φ f g).card := by
   aesop
     (add simp [card_complDisagreementSet])
     (add unsafe (by rw [Nat.sub_sub_self (by simp)]))
 
-private def agreementBlockUnion
+/-- The union of the blocks indexed by `complDisagreementSet`, i.e. the set of indices lying in
+  some `k`-block on which `f` and `g` agree everywhere. -/
+def agreementBlockUnion
   (k : ℕ) (φ : SmoothCosetFftDomain n F)
   (f g : Fin (2 ^ n) → F) : Finset (Fin (2 ^ n)) :=
   Finset.biUnion (complDisagreementSet k φ f g) (blockIdx φ k)
 
+/-- The union of agreeing blocks sits inside the index type, so has at most `2 ^ n` points. -/
 @[simp]
 lemma card_agreementBlockUnion_le :
   (agreementBlockUnion k φ f g).card ≤ 2 ^ n := by
@@ -203,6 +217,8 @@ lemma card_agreementBlockUnion_le :
     rw [show 2 ^ n = (Finset.univ (α := Fin (2 ^ n))).card by simp]
   exact Finset.card_le_card (by simp)
 
+/-- The `complDisagreementSet` blocks each have `2 ^ k` indices and are pairwise disjoint, so
+  their union has `2 ^ k` times as many indices as there are blocks. -/
 lemma card_agreementBlockUnion
   (hkn : k ≤ n) :
   (agreementBlockUnion k φ f g).card =
@@ -219,15 +235,18 @@ lemma card_agreementBlockUnion
         (t := complDisagreementSet k φ f g)
         (by simp)
         (fun i hi ↦ by
-          have := complDisagreementSet_sub_subdomain hi
+          have := complDisagreementSet_subset_subdomain hi
           aesop (add simp [card_block_of_mem_subdomain'])
         )]
   aesop (add safe (by ac_nf))
 
-lemma agreement_sub_agreementBlockUnion :
+/-- `f` and `g` agree at every index of every agreeing block. -/
+lemma agreementBlockUnion_subset_agreement :
   agreementBlockUnion k φ f g ⊆ ({ i | f i = g i } : Finset _) := fun x hx ↦ by
   aesop (add simp [agreementBlockUnion, complDisagreementSet, disagreementSet])
 
+/-- Indices where `f` and `g` differ lie outside every agreeing block, which bounds their number
+  by `2 ^ n` minus the size of the union of those blocks. -/
 lemma card_disagreement_le :
   Finset.card { i | f i ≠ g i } ≤ 2 ^ n - (agreementBlockUnion k φ f g).card := by
   conv_rhs =>
@@ -237,9 +256,10 @@ lemma card_disagreement_le :
   exact Finset.card_le_card <| fun x hx ↦ by
     simp only [Finset.mem_compl]
     intro contra
-    have := agreement_sub_agreementBlockUnion contra
+    have := agreementBlockUnion_subset_agreement contra
     simp_all
 
+/-- Relative Hamming distance is at most one minus the agreeing-block fraction, over `ℚ`. -/
 lemma relHammingDist_le_sub_agreementBlockUnion' :
   δᵣ(f, g) ≤ 1 - ((agreementBlockUnion k φ f g).card : ℚ) / (2 ^ n) := by
   unfold Code.relHammingDist
@@ -255,6 +275,7 @@ lemma relHammingDist_le_sub_agreementBlockUnion' :
   · field_simp
     aesop
 
+/-- Relative Hamming distance is at most one minus the agreeing-block fraction, over `ℚ≥0`. -/
 lemma relHammingDist_le_sub_agreementBlockUnion :
   δᵣ(f, g) ≤ 1 - ((agreementBlockUnion k φ f g).card : ℚ≥0) / (2 ^ n) := by
   have := relHammingDist_le_sub_agreementBlockUnion' (f := f) (g := g) (φ := φ)

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding/ListDecodability.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding/ListDecodability.lean
@@ -7,6 +7,27 @@ Authors: František Silváši, Ilia Vlasov
 import ArkLib.Data.CodingTheory.Basic.BlockRelDistance
 import ArkLib.Data.CodingTheory.ProximityGap.Folding
 
+/-!
+# Folding preserves block relative distance balls
+
+This file proves Claim 4.22 of [ACFY24]: for every folding randomness `α`, the image under
+`foldWord … 1 α` of the block relative distance ball around `f` is contained in the corresponding
+ball around `foldWord … 1 α f` for the folded code.
+
+This is one step towards Theorem 4.20 of [ACFY24], which is not yet formalised.
+
+## Main results
+
+* `folding_contracts_block_distance` / `folding_contracts_block_rel_distance`:
+  folding does not increase block (relative) distance.
+* `folding_preserves_block_balls`: Claim 4.22 itself.
+
+## References
+
+* [Arnon, G., Chiesa, A., Fenzi, G., and Yogev, E., *WHIR: Reed–Solomon Proximity Testing
+    with Super-Fast Verification*][ACFY24]
+-/
+
 namespace ProximityGap
 
 open NNReal Finset Function
@@ -22,15 +43,6 @@ variable {n k : ℕ}
 variable {ω : SmoothCosetFftDomain n F}
 variable {f : Word F (Fin (2 ^ n))}
 
-/-!
-  This file contains a proof of Theorem 4.20 from [ACFY24] (WIP for now).
-
-## References
-
-* [Arnon, G., Chiesa, A., Fenzi, G., and Yogev, E., *WHIR: Reed–Solomon Proximity Testing
-    with Super-Fast Verification*][ACFY24]
--/
-
 /-- The block distance of foldings of two words does not exceed
   the block distance of the original words.
 
@@ -41,11 +53,11 @@ lemma folding_contracts_block_distance
   Δ𞁒(k - 1, ω.subdomain 1, foldWord ω u 1 α, foldWord ω f 1 α) ≤
     Δ𞁒(k , ω, u, f) := by
   have : NeZero n := ⟨by omega⟩
-  simp only [blockDistance, card_disagreementSet', card_toFinset, Fintype.card_fin]
+  simp only [blockDistance, card_disagreementSet, card_toFinset, Fintype.card_fin]
   rw [show n - 1 - (k - 1) = n - k by omega,
       Nat.sub_le_sub_iff_left (by simp)]
   exact Finset.card_le_card <| fun x hx ↦ by
-    simp_all only [complDisagreementSet_def', mem_filter]
+    simp_all only [complDisagreementSet_def, mem_filter]
     exact And.intro
       (by aesop (add unsafe (by rw [Nat.add_sub_cancel']))) <| fun i hi ↦ by
       rw [foldWord_k_1, foldWord_k_1]
@@ -82,7 +94,7 @@ lemma folding_contracts_block_rel_distance
   This is the claim 4.22 from [ACFY24] with unfolded definition `⊆`.
 -/
 lemma folding_block_rel_ball {d : ℕ}
-  {α : F} {δ : ℝ≥0} (hk : 1 ≤ k) (hd : k ≤ d)
+  {α : F} {δ : ℝ≥0} (hk : 1 ≤ k) (hd : 1 ≤ d)
   (hkn : k ≤ n) {u : Word F (Fin (2 ^ n))}
   (hu : u ∈ Λ𞁒(code (ω : Fin (2 ^ n) ↪ F) (2 ^ d), k, ω, f, δ)) :
   foldWord ω u 1 α ∈
@@ -105,7 +117,7 @@ lemma folding_block_rel_ball {d : ℕ}
   This is the claim 4.22 from [ACFY24].
 -/
 theorem folding_preserves_block_balls {d : ℕ}
-  {α : F} {δ : ℝ≥0} (hk : 1 ≤ k) (hd : k ≤ d) (hkn : k ≤ n) :
+  {α : F} {δ : ℝ≥0} (hk : 1 ≤ k) (hd : 1 ≤ d) (hkn : k ≤ n) :
   Set.image
     (fun u ↦ foldWord ω u 1 α)
     (Λ𞁒(code (ω : Fin (2 ^ n) ↪ F) (2 ^ d), k, ω, f, δ)) ⊆

--- a/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
@@ -471,8 +471,8 @@ private lemma subdomain_eval (ω : D) (j : ℕ)
     (subdomain ω j) b =
       ω 0 ^ 2 ^ j * ((ω 0)⁻¹ * ω (CosetFftDomainClass.subdomain_embed j b)) := rfl
 
-/-- Composing the `k`th subdomain with one more folding step gives the `(k+1)`th subdomain
-  (pointwise, under the index identification `n - k - 1 = n - (k + 1)`). -/
+/-- Taking the `j`th subdomain of the `k`th subdomain gives the `(k + j)`th subdomain
+  (pointwise, under the index identification `n - k - j = n - (k + j)`). -/
 lemma subdomain_comp
   {k j : ℕ} (hk : k + j ≤ n)
   {a : Fin (2 ^ (n - k - j))} {i : Fin (2 ^ (n - (k + j)))}


### PR DESCRIPTION
Follow-up to #616, which was merged as-is because none of these were blocking. Hygiene plus one
hypothesis weakening — **no proof term changes, and nothing here alters what is proved except to
make one statement slightly stronger.**

### Weaker hypothesis

`folding_block_rel_ball` and `folding_preserves_block_balls` took `hd : k ≤ d`, but the only use is
discharging `2 ^ 1 ∣ 2 ^ d`, which needs just `1 ≤ d`. Weakened both. (`1 ≤ d` follows from
`1 ≤ k ≤ d` in WHIR's setting, so this is a strict generalisation of the statement, not a change of
meaning.)

### `private` definitions with public API

`complDisagreementSet` and `agreementBlockUnion` were `private def`, while #616 made **13 lemmas
about them public** — three of those global `@[simp]`. That left rewrite rules in the global simp
set whose left-hand sides name constants no downstream file can write, and it means
`ListDecodability.lean` reasons about definitions it cannot mention. Promoted both definitions to
public with docstrings.

While there: added docstrings to the 13 lemmas #616 newly exposes. (Six lemmas earlier in the file
were already public and undocumented before #616; left alone as out of scope.)

### Names

- `agreement_sub_agreementBlockUnion` → **`agreementBlockUnion_subset_agreement`**. The name was
  the wrong way round: the statement is `agreementBlockUnion k φ f g ⊆ {i | f i = g i}`, but the
  name read as `agreement ⊆ agreementBlockUnion`.
- `complDisagreementSet_def'` → **`complDisagreementSet_def`** and `card_disagreementSet'` →
  **`card_disagreementSet`**. Neither prime had an unprimed sibling, and the unprimed
  `card_disagreementSet` was free — it now pairs with `card_complDisagreementSet`.
  (The primes on `blockRelDistance_eq_one_sub'` and `relHammingDist_le_sub_agreementBlockUnion'`
  are kept: those *do* have `ℚ≥0` siblings.)
- `complDisagreementSet_sub_subdomain` → **`complDisagreementSet_subset_subdomain`**, using
  `subset` for `⊆`.

I left `complDisagreementSet` itself alone. `agreementSet` would read better and pair with
`agreementBlockUnion`, but the current name is systematically derived from the existing
`disagreementSet`, which keeps the relationship explicit and greppable; happy to change it if
preferred.

### Docstring corrections

- `ListDecodability.lean`'s module docstring sat *inside* `namespace ProximityGap` after the
  `open`/`variable` block, had no title, and said it "contains a proof of Theorem 4.20" when the
  content is Claim 4.22. Moved above the namespace, gave it a title, a `## Main results` section,
  and an accurate description — Theorem 4.20 is noted as not yet formalised.
- `subdomain_comp`'s docstring described only the `j = 1` case ("one more folding step … the
  `(k+1)`th subdomain … `n - k - 1 = n - (k + 1)`"), but the lemma is general in `j`. This matters
  because that generality is exactly what lets it subsume `subdomain_one_comp` in #534.

### Deliberately not included

`neg_mem_block_of_mem`, `neg_mem_block_iff_mem` (`Block.lean`) and `foldWord_k_1'` (`Folding.lean`)
have no consumers — verified by deleting them and rebuilding green, and none is `@[simp]`, so there
is no implicit use either. They are left in place: the two `Block.lean` lemmas encode the
"if `x ∈ Block` then `−x ∈ Block`" step of WHIR Claim 4.22 and are reasonable API for that file,
and `foldWord_k_1'` is a fine `funext` companion to `foldWord_k_1`. The only live issue is that
#534 adds an identical `foldWord_k_1'`, which that PR will need to drop.

### Validation

`./scripts/validate.sh` green.
